### PR TITLE
fix(plugin): map PublishMode.Auto to "onTag" for electron-builder

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/PublishMode.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/PublishMode.kt
@@ -13,7 +13,7 @@ enum class PublishMode(
     Never("never"),
 
     /** Publish to GitHub/S3 if configured (detects git tag). */
-    Auto("auto"),
+    Auto("onTag"),
 
     /** Always publish even without git tag. */
     Always("always"),


### PR DESCRIPTION
## Problem

`PublishMode.Auto` was mapped to `"auto"` but electron-builder does not accept this value:

```
Invalid values:
  Argument: publish, Given: "auto", Choices: "onTag", "onTagOrDraft", "always", "never", undefined
```

This caused `packageReleaseDmg` and `packageReleaseZip` tasks to fail.

## Fix

Map `PublishMode.Auto` to `"onTag"` — which is the correct electron-builder equivalent: publish when a git tag is detected.