### PR TITLE
fix(sandboxing): flatten native lib extraction to resources root

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -859,37 +859,14 @@ private fun JvmApplicationContext.configurePackageUberJarForCurrentOS(
  * JNA-specific args are always included: they are harmless if JNA is not on the classpath
  * (the JVM simply ignores unknown system properties).
  *
- * `jna.boot.library.path` must include the platform-specific subdirectory (e.g. `darwin-aarch64`)
- * because JNA looks for `libjnidispatch` directly in the listed directories without adding
- * any platform prefix itself.
+ * Native libs are extracted flat into [resourcesPath] (no platform subdirectories),
+ * so a single directory entry is sufficient for all lookup mechanisms.
  */
-private fun sandboxingJvmArgs(resourcesPath: String): List<String> {
-    val sep = java.io.File.pathSeparator
-    val jnaPlatformDir = "$resourcesPath/${jnaPlatformPrefix()}"
-    return listOf(
-        "-Djava.library.path=$jnaPlatformDir$sep$resourcesPath",
+private fun sandboxingJvmArgs(resourcesPath: String): List<String> =
+    listOf(
+        "-Djava.library.path=$resourcesPath",
         "-Djna.nounpack=true",
         "-Djna.nosys=true",
-        "-Djna.boot.library.path=$jnaPlatformDir$sep$resourcesPath",
-        "-Djna.library.path=$jnaPlatformDir$sep$resourcesPath",
+        "-Djna.boot.library.path=$resourcesPath",
+        "-Djna.library.path=$resourcesPath",
     )
-}
-
-/**
- * Returns the JNA platform resource prefix for the current OS and architecture.
- * This matches the directory name JNA uses inside its JAR (e.g. `darwin-aarch64`, `linux-x86-64`).
- */
-private fun jnaPlatformPrefix(): String {
-    val os =
-        when (currentOS) {
-            OS.Windows -> "win32"
-            OS.Linux -> "linux"
-            OS.MacOS -> "darwin"
-        }
-    val arch =
-        when (currentArch) {
-            Arch.X64 -> "x86-64"
-            Arch.Arm64 -> "aarch64"
-        }
-    return "$os-$arch"
-}


### PR DESCRIPTION
## Summary
- Native libs are now extracted flat to the resources root instead of platform-specific subdirectories (e.g. `darwin-aarch64/`)
- Removes `jnaPlatformPrefix()` and simplifies `sandboxingJvmArgs` to use a single directory entry
- Fixes `jna.boot.library.path` not finding `libjnidispatch` when pointed at the resources root
- Eliminates duplicate native libs 
- Universal macOS builds can now merge native libs via `lipo` (same relative path in both arch bundles)

## Test plan
- [x] Regenerated DMG/PKG locally — verified all native libs are flat in `Contents/Frameworks/` with no subdirectories
- [x] Verified `.cfg` JVM args point to `$APPDIR/../Frameworks` without platform suffix