### PR TITLE
fix(packaging): place universal-arch native libs in resources root

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractExtractNativeLibsTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractExtractNativeLibsTask.kt
@@ -75,11 +75,12 @@ abstract class AbstractExtractNativeLibsTask : AbstractNucleusTask() {
                                 entry.name
                                     .substringBeforeLast('/', "")
                                     .substringAfterLast('/')
-                            val relativePath = if (parentDir.isEmpty() || info.arch == NativeArch.UNIVERSAL) {
-                                fileName
-                            } else {
-                                "$parentDir/$fileName"
-                            }
+                            val relativePath =
+                                if (parentDir.isEmpty() || info.arch == NativeArch.UNIVERSAL) {
+                                    fileName
+                                } else {
+                                    "$parentDir/$fileName"
+                                }
                             if (fileName in extractedFiles) {
                                 logger.warn(
                                     "Sandboxing: skipping duplicate native lib" +


### PR DESCRIPTION
## Summary
- Universal (fat) native libraries were extracted to a `darwin-universal/` subdirectory by `AbstractExtractNativeLibsTask`, but `java.library.path` only includes the arch-specific subdirectory (e.g. `darwin-aarch64`) and the resources root
- `System.loadLibrary()` failed with `UnsatisfiedLinkError` in sandboxed apps because the library wasn't on any searched path
- Universal-arch libs are now placed directly in the resources root so they are found via the existing `java.library.path` entry

## Test plan
- [x] Build a sandboxed macOS app containing a universal native library (e.g. `libnucleus_macos.dylib`)
- [x] Verify the dylib is placed in `Contents/app/resources/` (not in a `darwin-universal/` subdirectory)
- [x] Verify the app launches without `UnsatisfiedLinkError`