### PR TITLE
fix: correct SingleInstanceManager example code

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1417,19 +1417,35 @@ fun main() {
 ```kotlin
 import io.github.kdroidfilter.nucleus.core.runtime.SingleInstanceManager
 
-val isSingle = SingleInstanceManager.isSingleInstance(
-    onRestoreFileCreated = {
-        // New instance: write deep link data for the primary instance
-    },
-    onRestoreRequest = {
-        // Primary instance: bring window to front
-        window.toFront()
-    },
-)
+application {
+    var restoreRequested by remember { mutableStateOf(false) }
 
-if (!isSingle) {
-    System.exit(0)
-    return
+    val isSingle = remember {
+        SingleInstanceManager.isSingleInstance(
+            onRestoreFileCreated = {
+                // New instance: write deep link data for the primary instance
+            },
+            onRestoreRequest = {
+                // Primary instance: notify UI to bring window to front
+                restoreRequested = true
+            },
+        )
+    }
+
+    if (!isSingle) {
+        exitApplication()
+        return@application
+    }
+
+    Window(onCloseRequest = ::exitApplication) {
+        LaunchedEffect(restoreRequested) {
+            if (restoreRequested) {
+                window.toFront()
+                restoreRequested = false
+            }
+        }
+        App()
+    }
 }
 ```
 
@@ -1466,7 +1482,7 @@ DeepLinkHandler.register(args) { uri -> handleDeepLink(uri) }
 
 val isSingle = SingleInstanceManager.isSingleInstance(
     onRestoreFileCreated = { DeepLinkHandler.writeUriTo(this) },
-    onRestoreRequest = { DeepLinkHandler.readUriFrom(this); window.toFront() },
+    onRestoreRequest = { DeepLinkHandler.readUriFrom(this); restoreRequested = true },
 )
 ```
 

--- a/docs/runtime/deep-links.md
+++ b/docs/runtime/deep-links.md
@@ -61,29 +61,43 @@ fun main(args: Array<String>) {
         handleDeepLink(uri)
     }
 
-    val isSingle = SingleInstanceManager.isSingleInstance(
-        onRestoreFileCreated = {
-            // New instance: write our deep link URI for the primary to read
-            // `this` is the Path to the restore request file
-            DeepLinkHandler.writeUriTo(this)
-        },
-        onRestoreRequest = {
-            // Primary instance: read the URI from the new instance
-            // `this` is the Path to the restore request file
-            DeepLinkHandler.readUriFrom(this)
-            window.toFront()
-        },
-    )
+    application {
+        var restoreRequested by remember { mutableStateOf(false) }
 
-    if (!isSingle) {
-        System.exit(0)
-        return
+        val isSingle = remember {
+            SingleInstanceManager.isSingleInstance(
+                onRestoreFileCreated = {
+                    // New instance: write our deep link URI for the primary to read
+                    // `this` is the Path to the restore request file
+                    DeepLinkHandler.writeUriTo(this)
+                },
+                onRestoreRequest = {
+                    // Primary instance: read the URI from the new instance
+                    // `this` is the Path to the restore request file
+                    DeepLinkHandler.readUriFrom(this)
+                    restoreRequested = true
+                },
+            )
+        }
+
+        if (!isSingle) {
+            exitApplication()
+            return@application
+        }
+
+        // Handle the initial deep link if launched with one
+        DeepLinkHandler.uri?.let { handleDeepLink(it) }
+
+        Window(onCloseRequest = ::exitApplication) {
+            LaunchedEffect(restoreRequested) {
+                if (restoreRequested) {
+                    window.toFront()
+                    restoreRequested = false
+                }
+            }
+            App()
+        }
     }
-
-    // Handle the initial deep link if launched with one
-    DeepLinkHandler.uri?.let { handleDeepLink(it) }
-
-    // Launch the UI...
 }
 ```
 

--- a/docs/runtime/single-instance.md
+++ b/docs/runtime/single-instance.md
@@ -20,29 +20,42 @@ import io.github.kdroidfilter.nucleus.core.runtime.SingleInstanceManager
 
 ```kotlin
 fun main() {
-    val isSingle = SingleInstanceManager.isSingleInstance(
-        onRestoreFileCreated = {
-            // Called on a NEW instance when the restore request file is created
-            // `this` is the Path to the restore request file
-            // You can write deep link data here for the primary instance to read
-        },
-        onRestoreRequest = {
-            // Called on the PRIMARY instance when another instance tries to start
-            // `this` is the Path to the restore request file
-            // Bring your window to the front here
-            window.toFront()
-        },
-    )
-
-    if (!isSingle) {
-        // Another instance is already running — this process will exit
-        System.exit(0)
-        return
-    }
-
-    // Launch the UI — we are the primary instance
     application {
-        Window(onCloseRequest = ::exitApplication) { App() }
+        var restoreRequested by remember { mutableStateOf(false) }
+
+        val isSingle = remember {
+            SingleInstanceManager.isSingleInstance(
+                onRestoreFileCreated = {
+                    // Called on a NEW instance when the restore request file is created
+                    // `this` is the Path to the restore request file
+                    // You can write deep link data here for the primary instance to read
+                },
+                onRestoreRequest = {
+                    // Called on the PRIMARY instance when another instance tries to start
+                    // `this` is the Path to the restore request file
+                    restoreRequested = true
+                },
+            )
+        }
+
+        if (!isSingle) {
+            // Another instance is already running — this process will exit
+            exitApplication()
+            return@application
+        }
+
+        // Launch the UI — we are the primary instance
+        Window(onCloseRequest = ::exitApplication) {
+            // Bring window to front when another instance tries to start
+            LaunchedEffect(restoreRequested) {
+                if (restoreRequested) {
+                    window.toFront()
+                    window.requestFocus()
+                    restoreRequested = false
+                }
+            }
+            App()
+        }
     }
 }
 ```


### PR DESCRIPTION
## Summary
- `window.toFront()` was used in the `onRestoreRequest` callback at the `main()` level, but `window` is only available inside a Compose `Window` scope
- Moved `SingleInstanceManager.isSingleInstance()` inside `application {}` with `remember {}`, using a state variable + `LaunchedEffect` to bring the window to front — matching the actual working demo app
- Fixed in `single-instance.md`, `deep-links.md`, and `llms-full.txt`

Closes #72

## Test plan
- [ ] Verify the example code in the docs compiles correctly
- [ ] Confirm single-instance behavior works as documented
