### PR TITLE
fix: fallback to default icon for GraalVM native image on Windows

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
@@ -213,8 +213,9 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             val winPkgVersion = provider { app.nativeDistributions.packageVersion ?: "1.0.0" }
             val winCopyright = provider { app.nativeDistributions.copyright ?: "" }
             val winDescription = provider { app.nativeDistributions.description ?: packageNameProvider.get() }
-            val winIconFile = app.nativeDistributions.windows.iconFile
-                .orElse(unpackDefaultResources.flatMap { it.resources.windowsIcon })
+            val winIconFile =
+                app.nativeDistributions.windows.iconFile
+                    .orElse(unpackDefaultResources.flatMap { it.resources.windowsIcon })
 
             tasks.register<DefaultTask>(
                 taskNameAction = "generate",


### PR DESCRIPTION
## Summary

- When no `windows.iconFile` is configured, GraalVM native image executables were generated without any icon
- Added fallback to `default-compose-desktop-icon-windows.ico` (same default icon used by JVM/jpackage builds)
- Moved `unpackDefaultResources` declaration earlier so it's accessible during Windows resource generation
- Simplified the `.rc` generation code since the icon is now always present (either custom or default)

## Test plan

- [ ] Build a GraalVM native image on Windows **without** setting `windows.iconFile` → should use the default Compose icon
- [ ] Build a GraalVM native image on Windows **with** a custom `windows.iconFile` → should use the custom icon
- [ ] Verify the resulting `.exe` shows the correct icon in Explorer and taskbar