### PR TITLE
fix(electron-builder): prevent crash when no publish provider is configured

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -608,7 +608,13 @@ internal class ElectronBuilderConfigGenerator {
         val github = publish.github
         val s3 = publish.s3
 
-        if (!github.enabled && !s3.enabled) return
+        if (!github.enabled && !s3.enabled) {
+            // Explicitly disable publish to prevent electron-builder from auto-detecting
+            // a publish provider via GH_TOKEN/GITHUB_TOKEN env vars and .git/config,
+            // which causes a crash in computeChannelNames when resolution fails.
+            yaml.appendLine("publish: null")
+            return
+        }
 
         yaml.appendLine("publish:")
         if (github.enabled) {


### PR DESCRIPTION
## Summary

- When no publish provider is enabled in the Nucleus DSL, electron-builder auto-detects one via `GH_TOKEN`/`GITHUB_TOKEN` env vars and `.git/config`. If resolution fails, a `null` publishConfig reaches `computeChannelNames()`, crashing with `Cannot read properties of null (reading 'channel')`.
- Fix: explicitly write `publish: null` in the generated `electron-builder.yml` when no provider is configured, preventing auto-detection entirely.

### Root cause details

The crash path in electron-builder ([source](https://github.com/electron-userland/electron-builder/blob/02a9105d1c4420e418d740dfa0bbbd22d5b44735/packages/app-builder-lib/src/publish/PublishManager.ts#L457-L474)):

1. `--publish never` only disables **uploading**, not update info file generation
2. With no `publish:` section in the YAML, `getPublishConfigs()` returns `[]`
3. `resolvePublishConfigurations()` detects `GITHUB_TOKEN` in the environment and calls `getResolvedPublishConfig()` with a non-null assertion (`!`)
4. `.git/config` can't be parsed → returns `null` → forced into `[null]` by the `!` assertion
5. `computeChannelNames(packager, null)` → `null.channel` → TypeError

### Reproduction

```bash
# Disable publish in DSL, then:
GITHUB_TOKEN=fake_token ./gradlew :example:packageReleaseDeb
# → ⨯ Cannot read properties of null (reading 'channel')
```

### Verified

```bash
# After fix:
GITHUB_TOKEN=fake_token ./gradlew :example:packageReleaseDeb
# → BUILD SUCCESSFUL
```

Fixes #37