### PR TITLE
fix(plugin): use per-platform winCodeSign archives to fix AppX build on Windows

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -74,6 +74,13 @@ internal class ElectronBuilderConfigGenerator {
         yaml.appendLine("artifactName: ${withTargetSuffix(distributions.artifactName, targetFormat)}")
         generateFileAssociations(yaml, distributions, targetFormat)
 
+        // Use per-platform winCodeSign archives on Windows to avoid extraction failures
+        // caused by macOS symlinks in the legacy combo archive (electron-builder#8149).
+        if (currentOS == OS.Windows) {
+            yaml.appendLine("toolsets:")
+            yaml.appendLine("  winCodeSign: \"1.0.0\"")
+        }
+
         // --- Platform-specific config ---
         when (currentOS) {
             OS.MacOS -> generateMacConfig(yaml, distributions, targetFormat)


### PR DESCRIPTION
## Summary

Fixes #46 — AppX builds fail on Windows with `exit status 2` from `app-builder` when extracting `winCodeSign-2.6.0.7z`.

**Root cause:** The legacy combo `winCodeSign-2.6.0.7z` archive contains macOS symlinks (`darwin/10.12/lib/libcrypto.dylib`, `libssl.dylib`). On Windows, creating symlinks requires admin rights or Developer Mode enabled. Without either, the embedded 7-Zip extraction in `app-builder` fails with `exit status 2` ([electron-builder#8149](https://github.com/electron-userland/electron-builder/issues/8149)).

**Fix:** Set `toolsets.winCodeSign: "1.0.0"` in the generated `electron-builder.yml` config. This makes electron-builder download per-platform code-signing archives (introduced in [electron-builder#9430](https://github.com/electron-userland/electron-builder/pull/9430)) that do not contain cross-platform symlinks.

## Changes

- `ElectronBuilderConfigGenerator.kt`: emit `toolsets.winCodeSign: "1.0.0"` on Windows builds

## Test plan

- [ ] Build an AppX package on Windows without admin rights or Developer Mode
- [ ] Verify `winCodeSign-2.6.0.7z` is no longer downloaded (replaced by per-platform archive)
- [ ] Verify other Windows formats (NSIS, MSI, Portable) still work
- [ ] Verify macOS and Linux builds are unaffected (no `toolsets` key emitted)