### PR TITLE
fix(signing): inject application-identifier for App Store and fix config cache

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
@@ -30,6 +30,26 @@ internal data class ValidatedMacOSSigningSettings(
                 else -> (if (!appStore) developerIdPrefix else thirdPartyMacDeveloperPrefix) + identity
             }
         }
+
+    /** Identity with all known certificate-type prefixes stripped. */
+    val bareIdentityName: String
+        get() {
+            val knownPrefixes =
+                listOf(
+                    "Developer ID Application: ",
+                    "3rd Party Mac Developer Application: ",
+                    "Developer ID Installer: ",
+                    "3rd Party Mac Developer Installer: ",
+                )
+            return knownPrefixes
+                .firstOrNull { identity.startsWith(it) }
+                ?.let { identity.removePrefix(it) }
+                ?: identity
+        }
+
+    /** Team ID extracted from the identity string, e.g. "NAME (XXXXXXX)" → "XXXXXXX". */
+    val teamID: String?
+        get() = TEAM_ID_REGEX.find(identity.trim())?.groupValues?.get(1)
 }
 
 internal fun MacOSSigningSettings.validate(
@@ -85,3 +105,5 @@ private val ERR_UNKNOWN_SIGN_ID =
        |  * Use '${NucleusProperties.MAC_SIGN_ID}' Gradle property;
        |  * Use 'nativeDistributions.macOS.signing.identity' DSL property;
     """.trimMargin()
+
+private val TEAM_ID_REGEX = Regex("\\(([A-Z0-9]+)\\)\\s*$")


### PR DESCRIPTION
## Summary

- Fix Gradle configuration cache incompatibility in `signPkgInstaller`
- Fix TestFlight error 90886: missing `application-identifier` in code signature
- Align CI script (`build-universal.sh`) with the same fix

## Problem

1. **Configuration cache**: `signPkgInstaller` called `project.file()` at execution time, which is forbidden with Gradle configuration cache
2. **TestFlight rejection**: Apple Transporter rejects the PKG with "the signature for the bundle is missing an application identifier" (error 90886) because `com.apple.application-identifier` and `com.apple.developer.team-identifier` are not in the entitlements used during codesigning

## Solution

1. Use `macSigner.settings.keychain` (already resolved at configuration time) instead of `project.file()`
2. Automatically inject `com.apple.application-identifier` (`TEAMID.BUNDLEID`) and `com.apple.developer.team-identifier` into entitlements during App Store signing — both in the plugin (`resignAppForPkg`) and the CI script (`build-universal.sh`)
3. Add `bareIdentityName` and `teamID` helpers to `ValidatedMacOSSigningSettings`

## Test plan

- [ ] `./gradlew preMerge` passes
- [ ] `./gradlew packagePkg` works with configuration cache enabled
- [ ] PKG passes `pkgutil --check-signature`
- [ ] PKG accepted by Apple Transporter / TestFlight