### PR TITLE
refactor(dsl): move installationPath to macOS-only

### DIFF
--- a/.github/actions/build-macos-universal/build-universal.sh
+++ b/.github/actions/build-macos-universal/build-universal.sh
@@ -509,7 +509,7 @@ if [[ -n "$INSTALLER_IDENTITY" && -n "$UNIVERSAL_SANDBOXED_APP" ]]; then
   fi
 
   productbuild \
-    --component "$PKG_APP_COPY" "/Applications" \
+    --component "$PKG_APP_COPY" "${INSTALL_LOCATION:-/Applications}" \
     --sign "$INSTALLER_IDENTITY" \
     "${PB_KC_ARGS[@]}" \
     "$OUTPUT_DIR/$PKG_NAME"

--- a/docs/targets/linux.md
+++ b/docs/targets/linux.md
@@ -250,7 +250,6 @@ No manual `desktopEntries` override is needed for MimeType.
 | `shortcut` | `Boolean` | `false` | Create `.desktop` file |
 | `packageName` | `String?` | `null` | Override package name |
 | `packageVersion` | `String?` | `null` | Override package version |
-| `installationPath` | `String?` | `null` | Installation directory |
 | `startupWMClass` | `String?` | `null` | `StartupWMClass` in `.desktop` |
 | `appRelease` | `String?` | `null` | Application release number |
 | `appCategory` | `String?` | `null` | Application category |

--- a/docs/targets/macos.md
+++ b/docs/targets/macos.md
@@ -179,6 +179,26 @@ macOS {
 }
 ```
 
+## Installation Path
+
+The `installationPath` property controls where the application is installed on disk. It defaults to `/Applications`.
+
+- **PKG installers** — passed as the `installLocation` to electron-builder and to `productbuild` for App Store builds. When the user chooses the local system domain during installation, the app is placed in `installationPath` (e.g. `/Applications`). When a home directory installation is chosen, the app is placed in `$HOME/Applications` instead.
+- **DMG** — used as the symlink target in the native DMG builder, so the drag-and-drop arrow points to the correct directory.
+
+```kotlin
+macOS {
+    // Default — installs into /Applications
+    installationPath = "/Applications"
+
+    // Custom — installs into /Applications/MyCompany
+    installationPath = "/Applications/MyCompany"
+}
+```
+
+!!! note
+    This property is macOS-only. Windows and Linux installers do not use it.
+
 ## Full macOS DSL Reference
 
 ### `macOS { }`
@@ -204,7 +224,7 @@ macOS {
 | `runtimeEntitlementsFile` | `RegularFileProperty` | — | Runtime entitlements plist |
 | `provisioningProfile` | `RegularFileProperty` | — | Provisioning profile |
 | `runtimeProvisioningProfile` | `RegularFileProperty` | — | Runtime provisioning profile |
-| `installationPath` | `String?` | `null` | Installation directory |
+| `installationPath` | `String?` | `/Applications` | The install location used by PKG installers and as the DMG symlink target (see [below](#installation-path)) |
 
 ### `macOS { signing { } }`
 

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/PlatformSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/PlatformSettings.kt
@@ -18,7 +18,6 @@ abstract class AbstractPlatformSettings {
 
     val iconFile: RegularFileProperty = objects.fileProperty()
     var packageVersion: String? = null
-    var installationPath: String? = null
 
     internal val fileAssociations: MutableSet<FileAssociation> = mutableSetOf()
 
@@ -41,6 +40,7 @@ abstract class AbstractMacOSPlatformSettings : AbstractPlatformSettings() {
     var dmgPackageBuildVersion: String? = null
     var appCategory: String? = null
     var minimumSystemVersion: String? = null
+    var installationPath: String? = null
     var layeredIconDir: DirectoryProperty = objects.directoryProperty()
 
     /**


### PR DESCRIPTION
## Summary
- Move `installationPath` from `AbstractPlatformSettings` (shared) to `AbstractMacOSPlatformSettings` — it was never used by Windows or Linux targets
- Fix `productbuild` in `build-universal.sh` that hardcoded `/Applications` instead of using `$INSTALL_LOCATION` from metadata JSON
- Update docs: remove `installationPath` from Linux DSL table, improve description in macOS table

## Test plan
- [x] `preMerge` passes with JDK 21
- [ ] Verify macOS CI build still reads `installationPath` correctly via `distributions.macOS.installationPath`