### PR TITLE
fix: handle ZIP stapling during macOS notarization

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractNotarizationTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractNotarizationTask.kt
@@ -68,10 +68,46 @@ abstract class AbstractNotarizationTask
         }
 
         private fun staple(packageFile: File) {
-            runExternalTool(
-                tool = MacUtils.xcrun,
-                args = listOf("stapler", "staple", packageFile.absolutePath),
-            )
+            if (packageFile.extension.equals("zip", ignoreCase = true)) {
+                stapleZip(packageFile)
+            } else {
+                runExternalTool(
+                    tool = MacUtils.xcrun,
+                    args = listOf("stapler", "staple", packageFile.absolutePath),
+                )
+            }
+        }
+
+        private fun stapleZip(zipFile: File) {
+            val ditto = File("/usr/bin/ditto")
+            val tmpDir = temporaryDir.resolve("staple-zip")
+            tmpDir.mkdirs()
+
+            try {
+                // Extract ZIP
+                logger.info("Extracting ZIP to staple inner .app bundle")
+                runExternalTool(tool = ditto, args = listOf("-x", "-k", zipFile.absolutePath, tmpDir.absolutePath))
+
+                // Find and staple the .app bundle
+                val appBundle =
+                    tmpDir.listFiles()?.firstOrNull { it.isDirectory && it.name.endsWith(".app") }
+                        ?: error("No .app bundle found inside ${zipFile.name}")
+
+                logger.info("Stapling ${appBundle.name}")
+                runExternalTool(
+                    tool = MacUtils.xcrun,
+                    args = listOf("stapler", "staple", appBundle.absolutePath),
+                )
+
+                // Re-create ZIP with stapled .app
+                logger.info("Re-creating ZIP with stapled .app")
+                runExternalTool(
+                    tool = ditto,
+                    args = listOf("-c", "-k", "--keepParent", appBundle.absolutePath, zipFile.absolutePath),
+                )
+            } finally {
+                tmpDir.deleteRecursively()
+            }
         }
 
         private fun updateMetadataFiles(packageFile: File) {


### PR DESCRIPTION
## Summary

Fixes ZIP notarization failure from #55 — `xcrun stapler staple` cannot staple ZIP files directly, causing the notarization task to fail for ZIP targets.

- ZIP files are now handled by extracting the inner `.app` bundle via `ditto`, stapling it, then re-creating the ZIP
- DMG and PKG stapling remains unchanged (direct `stapler staple`)
- Matches the existing CI workflow behavior (`release-desktop.yaml`)

## Test plan

- [ ] Run `notarizeReleaseZip` with notarization settings → verify ZIP is notarized and inner `.app` is stapled
- [ ] Run `notarizeReleaseDmg` → verify DMG stapling still works as before
- [ ] Verify the stapled `.app` inside the ZIP with `xcrun stapler validate`