### PR TITLE
refactor: centralize native library loading with persistent cache

### DIFF
--- a/core-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/core/runtime/NativeLibraryLoader.kt
+++ b/core-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/core/runtime/NativeLibraryLoader.kt
@@ -1,0 +1,172 @@
+package io.github.kdroidfilter.nucleus.core.runtime
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.logging.Level
+import java.util.logging.Logger
+
+/**
+ * Centralized native library loader with persistent caching.
+ *
+ * Extracts native libraries from JAR resources into a stable cache directory
+ * (`~/.cache/nucleus/native/` on macOS/Linux, `%LOCALAPPDATA%/nucleus/native/` on Windows)
+ * so that subsequent launches skip the extraction I/O entirely.
+ *
+ * The cache is invalidated per-library when the JAR resource size changes.
+ */
+object NativeLibraryLoader {
+    private val logger = Logger.getLogger(NativeLibraryLoader::class.java.simpleName)
+    private val loadedLibraries = mutableSetOf<String>()
+    private val lock = Any()
+
+    /**
+     * Loads a native library by name.
+     *
+     * @param libraryName the base library name (e.g. "nucleus_systemcolor")
+     * @param callerClass a class from the module's JAR, used to locate the resource
+     * @param resourcePrefix the JAR resource prefix (default: "/nucleus/native")
+     * @return true if the library was loaded successfully
+     */
+    fun load(
+        libraryName: String,
+        callerClass: Class<*>,
+        resourcePrefix: String = "/nucleus/native",
+    ): Boolean {
+        synchronized(lock) {
+            if (libraryName in loadedLibraries) return true
+
+            // Try system library path first (packaged app with native libs on java.library.path)
+            if (trySystemLoad(libraryName)) return true
+
+            // Fallback: extract from JAR with persistent cache
+            return tryJarExtraction(libraryName, callerClass, resourcePrefix)
+        }
+    }
+
+    private fun trySystemLoad(libraryName: String): Boolean =
+        try {
+            System.loadLibrary(libraryName)
+            loadedLibraries += libraryName
+            true
+        } catch (_: UnsatisfiedLinkError) {
+            false
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun tryJarExtraction(
+        libraryName: String,
+        callerClass: Class<*>,
+        resourcePrefix: String,
+    ): Boolean {
+        try {
+            val platform = resolvePlatform()
+            val fileName = mapLibraryFileName(libraryName, platform)
+            val resourcePath = "$resourcePrefix/${platform.resourceDir}/$fileName"
+
+            val stream =
+                callerClass.getResourceAsStream(resourcePath)
+                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
+
+            val cachedLib =
+                stream.use { input ->
+                    val cacheDir = resolveCacheDir().resolve(platform.resourceDir)
+                    Files.createDirectories(cacheDir)
+                    val target = cacheDir.resolve(fileName)
+
+                    val resourceSize = input.available().toLong()
+                    if (Files.exists(target) && isCacheValid(target, resourceSize)) {
+                        return@use target
+                    }
+
+                    // Write to a temp file first, then atomically move to avoid partial reads
+                    val tmp = Files.createTempFile(cacheDir, libraryName, ".tmp")
+                    try {
+                        Files.copy(input, tmp, StandardCopyOption.REPLACE_EXISTING)
+                        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+                    } catch (_: Exception) {
+                        // ATOMIC_MOVE not supported on all filesystems
+                        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING)
+                    }
+                    target
+                }
+
+            System.load(cachedLib.toAbsolutePath().toString())
+            loadedLibraries += libraryName
+            return true
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Failed to load $libraryName native library", e)
+            return false
+        }
+    }
+
+    private fun isCacheValid(
+        cachedFile: Path,
+        resourceSize: Long,
+    ): Boolean {
+        // If the resource stream doesn't report size (available() == 0), skip validation
+        if (resourceSize <= 0) return true
+        return try {
+            Files.size(cachedFile) == resourceSize
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun resolveCacheDir(): Path {
+        val os = System.getProperty("os.name", "").lowercase()
+        val base =
+            when {
+                os.contains("win") -> {
+                    val localAppData = System.getenv("LOCALAPPDATA")
+                    if (localAppData != null) {
+                        Path.of(localAppData)
+                    } else {
+                        Path.of(System.getProperty("user.home"), "AppData", "Local")
+                    }
+                }
+                os.contains("mac") -> {
+                    Path.of(System.getProperty("user.home"), "Library", "Caches")
+                }
+                else -> {
+                    val xdgCache = System.getenv("XDG_CACHE_HOME")
+                    if (xdgCache != null) {
+                        Path.of(xdgCache)
+                    } else {
+                        Path.of(System.getProperty("user.home"), ".cache")
+                    }
+                }
+            }
+        return base.resolve("nucleus").resolve("native")
+    }
+
+    private fun resolvePlatform(): NativePlatform {
+        val os = System.getProperty("os.name", "").lowercase()
+        val arch =
+            System.getProperty("os.arch").let {
+                if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
+            }
+        return when {
+            os.contains("mac") || os.contains("darwin") -> NativePlatform("darwin", arch)
+            os.contains("win") -> NativePlatform("win32", arch)
+            else -> NativePlatform("linux", arch)
+        }
+    }
+
+    private fun mapLibraryFileName(
+        libraryName: String,
+        platform: NativePlatform,
+    ): String =
+        when {
+            platform.os == "win32" -> "$libraryName.dll"
+            platform.os == "darwin" -> "lib$libraryName.dylib"
+            else -> "lib$libraryName.so"
+        }
+
+    private data class NativePlatform(
+        val os: String,
+        val arch: String,
+    ) {
+        val resourceDir: String get() = "$os-$arch"
+    }
+}

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/linux/NativeLinuxBridge.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/linux/NativeLinuxBridge.kt
@@ -1,58 +1,16 @@
 package io.github.kdroidfilter.nucleus.darkmodedetector.linux
 
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
-import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
-import java.util.logging.Level
-import java.util.logging.Logger
 
 private const val TAG = "NativeLinuxBridge"
+private const val LIBRARY_NAME = "nucleus_linux_theme"
 
 internal object NativeLinuxBridge {
-    private val logger = Logger.getLogger(NativeLinuxBridge::class.java.simpleName)
     private val listeners: MutableSet<Consumer<Boolean>> = ConcurrentHashMap.newKeySet()
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_linux_theme")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/linux-$arch/libnucleus_linux_theme.so"
-            val stream =
-                NativeLinuxBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("libnucleus_linux_theme.so")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_linux_theme native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeLinuxBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/mac/NativeDarkModeBridge.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/mac/NativeDarkModeBridge.kt
@@ -1,58 +1,16 @@
 package io.github.kdroidfilter.nucleus.darkmodedetector.mac
 
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
-import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
-import java.util.logging.Level
-import java.util.logging.Logger
 
 private const val TAG = "NativeDarkModeBridge"
+private const val LIBRARY_NAME = "nucleus_darkmode"
 
 internal object NativeDarkModeBridge {
-    private val logger = Logger.getLogger(NativeDarkModeBridge::class.java.simpleName)
     private val listeners: MutableSet<Consumer<Boolean>> = ConcurrentHashMap.newKeySet()
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_darkmode")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/darwin-$arch/libnucleus_darkmode.dylib"
-            val stream =
-                NativeDarkModeBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("libnucleus_darkmode.dylib")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_darkmode native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeDarkModeBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/windows/NativeWindowsBridge.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/windows/NativeWindowsBridge.kt
@@ -1,58 +1,16 @@
 package io.github.kdroidfilter.nucleus.darkmodedetector.windows
 
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
-import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
-import java.util.logging.Level
-import java.util.logging.Logger
 
 private const val TAG = "NativeWindowsBridge"
+private const val LIBRARY_NAME = "nucleus_windows_theme"
 
 internal object NativeWindowsBridge {
-    private val logger = Logger.getLogger(NativeWindowsBridge::class.java.simpleName)
     private val listeners: MutableSet<Consumer<Boolean>> = ConcurrentHashMap.newKeySet()
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_windows_theme")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/win32-$arch/nucleus_windows_theme.dll"
-            val stream =
-                NativeWindowsBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("nucleus_windows_theme.dll")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_windows_theme native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeWindowsBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/macos/NativeMacBridge.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/macos/NativeMacBridge.kt
@@ -1,54 +1,11 @@
 package io.github.kdroidfilter.nucleus.window.utils.macos
 
-import java.nio.file.Files
-import java.util.logging.Level
-import java.util.logging.Logger
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
+
+private const val LIBRARY_NAME = "nucleus_macos"
 
 internal object NativeMacBridge {
-    private val logger = Logger.getLogger(NativeMacBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        // Try system library path first (packaged app)
-        try {
-            System.loadLibrary("nucleus_macos")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        // Fallback: extract from JAR resources
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/darwin-$arch/libnucleus_macos.dylib"
-            val stream =
-                NativeMacBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("libnucleus_macos.dylib")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_macos native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeMacBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/linux/JniLinuxWindowBridge.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/linux/JniLinuxWindowBridge.kt
@@ -1,54 +1,11 @@
 package io.github.kdroidfilter.nucleus.window.utils.linux
 
-import java.nio.file.Files
-import java.util.logging.Level
-import java.util.logging.Logger
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
+
+private const val LIBRARY_NAME = "nucleus_linux_jni"
 
 internal object JniLinuxWindowBridge {
-    private val logger = Logger.getLogger(JniLinuxWindowBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        // Try system library path first (packaged app)
-        try {
-            System.loadLibrary("nucleus_linux_jni")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        // Fallback: extract from JAR resources
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/linux-$arch/libnucleus_linux_jni.so"
-            val stream =
-                JniLinuxWindowBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-jni-native")
-            val tempLib = tempDir.resolve("libnucleus_linux_jni.so")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_linux_jni native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, JniLinuxWindowBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/macos/JniMacTitleBarBridge.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/macos/JniMacTitleBarBridge.kt
@@ -1,58 +1,15 @@
 package io.github.kdroidfilter.nucleus.window.utils.macos
 
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
-import java.util.logging.Level
-import java.util.logging.Logger
+
+private const val LIBRARY_NAME = "nucleus_macos_jni"
 
 @Suppress("TooManyFunctions")
 internal object JniMacTitleBarBridge {
-    private val logger = Logger.getLogger(JniMacTitleBarBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        // Try system library path first (packaged app)
-        try {
-            System.loadLibrary("nucleus_macos_jni")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        // Fallback: extract from JAR resources
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/darwin-$arch/libnucleus_macos_jni.dylib"
-            val stream =
-                JniMacTitleBarBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-jni-native")
-            val tempLib = tempDir.resolve("libnucleus_macos_jni.dylib")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_macos_jni native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, JniMacTitleBarBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/windows/JniWindowsDecorationBridge.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/windows/JniWindowsDecorationBridge.kt
@@ -1,55 +1,12 @@
 package io.github.kdroidfilter.nucleus.window.utils.windows
 
-import java.nio.file.Files
-import java.util.logging.Level
-import java.util.logging.Logger
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
+
+private const val LIBRARY_NAME = "nucleus_windows_decoration"
 
 @Suppress("TooManyFunctions")
 internal object JniWindowsDecorationBridge {
-    private val logger = Logger.getLogger(JniWindowsDecorationBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        // Try system library path first (packaged app)
-        try {
-            System.loadLibrary("nucleus_windows_decoration")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        // Fallback: extract from JAR resources
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/win32-$arch/nucleus_windows_decoration.dll"
-            val stream =
-                JniWindowsDecorationBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-jni-native")
-            val tempLib = tempDir.resolve("nucleus_windows_decoration.dll")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_windows_decoration native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, JniWindowsDecorationBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/energy-manager/src/main/kotlin/io/github/kdroidfilter/nucleus/energymanager/linux/NativeLinuxEnergyBridge.kt
+++ b/energy-manager/src/main/kotlin/io/github/kdroidfilter/nucleus/energymanager/linux/NativeLinuxEnergyBridge.kt
@@ -1,52 +1,11 @@
 package io.github.kdroidfilter.nucleus.energymanager.linux
 
-import java.nio.file.Files
-import java.util.logging.Level
-import java.util.logging.Logger
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
+
+private const val LIBRARY_NAME = "nucleus_energy_manager"
 
 internal object NativeLinuxEnergyBridge {
-    private val logger = Logger.getLogger(NativeLinuxEnergyBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_energy_manager")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/linux-$arch/libnucleus_energy_manager.so"
-            val stream =
-                NativeLinuxEnergyBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("libnucleus_energy_manager.so")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_energy_manager native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeLinuxEnergyBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/energy-manager/src/main/kotlin/io/github/kdroidfilter/nucleus/energymanager/macos/NativeMacOsEnergyBridge.kt
+++ b/energy-manager/src/main/kotlin/io/github/kdroidfilter/nucleus/energymanager/macos/NativeMacOsEnergyBridge.kt
@@ -1,52 +1,11 @@
 package io.github.kdroidfilter.nucleus.energymanager.macos
 
-import java.nio.file.Files
-import java.util.logging.Level
-import java.util.logging.Logger
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
+
+private const val LIBRARY_NAME = "nucleus_energy_manager"
 
 internal object NativeMacOsEnergyBridge {
-    private val logger = Logger.getLogger(NativeMacOsEnergyBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_energy_manager")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/darwin-$arch/libnucleus_energy_manager.dylib"
-            val stream =
-                NativeMacOsEnergyBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("libnucleus_energy_manager.dylib")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_energy_manager native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeMacOsEnergyBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/energy-manager/src/main/kotlin/io/github/kdroidfilter/nucleus/energymanager/windows/NativeWindowsEnergyBridge.kt
+++ b/energy-manager/src/main/kotlin/io/github/kdroidfilter/nucleus/energymanager/windows/NativeWindowsEnergyBridge.kt
@@ -1,52 +1,11 @@
 package io.github.kdroidfilter.nucleus.energymanager.windows
 
-import java.nio.file.Files
-import java.util.logging.Level
-import java.util.logging.Logger
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
+
+private const val LIBRARY_NAME = "nucleus_energy_manager"
 
 internal object NativeWindowsEnergyBridge {
-    private val logger = Logger.getLogger(NativeWindowsEnergyBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_energy_manager")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/win32-$arch/nucleus_energy_manager.dll"
-            val stream =
-                NativeWindowsEnergyBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("nucleus_energy_manager.dll")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_energy_manager native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeWindowsEnergyBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/linux-hidpi/build.gradle.kts
+++ b/linux-hidpi/build.gradle.kts
@@ -15,6 +15,7 @@ val publishVersion =
 
 dependencies {
     implementation(kotlin("stdlib"))
+    compileOnly(project(":core-runtime"))
 }
 
 java {

--- a/linux-hidpi/src/main/kotlin/io/github/kdroidfilter/nucleus/hidpi/HiDpiLinuxBridge.kt
+++ b/linux-hidpi/src/main/kotlin/io/github/kdroidfilter/nucleus/hidpi/HiDpiLinuxBridge.kt
@@ -1,53 +1,11 @@
 package io.github.kdroidfilter.nucleus.hidpi
 
-import java.nio.file.Files
-import java.util.logging.Level
-import java.util.logging.Logger
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
+
+private const val LIBRARY_NAME = "nucleus_linux_hidpi_jni"
 
 internal object HiDpiLinuxBridge {
-    private val logger = Logger.getLogger(HiDpiLinuxBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        // Try system library path first (packaged app)
-        try {
-            System.loadLibrary("nucleus_linux_hidpi_jni")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        // Fallback: extract from JAR resources
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/linux-$arch/libnucleus_linux_hidpi_jni.so"
-            val stream =
-                HiDpiLinuxBridge::class.java.getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-hidpi-native")
-            val tempLib = tempDir.resolve("libnucleus_linux_hidpi_jni.so")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_linux_hidpi_jni native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, HiDpiLinuxBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/native-ssl/src/main/kotlin/io/github/kdroidfilter/nucleus/nativessl/mac/NativeSslBridge.kt
+++ b/native-ssl/src/main/kotlin/io/github/kdroidfilter/nucleus/nativessl/mac/NativeSslBridge.kt
@@ -1,55 +1,16 @@
 package io.github.kdroidfilter.nucleus.nativessl.mac
 
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 import io.github.kdroidfilter.nucleus.nativessl.debugln
-import java.nio.file.Files
 import java.util.logging.Level
 import java.util.logging.Logger
 
 private const val TAG = "NativeSslBridge"
+private const val LIBRARY_NAME = "nucleus_ssl"
 
 internal object NativeSslBridge {
     private val logger = Logger.getLogger(NativeSslBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_ssl")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/darwin-$arch/libnucleus_ssl.dylib"
-            val stream =
-                NativeSslBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("libnucleus_ssl.dylib")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_ssl native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeSslBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/native-ssl/src/main/kotlin/io/github/kdroidfilter/nucleus/nativessl/windows/WindowsSslBridge.kt
+++ b/native-ssl/src/main/kotlin/io/github/kdroidfilter/nucleus/nativessl/windows/WindowsSslBridge.kt
@@ -1,55 +1,16 @@
 package io.github.kdroidfilter.nucleus.nativessl.windows
 
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 import io.github.kdroidfilter.nucleus.nativessl.debugln
-import java.nio.file.Files
 import java.util.logging.Level
 import java.util.logging.Logger
 
 private const val TAG = "WindowsSslBridge"
+private const val LIBRARY_NAME = "nucleus_ssl"
 
 internal object WindowsSslBridge {
     private val logger = Logger.getLogger(WindowsSslBridge::class.java.simpleName)
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_ssl")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/win32-$arch/nucleus_ssl.dll"
-            val stream =
-                WindowsSslBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("nucleus_ssl.dll")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_ssl native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, WindowsSslBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/linux/NativeLinuxSystemColorBridge.kt
+++ b/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/linux/NativeLinuxSystemColorBridge.kt
@@ -1,62 +1,20 @@
 package io.github.kdroidfilter.nucleus.systemcolor.linux
 
 import androidx.compose.ui.graphics.Color
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 import io.github.kdroidfilter.nucleus.systemcolor.debugln
-import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
-import java.util.logging.Level
-import java.util.logging.Logger
 
 private const val TAG = "NativeLinuxSystemColorBridge"
 private const val RGB_COMPONENTS = 3
+private const val LIBRARY_NAME = "nucleus_systemcolor"
 
 @Suppress("TooManyFunctions")
 internal object NativeLinuxSystemColorBridge {
-    private val logger = Logger.getLogger(NativeLinuxSystemColorBridge::class.java.simpleName)
     private val accentListeners: MutableSet<Consumer<Color>> = ConcurrentHashMap.newKeySet()
     private val contrastListeners: MutableSet<Consumer<Boolean>> = ConcurrentHashMap.newKeySet()
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_systemcolor")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/linux-$arch/libnucleus_systemcolor.so"
-            val stream =
-                NativeLinuxSystemColorBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("libnucleus_systemcolor.so")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_systemcolor native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeLinuxSystemColorBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/mac/NativeMacSystemColorBridge.kt
+++ b/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/mac/NativeMacSystemColorBridge.kt
@@ -1,62 +1,20 @@
 package io.github.kdroidfilter.nucleus.systemcolor.mac
 
 import androidx.compose.ui.graphics.Color
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 import io.github.kdroidfilter.nucleus.systemcolor.debugln
-import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
-import java.util.logging.Level
-import java.util.logging.Logger
 
 private const val TAG = "NativeMacSystemColorBridge"
 private const val RGB_COMPONENTS = 3
+private const val LIBRARY_NAME = "nucleus_systemcolor"
 
 @Suppress("TooManyFunctions")
 internal object NativeMacSystemColorBridge {
-    private val logger = Logger.getLogger(NativeMacSystemColorBridge::class.java.simpleName)
     private val accentListeners: MutableSet<Consumer<Color>> = ConcurrentHashMap.newKeySet()
     private val contrastListeners: MutableSet<Consumer<Boolean>> = ConcurrentHashMap.newKeySet()
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_systemcolor")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/darwin-$arch/libnucleus_systemcolor.dylib"
-            val stream =
-                NativeMacSystemColorBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("libnucleus_systemcolor.dylib")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_systemcolor native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeMacSystemColorBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 

--- a/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/windows/NativeWindowsSystemColorBridge.kt
+++ b/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/windows/NativeWindowsSystemColorBridge.kt
@@ -1,63 +1,21 @@
 package io.github.kdroidfilter.nucleus.systemcolor.windows
 
 import androidx.compose.ui.graphics.Color
+import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 import io.github.kdroidfilter.nucleus.systemcolor.debugln
-import java.nio.file.Files
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Consumer
-import java.util.logging.Level
-import java.util.logging.Logger
 
 private const val TAG = "NativeWindowsSystemColorBridge"
 private const val RGB_COMPONENTS = 3
 private const val COLOR_MAX = 255f
+private const val LIBRARY_NAME = "nucleus_systemcolor"
 
 @Suppress("TooManyFunctions")
 internal object NativeWindowsSystemColorBridge {
-    private val logger = Logger.getLogger(NativeWindowsSystemColorBridge::class.java.simpleName)
     private val accentListeners: MutableSet<Consumer<Color>> = ConcurrentHashMap.newKeySet()
     private val contrastListeners: MutableSet<Consumer<Boolean>> = ConcurrentHashMap.newKeySet()
-
-    @Volatile
-    private var loaded = false
-
-    init {
-        loadNativeLibrary()
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private fun loadNativeLibrary() {
-        if (loaded) return
-
-        try {
-            System.loadLibrary("nucleus_systemcolor")
-            loaded = true
-            return
-        } catch (_: UnsatisfiedLinkError) {
-            // Fall through to JAR extraction
-        }
-
-        try {
-            val arch =
-                System.getProperty("os.arch").let {
-                    if (it == "aarch64" || it == "arm64") "aarch64" else "x64"
-                }
-            val resourcePath = "/nucleus/native/win32-$arch/nucleus_systemcolor.dll"
-            val stream =
-                NativeWindowsSystemColorBridge::class.java
-                    .getResourceAsStream(resourcePath)
-                    ?: throw UnsatisfiedLinkError("Native library not found in JAR at $resourcePath")
-            val tempDir = Files.createTempDirectory("nucleus-native")
-            val tempLib = tempDir.resolve("nucleus_systemcolor.dll")
-            stream.use { Files.copy(it, tempLib) }
-            tempLib.toFile().deleteOnExit()
-            tempDir.toFile().deleteOnExit()
-            System.load(tempLib.toAbsolutePath().toString())
-            loaded = true
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Failed to load nucleus_systemcolor native library", e)
-        }
-    }
+    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeWindowsSystemColorBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
 


### PR DESCRIPTION
## Summary
- Add `NativeLibraryLoader` in `core-runtime` to replace 14 duplicated `loadNativeLibrary()` implementations across all JNI bridge classes
- Native libraries are now cached in OS-specific directories (`~/Library/Caches/nucleus/native/`, `~/.cache/nucleus/native/`, `%LOCALAPPDATA%/nucleus/native/`) instead of creating ephemeral temp dirs on every launch
- Cache invalidation based on file size; atomic writes to avoid partial reads
- Migrated bridges: system-color (3), darkmode-detector (3), energy-manager (3), native-ssl (2), decorated-window-jni (3), decorated-window-jbr (1), linux-hidpi (1)
- Net result: **+229 / -723 lines** — eliminated ~500 lines of duplicated boilerplate

## Test plan
- [x] `compileKotlin` passes for all modules
- [x] `check` passes for all modified modules (ktlint + detekt + tests)
- [ ] Verify first launch extracts native libs to cache directory
- [ ] Verify second launch skips extraction (cache hit)
- [ ] Verify library update invalidates cache (size mismatch)