### PR TITLE
fix(ci): add decorated-window native macOS build and publish steps

### DIFF
--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -108,6 +108,25 @@ jobs:
           path: native-ssl/src/main/resources/nucleus/native/darwin-*/
           retention-days: 1
 
+      - name: Build decorated-window macOS dylibs
+        run: bash decorated-window/src/main/native/macos/build.sh
+
+      - name: Verify decorated-window macOS natives
+        run: |
+          for f in \
+            decorated-window/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_macos.dylib \
+            decorated-window/src/main/resources/nucleus/native/darwin-x64/libnucleus_macos.dylib; do
+            if [ ! -f "$f" ]; then echo "MISSING: $f" >&2; exit 1; fi
+            echo "OK: $f ($(wc -c < "$f") bytes)"
+          done
+
+      - name: Upload decorated-window macOS dylibs
+        uses: actions/upload-artifact@v4
+        with:
+          name: decorated-window-macos
+          path: decorated-window/src/main/resources/nucleus/native/darwin-*/
+          retention-days: 1
+
   linux:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -31,6 +31,13 @@ jobs:
           pattern: 'ssl-*'
           merge-multiple: true
 
+      - name: Download decorated-window artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: decorated-window/src/main/resources/nucleus/native/
+          pattern: 'decorated-window-*'
+          merge-multiple: true
+
       - name: Verify all natives present
         run: |
           EXPECTED=(
@@ -44,6 +51,8 @@ jobs:
             "native-ssl/src/main/resources/nucleus/native/darwin-x64/libnucleus_ssl.dylib"
             "native-ssl/src/main/resources/nucleus/native/win32-x64/nucleus_ssl.dll"
             "native-ssl/src/main/resources/nucleus/native/win32-aarch64/nucleus_ssl.dll"
+            "decorated-window/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_macos.dylib"
+            "decorated-window/src/main/resources/nucleus/native/darwin-x64/libnucleus_macos.dylib"
           )
           MISSING=0
           for f in "${EXPECTED[@]}"; do


### PR DESCRIPTION
## Problem

The `decorated-window` module was missing from the native build pipeline. As a result, `libnucleus_macos.dylib` was never bundled in the published JAR on Maven Central, causing an `UnsatisfiedLinkError` at runtime on macOS:

```
java.lang.UnsatisfiedLinkError: Native library not found in JAR at /nucleus/native/darwin-aarch64/libnucleus_macos.dylib
```

## Fix

- **`build-natives.yaml`**: added compilation of `decorated-window` macOS dylibs (arm64 + x64) on the macOS runner, with verification and artifact upload
- **`publish-maven.yaml`**: added download of `decorated-window` artifacts and verification before publishing to Maven Central