### PR TITLE
fix(plugin): derive plugin version from Git tag instead of gradle.properties

### DIFF
--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -8,9 +8,16 @@ plugins {
     alias(libs.plugins.versionCheck)
 }
 
+val resolvedVersion =
+    providers
+        .environmentVariable("GITHUB_REF")
+        .orNull
+        ?.removePrefix("refs/tags/v")
+        ?: "1.0.0"
+
 allprojects {
     group = property("GROUP").toString()
-    version = property("VERSION").toString()
+    version = resolvedVersion
 
     apply {
         plugin(

--- a/plugin-build/gradle.properties
+++ b/plugin-build/gradle.properties
@@ -1,5 +1,4 @@
 ID=io.github.kdroidfilter.nucleus
-VERSION=1.0.0
 GROUP=io.github.kdroidfilter
 DISPLAY_NAME=Nucleus Gradle Plugin
 DESCRIPTION=A JVM desktop application packaging plugin

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -41,7 +41,7 @@ val buildConfigDir
     get() = project.layout.buildDirectory.dir("generated/buildconfig")
 val composeVersion = project.findProperty("compose.version")?.toString() ?: "1.10.0"
 val composeMaterial3Version = project.findProperty("compose.material3.version")?.toString() ?: "1.9.0"
-val pluginVersion = project.property("VERSION").toString()
+val pluginVersion = project.version.toString()
 val buildConfig =
     tasks.register("buildConfig", GenerateBuildConfig::class.java) {
         classFqName.set("io.github.kdroidfilter.nucleus.NucleusBuildConfig")
@@ -62,7 +62,7 @@ gradlePlugin {
         create(property("ID").toString()) {
             id = property("ID").toString()
             implementationClass = property("IMPLEMENTATION_CLASS").toString()
-            version = property("VERSION").toString()
+            version = project.version.toString()
             description = property("DESCRIPTION").toString()
             displayName = property("DISPLAY_NAME").toString()
             tags.set(listOf("nucleus", "desktop", "jvm", "packaging"))


### PR DESCRIPTION
## Summary
- Align Gradle plugin versioning with Maven runtime modules: version is now derived from the Git tag (`GITHUB_REF`) instead of `gradle.properties`, removing the hardcoded `VERSION` property to avoid confusion

## Test plan
- [ ] Verify `./gradlew --project-dir plugin-build help` succeeds locally
- [ ] Verify CI publish workflow resolves version correctly from tag