### PR TITLE
fix(packaging): preserve symlinks when copying app image on macOS

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -48,9 +48,13 @@ import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.LinkOption
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.Locale
 import javax.imageio.ImageIO
 import javax.inject.Inject
@@ -1143,21 +1147,38 @@ private fun copyAppImage(
     if (destination.exists()) {
         destination.deleteRecursively()
     }
-    destination.mkdirs()
 
     logger.info("Copying app image to task-private working directory: ${destination.absolutePath}")
     val srcPath = source.toPath()
-    Files.walk(srcPath).use { stream ->
-        stream.forEach { srcFile ->
-            val relative = srcPath.relativize(srcFile)
-            val destFile = destination.toPath().resolve(relative)
-            if (Files.isDirectory(srcFile)) {
-                Files.createDirectories(destFile)
-            } else {
-                Files.copy(srcFile, destFile, StandardCopyOption.COPY_ATTRIBUTES)
+    val destPath = destination.toPath()
+
+    Files.walkFileTree(
+        srcPath,
+        emptySet(),
+        Int.MAX_VALUE,
+        object : SimpleFileVisitor<Path>() {
+            override fun preVisitDirectory(
+                dir: Path,
+                attrs: BasicFileAttributes,
+            ): FileVisitResult {
+                Files.createDirectories(destPath.resolve(srcPath.relativize(dir)))
+                return FileVisitResult.CONTINUE
             }
-        }
-    }
+
+            override fun visitFile(
+                file: Path,
+                attrs: BasicFileAttributes,
+            ): FileVisitResult {
+                val target = destPath.resolve(srcPath.relativize(file))
+                if (Files.isSymbolicLink(file)) {
+                    Files.createSymbolicLink(target, Files.readSymbolicLink(file))
+                } else {
+                    Files.copy(file, target, StandardCopyOption.COPY_ATTRIBUTES, LinkOption.NOFOLLOW_LINKS)
+                }
+                return FileVisitResult.CONTINUE
+            }
+        },
+    )
     return destination
 }
 


### PR DESCRIPTION
## Summary
- Fix `codesign` failure (exit code 1) on macOS caused by the app image copy introduced in v1.1.5
- `Files.walk` + `Files.copy` silently resolved symlinks to regular files, breaking the `.app` bundle structure
- Switch to `Files.walkFileTree` with explicit symlink detection: recreate symlinks at destination instead of copying their target content

## Context
The parallel packaging fix (v1.1.5) copies the app image to a task-private directory before modifying it. On macOS, `.app` bundles contain symlinks (e.g. in `Contents/runtime/Contents/Home/legal/`). The original copy logic destroyed these symlinks, causing `codesign --force --deep --sign -` to fail.

## Test plan
- [x] CI packaging passes on macOS ARM64 and Intel
- [x] DMG and PKG formats build successfully