### PR TITLE
feat(packaging): default artifactName template

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/JvmApplicationDistributions.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/JvmApplicationDistributions.kt
@@ -88,7 +88,7 @@ abstract class JvmApplicationDistributions : AbstractDistributions() {
 
     // --- Artifact name template (e.g., "\${name}-\${version}-\${arch}.\${ext}") ---
 
-    var artifactName: String? = "\${name}-\${version}-\${os}-\${arch}.\${ext}"
+    var artifactName: String = "\${name}-\${version}-\${os}-\${arch}.\${ext}"
 
     // --- URL protocol handlers (deep linking) ---
 

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -71,7 +71,7 @@ internal class ElectronBuilderConfigGenerator {
         yaml.appendLine("  output: .")
 
         appendIfNotNull(yaml, "compression", distributions.compressionLevel?.id)
-        appendIfNotNull(yaml, "artifactName", withTargetSuffix(distributions.artifactName, targetFormat))
+        yaml.appendLine("artifactName: ${withTargetSuffix(distributions.artifactName, targetFormat)}")
         generateFileAssociations(yaml, distributions, targetFormat)
 
         // --- Platform-specific config ---
@@ -321,10 +321,10 @@ internal class ElectronBuilderConfigGenerator {
     }
 
     private fun withTargetSuffix(
-        artifactName: String?,
+        artifactName: String,
         targetFormat: TargetFormat,
-    ): String? {
-        val template = artifactName ?: return null
+    ): String {
+        val template = artifactName
         // Only add a format suffix for formats whose id differs from the file extension,
         // to disambiguate formats sharing .exe (nsis, nsis-web, portable)
         val needsSuffix = targetFormat in setOf(TargetFormat.Nsis, TargetFormat.NsisWeb, TargetFormat.Portable)


### PR DESCRIPTION
## Summary
- Set the default `artifactName` to `${name}-${version}-${os}-${arch}.${ext}` instead of `null`
- Projects no longer need to explicitly configure `artifactName` to get consistent, descriptive filenames across all platforms

## Before
```
NucleusDemo-1.0.0.exe
NucleusDemo-1.0.0.deb
```

## After
```
NucleusDemo-1.0.0-win-x64.exe
NucleusDemo-1.0.0-linux-arm64.deb
NucleusDemo-1.0.0-mac-arm64.dmg
```