### PR TITLE
Remove deprecated internetEnabled DMG setting

### DIFF
--- a/.github/actions/build-macos-universal/build-universal.sh
+++ b/.github/actions/build-macos-universal/build-universal.sh
@@ -328,7 +328,6 @@ if [[ -n "$METADATA_FILE" ]]; then
   DMG_ICON_TEXT_SIZE="$(python3 -c "import json; m=json.load(open('$METADATA_FILE')); d=m.get('dmg',{}); v=d.get('iconTextSize'); print(v if v is not None else '')")"
   DMG_TITLE="$(python3 -c "import json; m=json.load(open('$METADATA_FILE')); d=m.get('dmg',{}); print(d.get('title') or '')")"
   DMG_FORMAT="$(python3 -c "import json; m=json.load(open('$METADATA_FILE')); d=m.get('dmg',{}); print(d.get('format') or '')")"
-  DMG_INTERNET_ENABLED="$(python3 -c "import json; m=json.load(open('$METADATA_FILE')); d=m.get('dmg',{}); print(str(d.get('internetEnabled', False)).lower())")"
   DMG_WIN_X="$(python3 -c "import json; m=json.load(open('$METADATA_FILE')); d=m.get('dmg',{}); v=d.get('windowX'); print(v if v is not None else '')")"
   DMG_WIN_Y="$(python3 -c "import json; m=json.load(open('$METADATA_FILE')); d=m.get('dmg',{}); v=d.get('windowY'); print(v if v is not None else '')")"
   DMG_WIN_W="$(python3 -c "import json; m=json.load(open('$METADATA_FILE')); d=m.get('dmg',{}); v=d.get('windowWidth'); print(v if v is not None else '')")"
@@ -359,7 +358,6 @@ else
   DMG_ICON_TEXT_SIZE=""
   DMG_TITLE=""
   DMG_FORMAT=""
-  DMG_INTERNET_ENABLED="false"
   DMG_WIN_X=""
   DMG_WIN_Y=""
   DMG_WIN_W=""
@@ -407,7 +405,6 @@ generate_eb_config() {
       [[ -n "$DMG_ICON_TEXT_SIZE" ]] && echo "  iconTextSize: $DMG_ICON_TEXT_SIZE"
       [[ -n "$DMG_TITLE" ]] && echo "  title: \"$DMG_TITLE\""
       [[ -n "$DMG_FORMAT" ]] && echo "  format: $DMG_FORMAT"
-      [[ "$DMG_INTERNET_ENABLED" == "true" ]] && echo "  internetEnabled: true"
       if [[ -n "$DMG_WIN_X" || -n "$DMG_WIN_Y" || -n "$DMG_WIN_W" || -n "$DMG_WIN_H" ]]; then
         echo "  window:"
         [[ -n "$DMG_WIN_X" ]] && echo "    x: $DMG_WIN_X"

--- a/docs/targets/macos.md
+++ b/docs/targets/macos.md
@@ -336,7 +336,6 @@ macOS {
 | `format` | `DmgFormat?` | `null` | DMG format enum (`UDZO`, `UDBZ`, etc.) |
 | `size` | `String?` | `null` | DMG size |
 | `shrink` | `Boolean?` | `null` | Shrink DMG |
-| `internetEnabled` | `Boolean` | `false` | Internet-enabled DMG |
 | `sign` | `Boolean` | `false` | Sign the DMG |
 | `background` | `RegularFileProperty` | — | Background image |
 | `backgroundColor` | `String?` | `null` | Background color (hex) |

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/DmgSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/DmgSettings.kt
@@ -45,9 +45,6 @@ abstract class DmgSettings {
     /** Whether to shrink the DMG image. Default: null (electron-builder uses true) */
     var shrink: Boolean? = null
 
-    /** Enable internet-enabled DMG. Default: false */
-    var internetEnabled: Boolean = false
-
     /** Sign the DMG image. Default: false */
     var sign: Boolean = false
 

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -195,9 +195,6 @@ internal class ElectronBuilderConfigGenerator {
         dmg.format?.let { yaml.appendLine("  format: ${it.id}") }
         appendIfNotNull(yaml, "  size", dmg.size)
         dmg.shrink?.let { yaml.appendLine("  shrink: $it") }
-        if (dmg.internetEnabled) {
-            yaml.appendLine("  internetEnabled: true")
-        }
 
         val w = dmg.window
         val hasWindowConfig = w.x != null || w.y != null || w.width != null || w.height != null

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -438,7 +438,6 @@ abstract class AbstractElectronBuilderPackageTask
                     appendLine("    \"iconTextSize\": ${dmg.iconTextSize ?: "null"},")
                     appendLine("    \"title\": ${jsonStr(dmg.title)},")
                     appendLine("    \"format\": ${jsonStr(dmg.format?.id)},")
-                    appendLine("    \"internetEnabled\": ${dmg.internetEnabled},")
                     appendLine("    \"windowX\": ${dmg.window.x ?: "null"},")
                     appendLine("    \"windowY\": ${dmg.window.y ?: "null"},")
                     appendLine("    \"windowWidth\": ${dmg.window.width ?: "null"},")


### PR DESCRIPTION
## Summary

- Remove the `internetEnabled` property from `DmgSettings` DSL — it relied on `hdiutil internet-enable` (IDME), which was removed in macOS 10.15 Catalina (2019) and has been a no-op ever since
- Clean up all references: electron-builder YAML generation, packaging metadata JSON export, universal build shell script, and documentation

## Test plan

- [x] Global grep confirms zero remaining references to `internetEnabled`
- [x] `./gradlew build` passes successfully
- [ ] Verify DMG packaging still works on macOS CI

Closes kdroidFilter/Nucleus#64