### PR TITLE
fix(signing): strip certificate prefix from PKG identity for electron-builder

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -637,14 +637,16 @@ internal class ElectronBuilderConfigGenerator {
     private fun resolveInstallerIdentity(macOS: JvmMacOSPlatformSettings): String? {
         val identity = macOS.signing.identity.orNull ?: return null
 
-        val knownPrefixes = listOf(
-            "Developer ID Application: ",
-            "3rd Party Mac Developer Application: ",
-            "Developer ID Installer: ",
-            "3rd Party Mac Developer Installer: ",
-        )
+        val knownPrefixes =
+            listOf(
+                "Developer ID Application: ",
+                "3rd Party Mac Developer Application: ",
+                "Developer ID Installer: ",
+                "3rd Party Mac Developer Installer: ",
+            )
 
-        return knownPrefixes.firstOrNull { identity.startsWith(it) }
+        return knownPrefixes
+            .firstOrNull { identity.startsWith(it) }
             ?.let { identity.removePrefix(it) }
             ?: identity
     }


### PR DESCRIPTION
## Summary
- electron-builder rejects PKG identities with prefixes like `3rd Party Mac Developer Installer:` — it expects just the bare team name and selects the appropriate certificate automatically
- `resolveInstallerIdentity()` was stripping the prefix from the user's input only to re-add the installer prefix, causing `packagePkg` to fail with: *"Please remove prefix '3rd Party Mac Developer Installer:' from the specified name"*
- Now returns only the bare identity (e.g., `"TEAM NAME (XXXXXX)"`) regardless of the input format

## Test plan
- [ ] Build a signed PKG with `appStore = true` and verify no electron-builder error
- [ ] Build a signed PKG with `appStore = false` (Developer ID) and verify no error
- [ ] Verify identity input with or without prefix both work correctly