### PR TITLE
fix(signing): re-sign macOS app after .cfg modification for PKG builds

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -628,6 +628,32 @@ private fun JvmApplicationContext.configureElectronBuilderPackageTask(
     packageTask.appxSquare150x150Logo.set(app.nativeDistributions.windows.appx.square150x150Logo)
     packageTask.appxWide310x150Logo.set(app.nativeDistributions.windows.appx.wide310x150Logo)
     packageTask.distributions = app.nativeDistributions
+
+    if (currentOS == OS.MacOS) {
+        val mac = app.nativeDistributions.macOS
+        packageTask.nonValidatedMacSigningSettings = mac.signing
+        packageTask.nonValidatedMacBundleID.set(mac.bundleID)
+        packageTask.macAppStore.set(mac.appStore)
+        val sandboxed = packageTask.targetFormat.isStoreFormat
+        val defaultAppEntitlements =
+            if (sandboxed) {
+                unpackDefaultResources.get { defaultSandboxEntitlements }
+            } else {
+                unpackDefaultResources.get { defaultEntitlements }
+            }
+        val defaultRuntimeEntitlements =
+            if (sandboxed) {
+                unpackDefaultResources.get { defaultSandboxRuntimeEntitlements }
+            } else {
+                unpackDefaultResources.get { defaultEntitlements }
+            }
+        packageTask.macEntitlementsFile.set(
+            mac.entitlementsFile.orElse(defaultAppEntitlements),
+        )
+        packageTask.macRuntimeEntitlementsFile.set(
+            mac.runtimeEntitlementsFile.orElse(defaultRuntimeEntitlements),
+        )
+    }
 }
 
 internal fun JvmApplicationContext.configureCommonNotarizationSettings(notarizationTask: AbstractNotarizationTask) {


### PR DESCRIPTION
## Summary

- Fix PKG builds being rejected by Apple Transporter with "App sandbox not enabled"
- Re-sign the `.app` bundle with proper sandbox entitlements after `.cfg` modification in the electron-builder packaging task
- Wire macOS signing settings (entitlements, signing identity, bundle ID) into `AbstractElectronBuilderPackageTask`

## Problem

When the Gradle plugin builds a PKG for the App Store:
1. `AbstractJPackageTask` creates the `.app` and signs it with sandbox entitlements
2. `AbstractElectronBuilderPackageTask` calls `updateExecutableTypeInAppImage()` which modifies `.cfg` files → invalidates the code signature
3. `ensureMacAdHocSigning()` skipped re-signing for PKG format
4. electron-builder packages the broken-signature `.app` into the PKG
5. Apple Transporter rejects: "App sandbox not enabled"

## Solution

Instead of skipping signing for PKG, re-sign the entire `.app` using the same signing flow as `AbstractJPackageTask.modifyRuntimeOnMacOsIfNeeded()`:
- Re-sign all executables and dylibs in `Contents/runtime`
- Re-sign native libs in `Contents/app/resources` (sandboxed)
- Re-sign the entire `.app` bundle with app entitlements

## Test plan

- [ ] Build a PKG with `./gradlew packagePkg` and verify code signature with `codesign --verify --deep --strict`
- [ ] Submit PKG to Apple Transporter and verify it passes sandbox validation
- [ ] Verify DMG builds are unaffected