### PR TITLE
fix(packaging): prevent JAR filename collisions in sandboxed pipeline

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -548,10 +548,15 @@ private fun JvmApplicationContext.configurePackageTask(
     when {
         stripNativeLibs != null -> {
             packageTask.dependsOn(stripNativeLibs)
-            packageTask.files.from(project.fileTree(stripNativeLibs.flatMap { it.outputDir }))
+            packageTask.files.from(
+                project.fileTree(stripNativeLibs.flatMap { it.outputDir }).apply {
+                    exclude(".main-jar-name")
+                },
+            )
             packageTask.launcherMainJar.set(stripNativeLibs.flatMap { it.mainJarInOutputDir })
+            // Strip task already mangles filenames for deduplication
+            packageTask.mangleJarFilesNames.set(false)
             if (runProguard != null) {
-                packageTask.mangleJarFilesNames.set(false)
                 packageTask.packageFromUberJar.set(runProguard.flatMap { it.joinOutputJars })
             }
         }


### PR DESCRIPTION
## Summary

- **Bug:** `AbstractStripNativeLibsFromJarsTask` écrivait tous les JARs dans un répertoire plat avec `file.name`, causant des écrasements silencieux quand plusieurs JARs partageaient le même nom simple (fréquent en KMP multi-modules). Résultat : `ClassNotFoundException` à l'exécution pour les builds App Store (PKG, AppX, Flatpak).
- **Fix:** Utilisation de `mangledName()` (suffixe MD5) pour dédupliquer les JARs de sortie, comme le fait déjà `AbstractJPackageTask`.
- **Metadata:** Un fichier `.main-jar-name` enregistre le nom manglé du JAR principal pour les tâches en aval, exclu du package final.

## Test plan

- [ ] Build `packagePkg` avec un projet multi-modules KMP ayant des JARs avec le même nom simple
- [ ] Vérifier que toutes les classes sont présentes dans le package final
- [ ] Vérifier que `runDistributable` continue de fonctionner