### PR TITLE
feat(updater): add installAndQuit() for silent background updates

### DIFF
--- a/updater-runtime/README.md
+++ b/updater-runtime/README.md
@@ -38,7 +38,7 @@ when (val result = updater.checkForUpdates()) {
             println("${progress.percent.toInt()}%")
             if (progress.file != null) {
                 // Download complete, install
-                updater.quitAndInstall(progress.file!!)
+                updater.installAndRestart(progress.file!!)
             }
         }
     }
@@ -94,7 +94,8 @@ Download URL: `{baseUrl}/{fileName}`
 |--------|-------------|
 | `suspend checkForUpdates(): UpdateResult` | Checks for a newer version |
 | `downloadUpdate(info): Flow<DownloadProgress>` | Downloads the binary, emits progress |
-| `quitAndInstall(file: File)` | Launches the installer and exits the process |
+| `installAndRestart(file: File)` | Launches the installer, exits the process, and relaunches after install |
+| `installAndQuit(file: File)` | Launches the installer and exits without relaunching — update takes effect on next start |
 
 ### UpdateResult
 
@@ -156,7 +157,7 @@ fun UpdateBanner() {
             LinearProgressIndicator(progress = { (progress / 100.0).toFloat() })
         }
         downloadedFile?.let { file ->
-            Button(onClick = { updater.quitAndInstall(file) }) {
+            Button(onClick = { updater.installAndRestart(file) }) {
                 Text("Install & Restart")
             }
         }

--- a/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/NucleusUpdater.kt
+++ b/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/NucleusUpdater.kt
@@ -116,7 +116,12 @@ class NucleusUpdater(
 
     fun installAndRestart(installerFile: File) {
         val platform = PlatformInfo.currentPlatform()
-        PlatformInstaller.install(installerFile, platform)
+        PlatformInstaller.install(installerFile, platform, restart = true)
+    }
+
+    fun installAndQuit(installerFile: File) {
+        val platform = PlatformInfo.currentPlatform()
+        PlatformInstaller.install(installerFile, platform, restart = false)
     }
 
     private fun doCheckForUpdates(): UpdateResult {


### PR DESCRIPTION
## Summary
- Add `installAndQuit()` method to `NucleusUpdater` — installs the update and exits without relaunching the app
- The update takes effect on next manual start, useful for transparent/silent updates
- Works silently on macOS (DMG/ZIP) and Windows NSIS/MSI in user mode; Linux DEB/RPM always requires elevation
- Fix README references to non-existent `quitAndInstall()` → `installAndRestart()`

## Test plan
- [ ] Verify `installAndRestart()` still relaunches the app after install on all platforms
- [ ] Verify `installAndQuit()` installs without relaunching on macOS ZIP
- [ ] Verify `installAndQuit()` installs without relaunching on Windows NSIS (user mode)
- [ ] Verify Linux DEB/RPM still prompts for elevation with both methods