### PR TITLE
fix: match native macOS traffic light button spacing

### DIFF
--- a/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
+++ b/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
@@ -13,7 +13,7 @@ static const char kZoomResponderKey         = 5;
 static const char kDragViewKey              = 6;
 
 static const float kMinHeightForFullSize = 28.0f;
-static const float kDefaultButtonOffset  = 20.0f;
+static const float kDefaultButtonOffset  = 23.0f;
 
 // _adjustWindowToScreen swizzle state
 static BOOL sAdjustWindowSwizzled = NO;


### PR DESCRIPTION
## Summary
- Adjust `kDefaultButtonOffset` from 20px to 23px to match native macOS window button spacing
- Measured using `NSWindow.standardWindowButton` on a real AppKit window: native inter-button center distance is 23px, not 20px
- For a standard 32px titlebar, buttons now land at exactly the native positions (centerX: 16, 39, 62)

## Test plan
- [ ] Build the macOS JNI dylib and run the demo app
- [ ] Compare traffic light positions with a native Swift/AppKit window
- [ ] Verify buttons still scale correctly with custom (smaller) title bar heights
- [ ] Test fullscreen transition — buttons should not jump