### PR TITLE
fix(plugin): preserve sandbox entitlements when re-signing PKG for App Store without certificate

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -578,8 +578,11 @@ abstract class AbstractElectronBuilderPackageTask
             if (macAppStore.orNull == true) {
                 val signer = macSigner ?: return
                 val appEntitlements = macEntitlementsFile.orNull?.asFile
+                // augmentEntitlementsForAppStore returns null when settings is null (NoCertificateSigner /
+                // unsigned builds). Fall back to the original entitlements so the app is never re-signed
+                // without them — which would silently strip sandbox entitlements from the bundle.
                 val bundleEntitlements = augmentEntitlementsForAppStore(appEntitlements, signer.settings)
-                signer.sign(appDir, bundleEntitlements, forceEntitlements = true)
+                signer.sign(appDir, bundleEntitlements ?: appEntitlements, forceEntitlements = true)
             }
         }
 


### PR DESCRIPTION
## Problem

When `macAppStore = true` and no signing certificate is configured (ad-hoc / `NoCertificateSigner`), the installed PKG app fails to start on macOS.

**Root cause:** `resignAppForPkg()` calls `augmentEntitlementsForAppStore(entitlements, signer.settings)`. Since `NoCertificateSigner.settings` is always `null`, this method returns `null` early. `resignAppForPkg()` then calls `signer.sign(appDir, null, forceEntitlements = true)`, which re-signs the entire app bundle **without** entitlements — silently stripping the previously applied sandbox entitlements.

**Call chain:**
```
resignAppForPkg()
  → resignApp()                          ✅ signs with sandbox entitlements
  → augmentEntitlementsForAppStore(ents, null)  → returns null
  → signer.sign(appDir, null)            ❌ re-signs WITHOUT entitlements
```

**Symptoms:**
- `app-sandboxed` build works correctly (has `com.apple.security.app-sandbox`, `cs.allow-jit`, `cs.disable-library-validation`, `network.client`)
- Installed PKG app has **no entitlements** — JVM cannot start (missing `cs.allow-jit`), JNA cannot load native libs (missing `cs.disable-library-validation`)

## Fix

Fall back to the original `appEntitlements` when `augmentEntitlementsForAppStore` returns `null`:

```kotlin
signer.sign(appDir, bundleEntitlements ?: appEntitlements, forceEntitlements = true)
```

This ensures the bundle is always re-signed with at least the base sandbox entitlements, even when no signing certificate is available.