### PR TITLE
feat: add runtime executable type detection with dev fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ ComposeDeskKit extends the official plugin with native library optimization, AOT
 - [Installation](#installation)
 - [What's different from the official plugin?](#whats-different-from-the-official-plugin)
   - [1. Native Library Cleanup](#1-native-library-cleanup)
-  - [2. JDK 25+ AOT Cache Generation](#2-jdk-25-aot-cache-generation)
-  - [3. Splash Screen](#3-splash-screen)
-  - [4. Architecture Suffix in Distribution Filenames](#4-architecture-suffix-in-distribution-filenames)
-  - [5. Linux Packaging Enhancements](#5-linux-packaging-enhancements)
-  - [6. DEB Compression Options](#6-deb-compression-options)
-  - [7. RPM Compression Options](#7-rpm-compression-options)
-  - [8. `--app-image` jpackage Fix](#8---app-image-jpackage-fix)
-  - [9. Improved Skiko Unpacking](#9-improved-skiko-unpacking)
-  - [10. MSIX Target for Windows](#10-msix-target-for-windows)
-  - [11. macOS Layered Icons (macOS 26+)](#11-macos-layered-icons-macos-26)
+  - [2. Runtime Executable Type Detection](#2-runtime-executable-type-detection)
+  - [3. JDK 25+ AOT Cache Generation](#3-jdk-25-aot-cache-generation)
+  - [4. Splash Screen](#4-splash-screen)
+  - [5. Architecture Suffix in Distribution Filenames](#5-architecture-suffix-in-distribution-filenames)
+  - [6. Linux Packaging Enhancements](#6-linux-packaging-enhancements)
+  - [7. DEB Compression Options](#7-deb-compression-options)
+  - [8. RPM Compression Options](#8-rpm-compression-options)
+  - [9. `--app-image` jpackage Fix](#9---app-image-jpackage-fix)
+  - [10. Improved Skiko Unpacking](#10-improved-skiko-unpacking)
+  - [11. MSIX Target for Windows](#11-msix-target-for-windows)
+  - [12. macOS Layered Icons (macOS 26+)](#12-macos-layered-icons-macos-26)
 - [Full DSL Reference](#full-dsl-reference-new-properties-only)
 - [Complete Example](#complete-example)
 - [Migration from `org.jetbrains.compose`](#migration-from-orgjetbrainscompose)
@@ -89,7 +90,32 @@ nativeDistributions {
 
 ---
 
-### 2. JDK 25+ AOT Cache Generation
+### 2. Runtime Executable Type Detection
+
+Launchers now expose the executable/package type to the app with:
+
+- `composedeskkit.executable.type=exe|msi|dmg|pkg|msix|deb|rpm`
+- `composedeskkit.executable.type=dev` for `run`/dev mode
+
+Use the runtime helper from `aot-runtime`:
+
+```kotlin
+import io.github.kdroidfilter.composedeskkit.aot.runtime.ExecutableRuntime
+
+if (ExecutableRuntime.isMsix()) {
+    // MSIX-specific behavior
+} else if (ExecutableRuntime.isMsi()) {
+    // MSI-specific behavior
+} else if (ExecutableRuntime.isDev()) {
+    // run/dev fallback when no installer type is detected
+}
+```
+
+You can also read the enum directly with `ExecutableRuntime.type()`.
+
+---
+
+### 3. JDK 25+ AOT Cache Generation
 
 Generates an ahead-of-time compilation cache using the JDK 25+ single-step AOT training, improving application startup time.
 
@@ -139,7 +165,7 @@ The application **must** must return an exit code 0.
 
 ---
 
-### 3. Splash Screen
+### 4. Splash Screen
 
 Adds a JVM splash screen from an image file in the application resources.
 
@@ -153,7 +179,7 @@ This automatically injects `-splash:$APPDIR/resources/splash.png` into the JVM l
 
 ---
 
-### 4. Architecture Suffix in Distribution Filenames
+### 5. Architecture Suffix in Distribution Filenames
 
 Installer filenames are automatically suffixed with the target architecture (`_x64` or `_arm64`) for clarity:
 
@@ -166,7 +192,7 @@ Installer filenames are automatically suffixed with the target architecture (`_x
 
 ---
 
-### 5. Linux Packaging Enhancements
+### 6. Linux Packaging Enhancements
 
 #### StartupWMClass
 
@@ -214,7 +240,7 @@ This rewrites known libraries to use fallback alternatives, for example:
 
 ---
 
-### 6. DEB Compression Options
+### 7. DEB Compression Options
 
 Control the compression algorithm and level used when building `.deb` packages:
 
@@ -240,7 +266,7 @@ If `null`, the `dpkg-deb` default is used.
 
 ---
 
-### 7. RPM Compression Options
+### 8. RPM Compression Options
 
 Control the compression algorithm and level used when building `.rpm` packages:
 
@@ -265,7 +291,7 @@ If `null`, the `rpmbuild` default is used.
 
 ---
 
-### 8. `--app-image` jpackage Fix
+### 9. `--app-image` jpackage Fix
 
 The official plugin passes the **parent directory** to jpackage's `--app-image` argument. ComposeDeskKit fixes this by passing the **actual platform-specific application directory**:
 
@@ -276,13 +302,13 @@ This ensures that files generated in-place (such as the AOT cache) are correctly
 
 ---
 
-### 9. Improved Skiko Unpacking
+### 10. Improved Skiko Unpacking
 
 Handles subdirectory paths when unpacking Skiko native dependencies, preserving correct file names in the output.
 
 ---
 
-### 10. MSIX Target for Windows
+### 11. MSIX Target for Windows
 
 Adds native `MSIX` packaging support via `TargetFormat.Msix`.
 
@@ -332,7 +358,7 @@ Implementation details:
 
 ---
 
-### 11. macOS Layered Icons (macOS 26+)
+### 12. macOS Layered Icons (macOS 26+)
 
 Adds support for [macOS layered icons](https://developer.apple.com/design/human-interface-guidelines/app-icons#macOS) (`.icon` directory) introduced in macOS 26. Layered icons enable the dynamic tilt/depth effects shown on the Dock and in Spotlight.
 

--- a/aot-runtime/src/main/kotlin/io/github/kdroidfilter/composedeskkit/aot/runtime/ExecutableRuntime.kt
+++ b/aot-runtime/src/main/kotlin/io/github/kdroidfilter/composedeskkit/aot/runtime/ExecutableRuntime.kt
@@ -1,0 +1,60 @@
+package io.github.kdroidfilter.composedeskkit.aot.runtime
+
+public enum class ExecutableType {
+    EXE,
+    MSI,
+    DMG,
+    PKG,
+    MSIX,
+    DEB,
+    RPM,
+    DEV,
+}
+
+@Suppress("TooManyFunctions")
+public object ExecutableRuntime {
+    public const val TYPE_PROPERTY: String = "composedeskkit.executable.type"
+
+    @JvmStatic
+    public fun type(): ExecutableType = parseType(System.getProperty(TYPE_PROPERTY))
+
+    @JvmStatic
+    public fun type(propertyName: String): ExecutableType = parseType(System.getProperty(propertyName))
+
+    @JvmStatic
+    public fun isExe(): Boolean = type() == ExecutableType.EXE
+
+    @JvmStatic
+    public fun isMsi(): Boolean = type() == ExecutableType.MSI
+
+    @JvmStatic
+    public fun isDmg(): Boolean = type() == ExecutableType.DMG
+
+    @JvmStatic
+    public fun isPkg(): Boolean = type() == ExecutableType.PKG
+
+    @JvmStatic
+    public fun isMsix(): Boolean = type() == ExecutableType.MSIX
+
+    @JvmStatic
+    public fun isDeb(): Boolean = type() == ExecutableType.DEB
+
+    @JvmStatic
+    public fun isRpm(): Boolean = type() == ExecutableType.RPM
+
+    @JvmStatic
+    public fun isDev(): Boolean = type() == ExecutableType.DEV
+
+    public fun parseType(rawValue: String?): ExecutableType =
+        when (rawValue?.trim()?.lowercase()) {
+            "exe", ".exe" -> ExecutableType.EXE
+            "msi", ".msi" -> ExecutableType.MSI
+            "dmg", ".dmg" -> ExecutableType.DMG
+            "pkg", ".pkg" -> ExecutableType.PKG
+            "msix", ".msix" -> ExecutableType.MSIX
+            "deb", ".deb" -> ExecutableType.DEB
+            "rpm", ".rpm" -> ExecutableType.RPM
+            "dev", "development", "app-image", "appimage" -> ExecutableType.DEV
+            else -> ExecutableType.DEV
+        }
+}

--- a/aot-runtime/src/test/kotlin/io/github/kdroidfilter/composedeskkit/aot/runtime/ExecutableRuntimeTest.kt
+++ b/aot-runtime/src/test/kotlin/io/github/kdroidfilter/composedeskkit/aot/runtime/ExecutableRuntimeTest.kt
@@ -1,0 +1,74 @@
+package io.github.kdroidfilter.composedeskkit.aot.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExecutableRuntimeTest {
+    @Test
+    fun `parses known executable types`() {
+        assertEquals(ExecutableType.EXE, ExecutableRuntime.parseType("exe"))
+        assertEquals(ExecutableType.MSI, ExecutableRuntime.parseType("msi"))
+        assertEquals(ExecutableType.DMG, ExecutableRuntime.parseType("dmg"))
+        assertEquals(ExecutableType.PKG, ExecutableRuntime.parseType("pkg"))
+        assertEquals(ExecutableType.MSIX, ExecutableRuntime.parseType("msix"))
+    }
+
+    @Test
+    fun `parses type variants`() {
+        assertEquals(ExecutableType.EXE, ExecutableRuntime.parseType(".EXE"))
+        assertEquals(ExecutableType.MSIX, ExecutableRuntime.parseType(" MsIx "))
+        assertEquals(ExecutableType.DEV, ExecutableRuntime.parseType("app-image"))
+    }
+
+    @Test
+    fun `returns dev for empty or unknown values`() {
+        assertEquals(ExecutableType.DEV, ExecutableRuntime.parseType(null))
+        assertEquals(ExecutableType.DEV, ExecutableRuntime.parseType(""))
+        assertEquals(ExecutableType.DEV, ExecutableRuntime.parseType("unknown"))
+    }
+
+    @Test
+    fun `reads type from custom system property`() {
+        val propertyName = "composedeskkit.test.executable.type"
+        val previousValue = System.getProperty(propertyName)
+        try {
+            System.setProperty(propertyName, "msix")
+            assertEquals(ExecutableType.MSIX, ExecutableRuntime.type(propertyName))
+        } finally {
+            restoreSystemProperty(propertyName, previousValue)
+        }
+    }
+
+    @Test
+    fun `boolean helpers expose target type and dev fallback`() {
+        val previousValue = System.getProperty(ExecutableRuntime.TYPE_PROPERTY)
+        try {
+            System.setProperty(ExecutableRuntime.TYPE_PROPERTY, "msi")
+            assertTrue(ExecutableRuntime.isMsi())
+            assertFalse(ExecutableRuntime.isDev())
+
+            System.setProperty(ExecutableRuntime.TYPE_PROPERTY, "rpm")
+            assertTrue(ExecutableRuntime.isRpm())
+            assertFalse(ExecutableRuntime.isDeb())
+
+            System.setProperty(ExecutableRuntime.TYPE_PROPERTY, "other")
+            assertTrue(ExecutableRuntime.isDev())
+            assertFalse(ExecutableRuntime.isMsi())
+        } finally {
+            restoreSystemProperty(ExecutableRuntime.TYPE_PROPERTY, previousValue)
+        }
+    }
+
+    private fun restoreSystemProperty(
+        name: String,
+        value: String?,
+    ) {
+        if (value == null) {
+            System.clearProperty(name)
+        } else {
+            System.setProperty(name, value)
+        }
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/ComposeSystemProperties.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/ComposeSystemProperties.kt
@@ -8,3 +8,4 @@ package io.github.kdroidfilter.composedeskkit.desktop.application.internal
 internal const val APP_RESOURCES_DIR = "compose.application.resources.dir"
 internal const val SKIKO_LIBRARY_PATH = "skiko.library.path"
 internal const val CONFIGURE_SWING_GLOBALS = "compose.application.configure.swing.globals"
+internal const val APP_EXECUTABLE_TYPE = "composedeskkit.executable.type"

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/ExecutableType.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/ExecutableType.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package io.github.kdroidfilter.composedeskkit.desktop.application.internal
+
+import io.github.kdroidfilter.composedeskkit.desktop.application.dsl.TargetFormat
+import org.gradle.api.logging.Logger
+import java.io.File
+
+internal const val EXECUTABLE_TYPE_DEV = "dev"
+private const val JAVA_OPTIONS_SECTION = "[JavaOptions]"
+private const val JAVA_OPTIONS_PREFIX = "java-options="
+private const val EXECUTABLE_TYPE_OPTION_PREFIX = "$JAVA_OPTIONS_PREFIX-D$APP_EXECUTABLE_TYPE="
+
+internal val TargetFormat.executableTypeValue: String
+    get() =
+        when (this) {
+            TargetFormat.Exe -> "exe"
+            TargetFormat.Msi -> "msi"
+            TargetFormat.Dmg -> "dmg"
+            TargetFormat.Pkg -> "pkg"
+            TargetFormat.Msix -> "msix"
+            TargetFormat.Deb -> "deb"
+            TargetFormat.Rpm -> "rpm"
+            TargetFormat.AppImage -> EXECUTABLE_TYPE_DEV
+        }
+
+internal fun updateExecutableTypeInAppImage(
+    appImageDir: File,
+    targetFormat: TargetFormat,
+    logger: Logger,
+) {
+    val cfgFiles =
+        appImageDir
+            .walkTopDown()
+            .filter { it.isFile && it.extension.equals("cfg", ignoreCase = true) }
+            .toList()
+
+    if (cfgFiles.isEmpty()) {
+        logger.warn("No .cfg launcher file found in app image at ${appImageDir.absolutePath}")
+        return
+    }
+
+    cfgFiles.forEach { cfgFile ->
+        updateExecutableTypeInCfg(cfgFile, targetFormat.executableTypeValue)
+    }
+}
+
+private fun updateExecutableTypeInCfg(
+    cfgFile: File,
+    executableType: String,
+) {
+    val updatedOption = "$JAVA_OPTIONS_PREFIX-D$APP_EXECUTABLE_TYPE=$executableType"
+    val lines = cfgFile.readLines().toMutableList()
+    var inJavaOptions = false
+    var javaOptionsSectionIndex = -1
+    var replaced = false
+
+    lines.forEachIndexed { index, line ->
+        val trimmed = line.trim()
+        when {
+            trimmed == JAVA_OPTIONS_SECTION -> {
+                inJavaOptions = true
+                if (javaOptionsSectionIndex == -1) {
+                    javaOptionsSectionIndex = index
+                }
+            }
+            trimmed.startsWith("[") -> inJavaOptions = false
+            inJavaOptions && trimmed.startsWith(EXECUTABLE_TYPE_OPTION_PREFIX) && !replaced -> {
+                lines[index] = updatedOption
+                replaced = true
+            }
+        }
+    }
+
+    if (!replaced) {
+        if (javaOptionsSectionIndex == -1) {
+            lines.add(JAVA_OPTIONS_SECTION)
+            lines.add(updatedOption)
+        } else {
+            lines.add(javaOptionsSectionIndex + 1, updatedOption)
+        }
+    }
+
+    cfgFile.writeText(lines.joinToString(System.lineSeparator()))
+}

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/internal/configureJvmApplication.kt
@@ -387,7 +387,8 @@ private fun JvmApplicationContext.configurePackageTask(
     packageTask.launcherMainClass.set(provider { app.mainClass })
     packageTask.launcherJvmArgs.set(
         provider {
-            val args = defaultJvmArgs + app.jvmArgs
+            val executableTypeArg = "-D$APP_EXECUTABLE_TYPE=${packageTask.targetFormat.executableTypeValue}"
+            val args = defaultJvmArgs + executableTypeArg + app.jvmArgs
             val splash = app.nativeDistributions.splashImage
             if (splash != null) args + "-splash:\$APPDIR/resources/$splash" else args
         },
@@ -589,6 +590,7 @@ private fun JvmApplicationContext.configureRunTask(
     exec.jvmArgs =
         arrayListOf<String>().apply {
             addAll(defaultJvmArgs)
+            add("-D$APP_EXECUTABLE_TYPE=$EXECUTABLE_TYPE_DEV")
 
             if (currentOS == OS.MacOS) {
                 val file = app.nativeDistributions.macOS.iconFile.ioFileOrNull

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/tasks/AbstractJPackageTask.kt
@@ -36,6 +36,7 @@ import io.github.kdroidfilter.composedeskkit.desktop.application.internal.files.
 import io.github.kdroidfilter.composedeskkit.desktop.application.internal.files.normalizedPath
 import io.github.kdroidfilter.composedeskkit.desktop.application.internal.files.transformJar
 import io.github.kdroidfilter.composedeskkit.desktop.application.internal.javaOption
+import io.github.kdroidfilter.composedeskkit.desktop.application.internal.updateExecutableTypeInAppImage
 import io.github.kdroidfilter.composedeskkit.desktop.application.internal.validation.validate
 import io.github.kdroidfilter.composedeskkit.internal.utils.Arch
 import io.github.kdroidfilter.composedeskkit.internal.utils.OS
@@ -478,11 +479,14 @@ abstract class AbstractJPackageTask
                     // Args, that can only be used, when creating an installer
                     // jpackage expects --app-image to point to the actual app directory,
                     // not the parent. The app dir name is platform-specific.
-                    val resolvedAppImage = when (currentOS) {
-                        OS.MacOS -> appImage.dir("${packageName.get()}.app")
-                        OS.Linux, OS.Windows -> appImage.dir(packageName.get())
-                    }
-                    cliArg("--app-image", resolvedAppImage)
+                    val resolvedAppImage =
+                        when (currentOS) {
+                            OS.MacOS -> appImage.dir("${packageName.get()}.app")
+                            OS.Linux, OS.Windows -> appImage.dir(packageName.get())
+                        }
+                    val appImageDir = resolvedAppImage.ioFile
+                    updateExecutableTypeInAppImage(appImageDir, targetFormat, logger)
+                    cliArg("--app-image", appImageDir)
                     cliArg("--install-dir", installationPath)
                     cliArg("--license-file", licenseFile)
                     cliArg("--resource-dir", jpackageResources)

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/tasks/AbstractMsixPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/composedeskkit/desktop/application/tasks/AbstractMsixPackageTask.kt
@@ -5,7 +5,9 @@
 
 package io.github.kdroidfilter.composedeskkit.desktop.application.tasks
 
+import io.github.kdroidfilter.composedeskkit.desktop.application.dsl.TargetFormat
 import io.github.kdroidfilter.composedeskkit.desktop.application.internal.WindowsKitsLocator
+import io.github.kdroidfilter.composedeskkit.desktop.application.internal.updateExecutableTypeInAppImage
 import io.github.kdroidfilter.composedeskkit.desktop.tasks.AbstractComposeDesktopTask
 import io.github.kdroidfilter.composedeskkit.internal.utils.Arch
 import io.github.kdroidfilter.composedeskkit.internal.utils.OS
@@ -133,6 +135,7 @@ abstract class AbstractMsixPackageTask : AbstractComposeDesktopTask() {
         }
 
         val appDir = resolveAppImageDir()
+        updateExecutableTypeInAppImage(appDir, TargetFormat.Msix, logger)
         val resourcesDir = appDir.resolve("resources").apply { mkdirs() }
         renderMsixIcons(resourcesDir)
         writeManifest(appDir)


### PR DESCRIPTION
## Summary
- expose `composedeskkit.executable.type` to runtime launchers
- add `ExecutableRuntime` API in `aot-runtime` with helpers: `isExe`, `isMsi`, `isDmg`, `isPkg`, `isMsix`, `isDeb`, `isRpm`, `isDev`
- ensure installer packaging rewrites app-image `.cfg` so final installers report the correct type (including MSIX)
- set `dev` type for `run` / app-image fallback
- move Runtime Executable Type Detection section to #2 in README and renumber sections

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :aot-runtime:check`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew -p plugin-build :plugin:compileKotlin`
