### PR TITLE
Add aot-runtime module for AOT mode detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,31 @@ nativeDistributions {
 
 **Requirements:**
 - JDK 25 or newer.
-- The application **must self-terminate** during the training run. Recommended app-side pattern:
+- The application **must self-terminate** during the training run.
+
+If your app is built in this repository, add the runtime helper:
 
 ```kotlin
+dependencies {
+    implementation(project(":aot-runtime"))
+}
+```
+
+Recommended app-side pattern using the helper API:
+
+```kotlin
+import io.github.kdroidfilter.composedeskkit.aot.runtime.AotRuntime
+
 fun main() {
-    System.getProperty("aot.training.autoExit")?.toLongOrNull()?.let { seconds ->
-        Thread({ Thread.sleep(seconds * 1000); System.exit(0) }, "aot-timer")
+    if (AotRuntime.isTraining()) {
+        Thread({ Thread.sleep(60_000); System.exit(0) }, "aot-timer")
             .apply { isDaemon = true; start() }
     }
+
+    if (AotRuntime.isRuntime()) {
+        // Optional runtime-only behavior
+    }
+
     // normal app startup...
 }
 ```

--- a/aot-runtime/build.gradle.kts
+++ b/aot-runtime/build.gradle.kts
@@ -1,0 +1,21 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    testImplementation(libs.junit)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
+}

--- a/aot-runtime/src/main/kotlin/io/github/kdroidfilter/composedeskkit/aot/runtime/AotRuntime.kt
+++ b/aot-runtime/src/main/kotlin/io/github/kdroidfilter/composedeskkit/aot/runtime/AotRuntime.kt
@@ -1,0 +1,43 @@
+package io.github.kdroidfilter.composedeskkit.aot.runtime
+
+import java.lang.management.ManagementFactory
+
+public enum class AotRuntimeMode {
+    OFF,
+    TRAINING,
+    RUNTIME,
+}
+
+public object AotRuntime {
+    private const val MODE_PROPERTY = "composedeskkit.aot.mode"
+    private const val AOT_RUNTIME_FLAG = "-XX:AOTCache="
+    private const val AOT_TRAINING_FLAG = "-XX:AOTCacheOutput="
+
+    @JvmStatic
+    public fun mode(): AotRuntimeMode {
+        parseModeProperty(System.getProperty(MODE_PROPERTY))?.let { return it }
+        return detectMode(ManagementFactory.getRuntimeMXBean().inputArguments)
+    }
+
+    @JvmStatic
+    public fun isRuntime(): Boolean = mode() == AotRuntimeMode.RUNTIME
+
+    @JvmStatic
+    public fun isTraining(): Boolean = mode() == AotRuntimeMode.TRAINING
+
+    internal fun detectMode(inputArguments: List<String>): AotRuntimeMode =
+        when {
+            inputArguments.any { it.startsWith(AOT_TRAINING_FLAG) } -> AotRuntimeMode.TRAINING
+            inputArguments.any { it.startsWith(AOT_RUNTIME_FLAG) } -> AotRuntimeMode.RUNTIME
+            else -> AotRuntimeMode.OFF
+        }
+
+    internal fun parseModeProperty(rawValue: String?): AotRuntimeMode? =
+        when (rawValue?.trim()?.lowercase()) {
+            null, "" -> null
+            "train", "training" -> AotRuntimeMode.TRAINING
+            "runtime", "run", "on", "use", "enabled" -> AotRuntimeMode.RUNTIME
+            "off", "disabled", "none" -> AotRuntimeMode.OFF
+            else -> null
+        }
+}

--- a/aot-runtime/src/test/kotlin/io/github/kdroidfilter/composedeskkit/aot/runtime/AotRuntimeTest.kt
+++ b/aot-runtime/src/test/kotlin/io/github/kdroidfilter/composedeskkit/aot/runtime/AotRuntimeTest.kt
@@ -1,0 +1,50 @@
+package io.github.kdroidfilter.composedeskkit.aot.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AotRuntimeTest {
+    @Test
+    fun `detects training when AOTCacheOutput flag is present`() {
+        val mode = AotRuntime.detectMode(listOf("-Xmx512m", "-XX:AOTCacheOutput=/tmp/app.aot"))
+        assertEquals(AotRuntimeMode.TRAINING, mode)
+    }
+
+    @Test
+    fun `detects runtime when AOTCache flag is present`() {
+        val mode = AotRuntime.detectMode(listOf("-Xmx512m", "-XX:AOTCache=/tmp/app.aot"))
+        assertEquals(AotRuntimeMode.RUNTIME, mode)
+    }
+
+    @Test
+    fun `training takes precedence when both flags are present`() {
+        val mode =
+            AotRuntime.detectMode(
+                listOf(
+                    "-XX:AOTCache=/tmp/app.aot",
+                    "-XX:AOTCacheOutput=/tmp/app.aot",
+                ),
+            )
+        assertEquals(AotRuntimeMode.TRAINING, mode)
+    }
+
+    @Test
+    fun `returns off when no aot flags are present`() {
+        val mode = AotRuntime.detectMode(listOf("-Xmx512m"))
+        assertEquals(AotRuntimeMode.OFF, mode)
+    }
+
+    @Test
+    fun `parses explicit mode property values`() {
+        assertEquals(AotRuntimeMode.TRAINING, AotRuntime.parseModeProperty("train"))
+        assertEquals(AotRuntimeMode.RUNTIME, AotRuntime.parseModeProperty("runtime"))
+        assertEquals(AotRuntimeMode.OFF, AotRuntime.parseModeProperty("off"))
+    }
+
+    @Test
+    fun `returns null for empty or unknown mode property`() {
+        assertNull(AotRuntime.parseModeProperty(""))
+        assertNull(AotRuntime.parseModeProperty("unknown"))
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ tasks.register("reformatAll") {
 tasks.register("preMerge") {
     description = "Runs all the tests/verification tasks on both top level and included build."
 
+    dependsOn(":aot-runtime:check")
     dependsOn(":example:check")
     dependsOn(gradle.includedBuild("plugin-build").task(":plugin:check"))
     dependsOn(gradle.includedBuild("plugin-build").task(":plugin:validatePlugins"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,4 +28,5 @@ develocity {
 rootProject.name = "io.github.kdroidfilter.composedeskkit"
 
 include(":example")
+include(":aot-runtime")
 includeBuild("plugin-build")


### PR DESCRIPTION
## Summary
- add a new JVM module `aot-runtime` with a small helper API to detect AOT mode at runtime
- expose `AotRuntime.mode()`, `AotRuntime.isRuntime()`, and `AotRuntime.isTraining()`
- detect mode from JVM args (`-XX:AOTCacheOutput=` for training, `-XX:AOTCache=` for runtime) with optional override via `composedeskkit.aot.mode`
- wire the new module into root `settings.gradle.kts` and `preMerge`
- document usage in `README.md` with a simple app-side example

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :aot-runtime:check`
