### PR TITLE
Add support for macOS 26+ layered icons

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/dsl/PlatformSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/dsl/PlatformSettings.kt
@@ -6,6 +6,7 @@
 package io.github.kdroidfilter.composedeskkit.desktop.application.dsl
 
 import org.gradle.api.Action
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import java.io.File
@@ -40,6 +41,7 @@ abstract class AbstractMacOSPlatformSettings : AbstractPlatformSettings() {
     var dmgPackageBuildVersion: String? = null
     var appCategory: String? = null
     var minimumSystemVersion: String? = null
+    var layeredIconDir: DirectoryProperty = objects.directoryProperty()
 
     /**
      * An application's unique identifier across Apple's ecosystem.

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/InfoPlistBuilder.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/InfoPlistBuilder.kt
@@ -142,6 +142,7 @@ internal object PlistKeys {
     val CFBundleTypeOSTypes by this
     val CFBundleExecutable by this
     val CFBundleIconFile by this
+    val CFBundleIconName by this
     val CFBundleIdentifier by this
     val CFBundleInfoDictionaryVersion by this
     val CFBundleName by this

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/MacAssetsTool.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/MacAssetsTool.kt
@@ -1,0 +1,99 @@
+package io.github.kdroidfilter.composedeskkit.desktop.application.internal
+
+import org.gradle.api.logging.Logger
+import io.github.kdroidfilter.composedeskkit.internal.utils.MacUtils
+import java.io.File
+
+internal class MacAssetsTool(private val runTool: ExternalToolRunner, private val logger: Logger) {
+
+    fun compileAssets(iconDir: File, workingDir: File, minimumSystemVersion: String?): File {
+        val toolVersion = checkAssetsToolVersion()
+        logger.info("compile mac assets is starting, supported actool version:$toolVersion")
+
+        val result = runTool(
+            tool = MacUtils.xcrun,
+            args = listOf(
+                "actool",
+                iconDir.absolutePath, // Input asset catalog
+                "--compile", workingDir.absolutePath,
+                "--app-icon", iconDir.name.removeSuffix(".icon"),
+                "--enable-on-demand-resources", "NO",
+                "--development-region", "en",
+                "--target-device", "mac",
+                "--platform", "macosx",
+                "--enable-icon-stack-fallback-generation=disabled",
+                "--include-all-app-icons",
+                "--minimum-deployment-target", minimumSystemVersion ?: "10.13",
+                "--output-partial-info-plist", "/dev/null"
+            ),
+        )
+
+        if (result.exitValue != 0) {
+            error("Could not compile the layered icons directory into Assets.car.")
+        }
+        if (!assetsFile(workingDir).exists()) {
+            error("Could not find Assets.car in the working directory.")
+        }
+        return workingDir.resolve("Assets.car")
+    }
+
+    fun assetsFile(workingDir: File): File = workingDir.resolve("Assets.car")
+
+    private fun checkAssetsToolVersion(): String {
+        val requiredVersion = 26.0
+        var outputContent = ""
+        val result = runTool(
+            tool = MacUtils.xcrun,
+            args = listOf("actool", "--version"),
+            processStdout = { outputContent = it },
+        )
+
+        if (result.exitValue != 0) {
+            error("Could not get actool version: Command `xcrun actool -version` exited with code ${result.exitValue}\nStdOut: $outputContent\n")
+        }
+
+        val versionString: String? = try {
+            var versionContent = ""
+            runTool(
+                tool = MacUtils.plutil,
+                args = listOf(
+                    "-extract",
+                    "com\\.apple\\.actool\\.version.short-bundle-version",
+                    "raw",
+                    "-expect",
+                    "string",
+                    "-o",
+                    "-",
+                    "-"
+                ),
+                stdinStr = outputContent,
+                processStdout = {
+                    versionContent = it
+                }
+            )
+            versionContent
+        } catch (e: Exception) {
+            error("Could not check actool version. Error: ${e.message}")
+        }
+
+        if (versionString.isNullOrBlank()) {
+            error("Could not extract short-bundle-version from actool output: '$outputContent'. Assuming it meets requirements.")
+        }
+
+        val majorVersion = versionString
+            .split(".")
+            .firstOrNull()
+            ?.toIntOrNull()
+            ?: error("Could not get actool major version from version string '$versionString' . Output was: '$outputContent'. Assuming it meets requirements.")
+
+        if (majorVersion < requiredVersion) {
+            error(
+                "Unsupported actool version: $versionString. " +
+                        "Version $requiredVersion or higher is required. " +
+                        "Please update your Xcode Command Line Tools."
+            )
+        } else {
+            return versionString
+        }
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/configureJvmApplication.kt
@@ -571,6 +571,7 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                 packageTask.iconFile.set(mac.iconFile.orElse(defaultResources.get { macIcon }))
                 packageTask.installationPath.set(mac.installationPath)
                 packageTask.fileAssociations.set(provider { mac.fileAssociations })
+                packageTask.macLayeredIcons.set(mac.layeredIconDir)
             }
         }
     }

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/configureNativeApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/configureNativeApplication.kt
@@ -80,6 +80,7 @@ private fun configureNativeApplication(
                     }
                 composeResourcesDirs.setFrom(binaryResources)
             }
+            macLayeredIcons.set(app.distributions.macOS.layeredIconDir)
         }
 
     if (TargetFormat.Dmg in app.distributions.targetFormats) {

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/tasks/AbstractNativeMacApplicationPackageAppDirTask.kt
@@ -6,16 +6,19 @@
 package io.github.kdroidfilter.composedeskkit.desktop.application.tasks
 
 import io.github.kdroidfilter.composedeskkit.desktop.application.internal.InfoPlistBuilder
+import io.github.kdroidfilter.composedeskkit.desktop.application.internal.MacAssetsTool
 import io.github.kdroidfilter.composedeskkit.desktop.application.internal.PlistKeys
 import io.github.kdroidfilter.composedeskkit.internal.utils.ioFile
 import io.github.kdroidfilter.composedeskkit.internal.utils.notNullProperty
 import io.github.kdroidfilter.composedeskkit.internal.utils.nullableProperty
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.Optional
 import java.io.File
+import kotlin.getValue
 
 private const val KOTLIN_NATIVE_MIN_SUPPORTED_MAC_OS = "10.13"
 
@@ -49,6 +52,12 @@ abstract class AbstractNativeMacApplicationPackageAppDirTask : AbstractNativeMac
     @get:PathSensitive(PathSensitivity.ABSOLUTE)
     val composeResourcesDirs: ConfigurableFileCollection = objects.fileCollection()
 
+    @get:InputDirectory
+    @get:Optional
+    internal val macLayeredIcons: DirectoryProperty = objects.directoryProperty()
+
+    private val macAssetsTool by lazy { MacAssetsTool(runExternalTool, logger) }
+
     override fun createPackage(
         destinationDir: File,
         workingDir: File,
@@ -63,6 +72,18 @@ abstract class AbstractNativeMacApplicationPackageAppDirTask : AbstractNativeMac
         executable.ioFile.copyTo(appExecutableFile)
         appExecutableFile.setExecutable(true)
 
+        macLayeredIcons.orNull?.let {
+            try {
+                macAssetsTool.compileAssets(
+                    iconDir = it.asFile,
+                    workingDir = workingDir,
+                    minimumSystemVersion = minimumSystemVersion.getOrElse(KOTLIN_NATIVE_MIN_SUPPORTED_MAC_OS)
+                )
+            } catch (e: Exception) {
+                logger.warn("Can not compile layered icon: ${e.message}")
+            }
+        }
+
         val appIconFile = appResourcesDir.resolve("$packageName.icns")
         iconFile.ioFile.copyTo(appIconFile)
 
@@ -75,6 +96,15 @@ abstract class AbstractNativeMacApplicationPackageAppDirTask : AbstractNativeMac
             fileOperations.copy { copySpec ->
                 copySpec.from(composeResourcesDirs)
                 copySpec.into(appResourcesDir.resolve("compose-resources").apply { mkdirs() })
+            }
+        }
+
+        macAssetsTool.assetsFile(workingDir).let {
+            if (it.exists()) {
+                fileOperations.copy { copySpec ->
+                    copySpec.from(it)
+                    copySpec.into(appResourcesDir)
+                }
             }
         }
     }
@@ -93,5 +123,9 @@ abstract class AbstractNativeMacApplicationPackageAppDirTask : AbstractNativeMac
         this[PlistKeys.NSHumanReadableCopyright] = copyright.orNull
         this[PlistKeys.NSSupportsAutomaticGraphicsSwitching] = "true"
         this[PlistKeys.NSHighResolutionCapable] = "true"
+
+        if (macAssetsTool.assetsFile(workingDir.ioFile).exists()) {
+            macLayeredIcons.orNull?.let { this[PlistKeys.CFBundleIconName] = it.asFile.name.removeSuffix(".icon") }
+        }
     }
 }

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/internal/utils/osUtils.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/internal/utils/osUtils.kt
@@ -85,6 +85,10 @@ internal object MacUtils {
     val open: File by lazy {
         File("/usr/bin/open").checkExistingFile()
     }
+
+    val plutil: File by lazy {
+        File("/usr/bin/plutil").checkExistingFile()
+    }
 }
 
 internal object UnixUtils {


### PR DESCRIPTION
## Summary
- Port of [JetBrains/compose-multiplatform#5451](https://github.com/JetBrains/compose-multiplatform/pull/5451)
- Adds `layeredIconDir` DSL property to `macOS {}` block for both JVM and native targets
- Compiles `.icon` directories into `Assets.car` via `xcrun actool` (requires actool >= 26.0)
- Embeds `Assets.car` in the `.app` bundle and sets `CFBundleIconName` in `Info.plist`
- Gracefully degrades with a warning if actool is missing or too old

## Changed files
- **`PlatformSettings.kt`** — new `layeredIconDir: DirectoryProperty`
- **`MacAssetsTool.kt`** — new utility for actool compilation and version checking
- **`AbstractJPackageTask.kt`** — layered icon support for JVM packaging
- **`AbstractNativeMacApplicationPackageAppDirTask.kt`** — layered icon support for native packaging
- **`InfoPlistBuilder.kt`** — added `CFBundleIconName` plist key
- **`osUtils.kt`** — added `plutil` to `MacUtils`
- **`configureJvmApplication.kt`** / **`configureNativeApplication.kt`** — DSL wiring
- **`README.md`** — documentation with usage examples

## Usage
```kotlin
nativeDistributions {
    macOS {
        iconFile.set(project.file("icons/MyApp.icns"))       // fallback
        layeredIconDir.set(project.file("icons/MyApp.icon")) // layered
    }
}
```

## Test plan
- [ ] Verify build compiles successfully on all platforms
- [ ] Test on macOS with Xcode 26+ that Assets.car is generated and included in the .app bundle
- [ ] Test that builds without layeredIconDir set still work unchanged
- [ ] Test graceful degradation when actool < 26 or missing