### PR TITLE
fix: resolve Gradle configuration cache serialization failures

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/MacOSNotarizationSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/MacOSNotarizationSettings.kt
@@ -46,11 +46,5 @@ abstract class MacOSNotarizationSettings {
     @Deprecated("This option is no longer supported and got replaced by teamID", level = DeprecationLevel.ERROR)
     @get:Internal
     val ascProvider: Property<String> =
-        objects.nullableProperty<String>().apply {
-            set(
-                providers.provider {
-                    throw UnsupportedOperationException("This option is not supported by notary tool and was replaced by teamID")
-                },
-            )
-        }
+        objects.nullableProperty()
 }

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -235,7 +235,7 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
                 if (runProguard != null) {
                     dependsOn(runProguard)
                     inputJars.from(project.fileTree(runProguard.flatMap { it.destinationDir }))
-                    mainJarName.set(runProguard.flatMap { it.mainJarInDestinationDir }.map { it.asFile.name })
+                    mainJarName.set(runProguard.flatMap { it.mainJarBaseName })
                 } else {
                     useAppRuntimeFiles { (runtimeJars, mainJar) ->
                         inputJars.from(runtimeJars)
@@ -494,6 +494,7 @@ private fun JvmApplicationContext.configureProguardTask(
         useAppRuntimeFiles { files ->
             inputFiles.from(files.allRuntimeJars)
             mainJar.set(files.mainJar)
+            mainJarBaseName.set(files.mainJar.map { it.asFile.name })
         }
     }
 

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractProguardTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractProguardTask.kt
@@ -27,10 +27,11 @@ abstract class AbstractProguardTask : AbstractNucleusTask() {
     val mainJar: RegularFileProperty = objects.fileProperty()
 
     @get:Internal
-    internal val mainJarInDestinationDir: Provider<RegularFile> =
-        mainJar.flatMap {
-            destinationDir.file(it.asFile.name)
-        }
+    val mainJarBaseName: Property<String> = objects.property(String::class.java)
+
+    @get:Internal
+    internal val mainJarInDestinationDir: Provider<RegularFile>
+        get() = destinationDir.file(mainJarBaseName)
 
     @get:InputFiles
     val configurationFiles: ConfigurableFileCollection = objects.fileCollection()


### PR DESCRIPTION
## Summary
- Remove the throwing provider from the deprecated `ascProvider` property in `MacOSNotarizationSettings` — it caused Gradle configuration cache serialization to fail with "This option is not supported by notary tool and was replaced by teamID"
- Replace `mainJar.flatMap` in `AbstractProguardTask` with a separate `mainJarBaseName` string property to avoid resolving task outputs at configuration time — this fixes "Querying the mapped value of flatmap(...) before task has completed is not supported"

## Test plan
- [x] Verified `packageReleaseDeb --dry-run --configuration-cache` passes
- [x] Verified `createReleaseSandboxedDistributable --dry-run --configuration-cache` passes