### PR TITLE
fix(ci): default setup-node to true, remove npm cache workaround

### DIFF
--- a/.github/actions/setup-nucleus/action.yml
+++ b/.github/actions/setup-nucleus/action.yml
@@ -33,7 +33,7 @@ inputs:
   setup-node:
     description: 'Setup Node.js'
     required: false
-    default: 'false'
+    default: 'true'
   node-version:
     description: 'Node.js version'
     required: false
@@ -228,9 +228,3 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-
-    # ── npm cache workaround (Windows ARM) ───────────────────────────
-    - name: Clean npm cache (Windows ARM workaround)
-      if: runner.os == 'Windows'
-      shell: bash
-      run: npm cache clean --force


### PR DESCRIPTION
## Summary
- Change `setup-node` default from `'false'` to `'true'` in `setup-nucleus` action so all users get a clean Node.js installation via `actions/setup-node`
- Remove the `npm cache clean --force` workaround step added in #28, which is no longer needed

## Context
The npm `ECOMPROMISED` errors on Windows ARM runners were caused by a corrupted system Node.js cache. The Nucleus example workflow already used `setup-node: 'true'` and worked fine, while AeroDL (using the default `'false'`) hit the issue. Using `actions/setup-node` provides a fresh, reliable Node.js installation, making the cache clean workaround unnecessary.

## Test plan
- [ ] Verify Nucleus example CI still passes with the new default
- [ ] Verify AeroDL Windows ARM builds pass without `ECOMPROMISED` errors