### PR TITLE
Add GraalVM native image release workflow for Jewel Sample

### DIFF
--- a/.github/workflows/release-graalvm.yaml
+++ b/.github/workflows/release-graalvm.yaml
@@ -1,0 +1,184 @@
+name: Release GraalVM Native Image (Jewel Sample)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-graalvm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-natives:
+    uses: ./.github/workflows/build-natives.yaml
+
+  build:
+    needs: build-natives
+    name: GraalVM - ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            os: ubuntu-latest
+            arch: amd64
+          - name: Linux ARM64
+            os: ubuntu-24.04-arm
+            arch: arm64
+          - name: macOS ARM64
+            os: macos-latest
+            arch: arm64
+          - name: macOS Intel
+            os: macos-15-intel
+            arch: amd64
+          - name: Windows x64
+            os: windows-latest
+            arch: amd64
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download darkmode-detector native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: darkmode-detector/src/main/resources/nucleus/native/
+          pattern: '*-natives*'
+          merge-multiple: true
+
+      - name: Download native-ssl artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: native-ssl/src/main/resources/nucleus/native/
+          pattern: 'ssl-*'
+          merge-multiple: true
+
+      - name: Download decorated-window-jbr artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: decorated-window-jbr/src/main/resources/nucleus/native/
+          pattern: 'decorated-window-jbr-*'
+          merge-multiple: true
+
+      - name: Download decorated-window-jni artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: decorated-window-jni/src/main/resources/nucleus/native/
+          pattern: 'decorated-window-jni-*'
+          merge-multiple: true
+
+      - name: Download linux-hidpi artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: linux-hidpi/src/main/resources/nucleus/native/
+          pattern: 'linux-hidpi-*'
+          merge-multiple: true
+
+      - name: Select Xcode 26
+        if: runner.os == 'macOS'
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
+
+      - name: Set up BellSoft Liberica NIK 25
+        uses: graalvm/setup-graalvm@v1
+        with:
+          distribution: 'liberica'
+          java-version: '25'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y xvfb patchelf
+
+      - name: Setup MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build GraalVM native image
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            xvfb-run ./gradlew :jewel-sample:packageGraalvmNative -PnativeMarch=compatibility --no-daemon --stacktrace
+          else
+            ./gradlew :jewel-sample:packageGraalvmNative -PnativeMarch=compatibility --no-daemon --stacktrace
+          fi
+
+      - name: Upload GraalVM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: graalvm-jewel-${{ runner.os }}-${{ matrix.arch }}
+          path: |
+            jewel-sample/build/compose/tmp/**/graalvm/output/**
+          if-no-files-found: error
+
+  publish:
+    name: Publish Release
+    needs: [build]
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Download all GraalVM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: graalvm-jewel-*
+
+      - name: Determine version
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "TAG=$TAG" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+          if [[ "$VERSION" == *"-alpha"* ]] || [[ "$VERSION" == *"-beta"* ]]; then
+            echo "PRERELEASE=true" >> "$GITHUB_ENV"
+          else
+            echo "PRERELEASE=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: List downloaded artifacts
+        shell: bash
+        run: find artifacts -type f | head -100
+
+      - name: Upload to GitHub Release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ASSETS=()
+          while IFS= read -r file; do
+            ASSETS+=("$file")
+          done < <(find artifacts -type f)
+
+          if [ ${#ASSETS[@]} -eq 0 ]; then
+            echo "::error::No artifacts found to publish"
+            exit 1
+          fi
+
+          # Create the release if it doesn't exist yet, then upload assets
+          if ! gh release view "$TAG" > /dev/null 2>&1; then
+            ARGS=(release create "$TAG" --title "$TAG" --generate-notes)
+            if [ "$PRERELEASE" = "true" ]; then
+              ARGS+=(--prerelease)
+            fi
+            gh "${ARGS[@]}"
+          fi
+
+          gh release upload "$TAG" "${ASSETS[@]}" --clobber


### PR DESCRIPTION
## Summary
- Add new CI workflow `release-graalvm.yaml` that builds and publishes Jewel Sample as GraalVM native images on tag push (`v*`)
- Targets 5 platforms: Linux x64/ARM64, macOS ARM64/Intel, Windows x64
- Reuses `build-natives.yaml` for JNI libraries, then builds with `:jewel-sample:packageGraalvmNative`
- Publishes artifacts to the existing GitHub Release (or creates one if it doesn't exist yet)

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with a tag push to confirm builds succeed on all 5 platforms
- [ ] Confirm artifacts are correctly uploaded to the GitHub Release
- [ ] Verify no conflict with `release-desktop.yaml` when both run on the same tag