### PR TITLE
Generate Linux .desktop when using app-image packaging

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/tasks/AbstractJPackageTask.kt
@@ -724,6 +724,10 @@ abstract class AbstractJPackageTask
                     val debFile = findOutputFileOrDir(destinationDir.ioFile, targetFormat)
                     LinuxPackagePostProcessor.postProcessDeb(
                         debFile = debFile,
+                        appName = packageName.get(),
+                        linuxPackageName = linuxPackageName.orNull,
+                        packageDescription = packageDescription.orNull,
+                        linuxAppCategory = linuxAppCategory.orNull,
                         startupWMClass = startupWMClass,
                         debDepends = linuxDebDepends.get(),
                         enableT64 = linuxEnableT64AlternativeDeps.get(),
@@ -737,6 +741,10 @@ abstract class AbstractJPackageTask
                     val rpmFile = findOutputFileOrDir(destinationDir.ioFile, targetFormat)
                     LinuxPackagePostProcessor.postProcessRpm(
                         rpmFile = rpmFile,
+                        appName = packageName.get(),
+                        linuxPackageName = linuxPackageName.orNull,
+                        packageDescription = packageDescription.orNull,
+                        linuxAppCategory = linuxAppCategory.orNull,
                         startupWMClass = startupWMClass,
                         rpmRequires = linuxRpmRequires.get(),
                         compression = linuxRpmCompression.orNull,


### PR DESCRIPTION
## Summary
- keep Linux packaging flow with app-image
- create a `.desktop` entry during Linux post-processing when none exists (DEB and RPM)
- continue injecting `StartupWMClass` into existing or newly created desktop entries
- pass package metadata from `AbstractJPackageTask` to the Linux post-processor so generated desktop files use app/package/category info

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew -p plugin-build :plugin:compileKotlin`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew -p plugin-build :plugin:ktlintCheck`
