### PR TITLE
fix(aot): ad-hoc sign jspawnhelper instead of stripping signature

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractGenerateAotCacheTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractGenerateAotCacheTask.kt
@@ -368,13 +368,13 @@ abstract class AbstractGenerateAotCacheTask : AbstractNucleusTask() {
     }
 
     /**
-     * Strips the code signature from jspawnhelper so it can spawn child processes
-     * during AOT training. When signed with app-sandbox entitlements, macOS kills
-     * jspawnhelper with SIGTRAP (signal 5) on fork/exec.
+     * Ad-hoc re-signs jspawnhelper without sandbox entitlements so it can spawn
+     * child processes during AOT training. Completely removing the signature
+     * causes macOS to SIGKILL the binary; ad-hoc signing avoids this.
      */
     private fun unsandboxJspawnhelper(jspawnhelper: File) {
-        logger.lifecycle("[aotCache] Temporarily stripping signature from jspawnhelper for AOT training")
-        runCodesign(listOf("codesign", "--remove-signature", jspawnhelper.absolutePath))
+        logger.lifecycle("[aotCache] Temporarily re-signing jspawnhelper without sandbox for AOT training")
+        runCodesign(listOf("codesign", "--force", "--sign", "-", jspawnhelper.absolutePath))
     }
 
     /**


### PR DESCRIPTION
## Summary
- On macOS, completely removing the code signature from `jspawnhelper` causes the OS to SIGKILL it when the JVM forks to assemble the AOT cache
- Changed to ad-hoc signing (`codesign --force --sign -`) without sandbox entitlements, which keeps the binary executable while still allowing child process spawning

## Test plan
- [x] Verified `generateReleaseAotCache` now completes successfully (AOT cache ~50MB created)