### PR TITLE
feat: macOS live resize sync, RTL traffic-lights, platform docs

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.offset
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
@@ -190,8 +191,10 @@ class TitleBarMeasurePolicy(
 
         val contentPadding = applyTitleBar(boxHeight.toDp(), state)
 
-        val leftInset = contentPadding.calculateLeftPadding(layoutDirection).roundToPx()
-        val rightInset = contentPadding.calculateRightPadding(layoutDirection).roundToPx()
+        // Use Ltr to get the logical start/end insets without resolving
+        // to absolute left/right — placeRelative already handles RTL mirroring.
+        val leftInset = contentPadding.calculateLeftPadding(LayoutDirection.Ltr).roundToPx()
+        val rightInset = contentPadding.calculateRightPadding(LayoutDirection.Ltr).roundToPx()
 
         val occupiedSpaceHorizontally = endOccupied + otherOccupied + leftInset + rightInset
         val boxWidth = maxOf(constraints.minWidth, occupiedSpaceHorizontally)

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
@@ -182,11 +182,12 @@ private fun BoxScope.FullscreenTitleBarRenderers(
     icon: Painter?,
 ) {
     val ctx = titleBarHolder.compositionLocalContext
-    val wrapper: @Composable (@Composable () -> Unit) -> Unit = if (ctx != null) {
-        { content -> CompositionLocalProvider(ctx) { content() } }
-    } else {
-        { content -> content() }
-    }
+    val wrapper: @Composable (@Composable () -> Unit) -> Unit =
+        if (ctx != null) {
+            { content -> CompositionLocalProvider(ctx) { content() } }
+        } else {
+            { content -> content() }
+        }
 
     if (isNativeFullscreen) {
         wrapper {

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -24,7 +24,9 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
@@ -85,6 +87,16 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
         onDispose {
             val ptr = JniMacWindowUtil.getWindowPtr(window)
             if (ptr != 0L) JniMacTitleBarBridge.nativeResetTitleBar(ptr)
+        }
+    }
+
+    // Sync RTL state with native side so traffic-light buttons move to the
+    // correct side. Reacts to live changes in LocalLayoutDirection.
+    val layoutDirection = LocalLayoutDirection.current
+    LaunchedEffect(window, layoutDirection) {
+        val ptr = JniMacWindowUtil.getWindowPtr(window)
+        if (ptr != 0L && JniMacTitleBarBridge.isLoaded) {
+            JniMacTitleBarBridge.nativeSetRTL(ptr, layoutDirection == LayoutDirection.Rtl)
         }
     }
 

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/macos/JniMacTitleBarBridge.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/macos/JniMacTitleBarBridge.kt
@@ -111,4 +111,13 @@ internal object JniMacTitleBarBridge {
         nsWindowPtr: Long,
         enabled: Boolean,
     )
+
+    // Sets the RTL (right-to-left) flag on the NSWindow.
+    // When enabled, traffic-light buttons are positioned on the right side.
+    // Re-applies constraints immediately so the change is visible live.
+    @JvmStatic
+    external fun nativeSetRTL(
+        nsWindowPtr: Long,
+        rtl: Boolean,
+    )
 }

--- a/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
+++ b/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
@@ -1,4 +1,5 @@
 #import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
 #import <objc/runtime.h>
 #include <jni.h>
 #include <math.h>
@@ -16,6 +17,8 @@ static const char kMenuBarOffsetKey            = 8;
 static const char kMenuBarMonitorKey           = 9;
 static const char kMenuBarLastRawOffsetKey     = 10;
 static const char kLargeCornerRadiusKey        = 11;
+static const char kResizeObserverKey           = 12;
+static const char kRTLKey                     = 13;
 
 static const float kMinHeightForFullSize = 28.0f;
 static const float kDefaultButtonOffset  = 23.0f;
@@ -353,6 +356,68 @@ static void notifyMenuBarOffsetChanged(NSWindow *window, float offset) {
 
 @end
 
+// ─── Live resize observer ────────────────────────────────────────────────────────
+
+// Recursively toggles presentsWithTransaction on all CAMetalLayer instances
+// found in the view hierarchy. During live resize, enabling this flag forces
+// Metal to present each frame synchronously, so the compositor uses the
+// freshly rendered frame instead of stretching the stale one.
+static void setPresentsWithTransactionRecursive(NSView *view, BOOL value) {
+    CALayer *layer = view.layer;
+    if (layer && [layer isKindOfClass:[CAMetalLayer class]]) {
+        ((CAMetalLayer *)layer).presentsWithTransaction = value;
+    }
+    for (NSView *subview in view.subviews) {
+        setPresentsWithTransactionRecursive(subview, value);
+    }
+}
+
+// Invisible view added to the content view. Its sole purpose is to receive
+// viewWillStartLiveResize / viewDidEndLiveResize from AppKit and toggle
+// synchronous Metal presentation accordingly.
+@interface NucleusResizeObserverView : NSView
+@end
+
+@implementation NucleusResizeObserverView
+
+- (void)viewWillStartLiveResize {
+    [super viewWillStartLiveResize];
+    NSWindow *w = self.window;
+    if (w && w.contentView) {
+        setPresentsWithTransactionRecursive(w.contentView, YES);
+    }
+}
+
+- (void)viewDidEndLiveResize {
+    [super viewDidEndLiveResize];
+    NSWindow *w = self.window;
+    if (w && w.contentView) {
+        setPresentsWithTransactionRecursive(w.contentView, NO);
+    }
+}
+
+@end
+
+static void ensureResizeObserver(NSWindow *window) {
+    if (objc_getAssociatedObject(window, &kResizeObserverKey)) return;
+
+    NucleusResizeObserverView *observer = [[NucleusResizeObserverView alloc]
+        initWithFrame:NSZeroRect];
+    observer.hidden = YES;
+    [window.contentView addSubview:observer];
+    objc_setAssociatedObject(window, &kResizeObserverKey, observer,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void removeResizeObserver(NSWindow *window) {
+    NucleusResizeObserverView *observer =
+        objc_getAssociatedObject(window, &kResizeObserverKey);
+    if (!observer) return;
+    [observer removeFromSuperview];
+    objc_setAssociatedObject(window, &kResizeObserverKey, nil,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 // ─── Fullscreen button helpers ──────────────────────────────────────────────────
 
 // Hides the native NSToolbarFullScreenWindow so the system hover toolbar
@@ -395,16 +460,21 @@ static void installFullScreenButtons(NSWindow *window, float titleBarHeight) {
     computeButtonMetrics(titleBarHeight, &btnWidth, &btnHeight, &offset);
 
     // Create container spanning the full title bar height at the top of the content view
+    BOOL isRTL = [objc_getAssociatedObject(window, &kRTLKey) boolValue];
     NucleusButtonsView *container = [[NucleusButtonsView alloc] init];
     NSView *parent = window.contentView;
     CGFloat y = parent.frame.size.height - titleBarHeight;
-    float leftMargin = fminf(titleBarHeight / 2.0f, kMaxButtonLeftMargin);
-    [container setFrame:NSMakeRect(0, y, leftMargin + 2.0f * offset + btnWidth, titleBarHeight)];
+    float margin = fminf(titleBarHeight / 2.0f, kMaxButtonLeftMargin);
+    float containerWidth = margin + 2.0f * offset + btnWidth;
+    CGFloat containerX = isRTL
+        ? parent.frame.size.width - containerWidth
+        : 0;
+    [container setFrame:NSMakeRect(containerX, y, containerWidth, titleBarHeight)];
 
     NSUInteger masks = [window styleMask];
 
-    // Create replacement buttons positioned with the same formula as applyConstraints:
-    // centerX = leftMargin + idx * offset, centerY = titleBarHeight/2
+    // Create replacement buttons positioned with the same formula as applyConstraints.
+    // In RTL mode, buttons are mirrored inside the container.
     NSArray<NSNumber *> *buttonTypes = @[
         @(NSWindowCloseButton), @(NSWindowMiniaturizeButton), @(NSWindowZoomButton)
     ];
@@ -413,7 +483,12 @@ static void installFullScreenButtons(NSWindow *window, float titleBarHeight) {
     for (NSUInteger idx = 0; idx < 3; idx++) {
         NSButton *btn = [NSWindow standardWindowButton:[buttonTypes[idx] unsignedIntegerValue]
                                           forStyleMask:masks];
-        CGFloat centerX = leftMargin + idx * offset;
+        CGFloat centerX;
+        if (isRTL) {
+            centerX = containerWidth - margin - idx * offset;
+        } else {
+            centerX = margin + idx * offset;
+        }
         CGFloat centerY = titleBarHeight / 2.0f;
         [btn setFrame:NSMakeRect(centerX - btnWidth / 2.0f, centerY - btnHeight / 2.0f,
                                  btnWidth, btnHeight)];
@@ -569,17 +644,25 @@ static void updateFullScreenButtonsPosition(NSWindow *window) {
     NSNumber *storedMenuBarOffset = objc_getAssociatedObject(window, &kMenuBarOffsetKey);
     float menuBarOffset = storedMenuBarOffset ? [storedMenuBarOffset floatValue] : 0.0f;
 
-    float leftMargin = fminf(titleBarHeight / 2.0f, kMaxButtonLeftMargin);
+    BOOL isRTL = [objc_getAssociatedObject(window, &kRTLKey) boolValue];
+    float margin = fminf(titleBarHeight / 2.0f, kMaxButtonLeftMargin);
+    float containerWidth = margin + 2.0f * offset + btnWidth;
     CGFloat y = parent.frame.size.height - titleBarHeight - menuBarOffset;
-    [container setFrame:NSMakeRect(0, y,
-                                   leftMargin + 2.0f * offset + btnWidth,
-                                   titleBarHeight)];
+    CGFloat containerX = isRTL
+        ? parent.frame.size.width - containerWidth
+        : 0;
+    [container setFrame:NSMakeRect(containerX, y, containerWidth, titleBarHeight)];
 
     // Reposition each button inside the container
     NSArray<NSView *> *buttons = [container subviews];
     for (NSUInteger idx = 0; idx < buttons.count && idx < 3; idx++) {
         NSView *btn = buttons[idx];
-        CGFloat centerX = leftMargin + idx * offset;
+        CGFloat centerX;
+        if (isRTL) {
+            centerX = containerWidth - margin - idx * offset;
+        } else {
+            centerX = margin + idx * offset;
+        }
         CGFloat centerY = titleBarHeight / 2.0f;
         [btn setFrame:NSMakeRect(centerX - btnWidth / 2.0f, centerY - btnHeight / 2.0f,
                                  btnWidth, btnHeight)];
@@ -738,14 +821,20 @@ static void applyConstraints(NSWindow *window, float height) {
         ]];
     }
 
+    BOOL isRTL = [objc_getAssociatedObject(window, &kRTLKey) boolValue];
     float shrinkFactor = fminf(height / kMinHeightForFullSize, 1.0f);
     float offset       = shrinkFactor * kDefaultButtonOffset;
     float extraInset   = window.toolbar ? kToolbarExtraInset : 0.0f;
-    float leftMargin   = fminf(height / 2.0f, kMaxButtonLeftMargin) + extraInset;
+    float margin       = fminf(height / 2.0f, kMaxButtonLeftMargin) + extraInset;
+
+    NSLayoutAnchor *anchorEdge = isRTL
+        ? titlebarContainer.rightAnchor
+        : titlebarContainer.leftAnchor;
 
     NSArray *buttons = @[closeBtn, miniBtn, zoomBtn];
     [buttons enumerateObjectsUsingBlock:^(NSView *btn, NSUInteger idx, BOOL *stop) {
         btn.translatesAutoresizingMaskIntoConstraints = NO;
+        float c = margin + idx * offset;
         [constraints addObjectsFromArray:@[
             [btn.widthAnchor  constraintLessThanOrEqualToAnchor:titlebarContainer.heightAnchor
                                                      multiplier:0.5],
@@ -754,8 +843,8 @@ static void applyConstraints(NSWindow *window, float height) {
                                              constant:-2.0],
             [btn.centerYAnchor constraintEqualToAnchor:titlebarContainer.topAnchor
                                               constant:height / 2.0f],
-            [btn.centerXAnchor constraintEqualToAnchor:titlebarContainer.leftAnchor
-                                              constant:(leftMargin + idx * offset)],
+            [btn.centerXAnchor constraintEqualToAnchor:anchorEdge
+                                              constant:(isRTL ? -c : c)],
         ]];
     }];
 
@@ -890,6 +979,7 @@ Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nati
             [window setTitleVisibility:NSWindowTitleHidden];
             [window setMovable:NO];
             ensureDragView(window);
+            ensureResizeObserver(window);
             applyConstraints(window, capturedHeight);
         }
     });
@@ -910,6 +1000,7 @@ Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nati
             removeFullscreenObserver(window);
             removeZoomButtonResponder(window);
             removeDragView(window);
+            removeResizeObserver(window);
             removeExistingConstraints(window);
             objc_setAssociatedObject(window, &kTitleBarHeightKey, nil,
                                      OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -918,6 +1009,8 @@ Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nati
             objc_setAssociatedObject(window, &kMenuBarOffsetKey, nil,
                                      OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             objc_setAssociatedObject(window, &kLargeCornerRadiusKey, nil,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            objc_setAssociatedObject(window, &kRTLKey, nil,
                                      OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             window.toolbar = nil;
             [window setTitlebarAppearsTransparent:NO];
@@ -1105,6 +1198,35 @@ Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nati
             NSNumber *storedHeight = objc_getAssociatedObject(window, &kTitleBarHeightKey);
             if (storedHeight && !(window.styleMask & NSWindowStyleMaskFullScreen)) {
                 applyConstraints(window, [storedHeight floatValue]);
+            }
+        }
+    });
+}
+
+// Sets the RTL (right-to-left) flag on the window.
+// When enabled, the traffic-light buttons are positioned on the right side
+// of the title bar, mirroring the layout for RTL locales (Hebrew, Arabic, etc.).
+// Re-applies constraints immediately so the change is visible without delay.
+JNIEXPORT void JNICALL
+Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nativeSetRTL(
+    JNIEnv *env, jclass clazz, jlong nsWindowPtr, jboolean rtl) {
+
+    if (nsWindowPtr == 0) return;
+    NSWindow *window = (__bridge NSWindow *)(void *)nsWindowPtr;
+    BOOL flag = (rtl == JNI_TRUE);
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        @autoreleasepool {
+            objc_setAssociatedObject(window, &kRTLKey, @(flag),
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            // Re-apply constraints so buttons move to the correct side
+            NSNumber *storedHeight = objc_getAssociatedObject(window, &kTitleBarHeightKey);
+            if (storedHeight) {
+                if (window.styleMask & NSWindowStyleMaskFullScreen) {
+                    updateFullScreenButtonsPosition(window);
+                } else {
+                    applyConstraints(window, [storedHeight floatValue]);
+                }
             }
         }
     });

--- a/decorated-window-jni/src/main/native/macos/build.sh
+++ b/decorated-window-jni/src/main/native/macos/build.sh
@@ -36,6 +36,7 @@ COMMON_FLAGS=(
     -dynamiclib
     -I"$JNI_INCLUDE" -I"$JNI_INCLUDE_DARWIN"
     -framework Cocoa
+    -framework QuartzCore
     -mmacosx-version-min=10.13
     -fobjc-arc
     -Oz                     # optimize for smallest code size

--- a/docs/runtime/decorated-window.md
+++ b/docs/runtime/decorated-window.md
@@ -49,6 +49,18 @@ This module does not depend on JBR, making it compatible with **any JVM** (OpenJ
 
     This fix is **not present** in `decorated-window-jbr`.
 
+!!! note "macOS: smooth live resize with synchronous Metal presentation"
+    On macOS, resizing a window triggers a modal tracking loop on the main thread. By default, Skiko's Metal layer (`CAMetalLayer`) presents frames asynchronously — which means macOS stretches the stale frame content to fill the new window size, producing a visible freeze/lag during resize.
+
+    The JNI module fixes this by toggling `CAMetalLayer.presentsWithTransaction` during live resize:
+
+    - When a resize starts (`viewWillStartLiveResize`), the module enables synchronous presentation on all Metal layers in the window hierarchy. This forces each rendered frame to be committed to the compositor before the next resize step, so the window content follows the resize in real time.
+    - When the resize ends (`viewDidEndLiveResize`), the module restores asynchronous presentation for optimal rendering performance during normal use.
+
+    This matches the behavior of native macOS Metal applications (Safari, Finder, etc.). The trade-off is that windows with heavy Compose layouts may see a lower frame rate during resize (since each frame blocks until presented), but the content will always track the window size instead of freezing.
+
+    This fix is **not present** in `decorated-window-jbr`.
+
 !!! warning "Less battle-tested"
     While the JNI module has no known bugs, it has not been as widely tested as the JBR implementation. Use it with appropriate caution in production, and report any issues you encounter.
 
@@ -118,34 +130,79 @@ fun main() = application {
 
     ![KDE Decorated Window](../assets/KdeDecoratedWindow.png)
 
-## Platform Behavior
+## Platform Comparison
 
-### JBR module (`decorated-window-jbr`)
+The following tables compare a standard Compose `Window()`, the JBR module (`decorated-window-jbr`), and the JNI module (`decorated-window-jni`) across all three platforms.
 
-|  | macOS | Windows | Linux |
-|---|-------|---------|-------|
-| Decoration | JBR `CustomTitleBar` | JBR `CustomTitleBar` | Fully undecorated |
-| Window controls | Native traffic lights | Native min/max/close | Compose `WindowControlArea` (SVG icons) |
-| Drag | JBR hit-test | JBR `forceHitTest` | `JBR.getWindowMove().startMovingTogetherWithMouse()` |
-| Double-click maximize | Native | Native | Manual detection |
-| RTL support | No (requires [custom JBR](../targets/macos.md#jvm-based-applications) for hot-swap) | Yes (no hot-swap, restart required) | Yes (hot-swap) |
+### macOS
 
-### JNI module (`decorated-window-jni`)
+| Feature | Compose `Window()` | `decorated-window-jbr` | `decorated-window-jni` |
+|---|---|---|---|
+| Custom title bar content | No | Yes (JBR `CustomTitleBar`) | Yes (JNI native bridge) |
+| Window controls | Native traffic lights | Native traffic lights | Native traffic lights |
+| Title bar drag | Native | JBR hit-test | `nativeStartWindowDrag()` via JNI |
+| Double-click maximize | Native | Native (via JBR `CustomTitleBar`) | Native via JNI |
+| Window snapping / tiling | Native | Native | Native (swizzled `_adjustWindowToScreen`) |
+| Resize flash / freeze | Image freezes during resize | No freeze (JBR handles it) | **Fixed** — synchronous Metal presentation via `presentsWithTransaction` |
+| 26pt corner radius | No | No | Yes (`macOSLargeCornerRadius()`) |
+| Fullscreen controls | No custom title bar | macOS native (`apple.awt.newFullScreenControls`) | Sliding overlay (`newFullscreenControls()`) |
+| RTL support | No custom title bar | No (requires [custom JBR](../targets/macos.md#jvm-based-applications)) | Yes (live hot-swap, traffic lights move to right) |
+| JDK requirement | Any | JBR only | Any (requires Xcode 26-compiled JDK for native features) |
+| Fallback (no native lib) | N/A | N/A | AWT client properties (no custom positioning) |
 
-|  | macOS | Windows | Linux |
-|---|-------|---------|-------|
-| Decoration | JNI native bridge | JNI DLL (WndProc subclass) | JNI .so (`_NET_WM_MOVERESIZE`) |
-| Window controls | Native traffic lights | Compose `WindowsWindowControlArea` (SVG icons) | Compose `WindowControlArea` (SVG icons) |
-| Drag | `nativeStartWindowDrag()` via JNI | Native DLL or Compose fallback | `_NET_WM_MOVERESIZE` or Compose fallback |
-| Double-click maximize | Native via JNI | Native or Compose detection | Compose detection |
-| Fallback (no native lib) | AWT client properties | Compose `windowDragHandler()` | Compose `windowDragHandler()` |
-| RTL support | Yes (live hot-swap) | Yes (live hot-swap) | Yes (hot-swap) |
+### Windows
 
-On **macOS**, both modules preserve the native traffic lights.
+| Feature | Compose `Window()` | `decorated-window-jbr` | `decorated-window-jni` |
+|---|---|---|---|
+| Custom title bar content | No | Yes (JBR `CustomTitleBar`) | Yes (JNI DLL, WndProc subclass) |
+| Window controls | Native | Native min/max/close | Compose-drawn (SVG icons, Windows style) |
+| Title bar drag | Native | JBR `forceHitTest` | Native DLL or Compose fallback |
+| Double-click maximize | Native | Native (via JBR `CustomTitleBar`) | Compose detection |
+| Window snapping / tiling | Native | Native | Native (via `WM_NCLBUTTONDOWN` + `HTCAPTION`) |
+| Resize white flash | White flash on dark themes | White flash on dark themes | **Fixed** — `WM_ERASEBKGND` fill + `SWP_NOCOPYBITS` + DWM color sync |
+| Open in maximized state | Works | Broken (requires `LaunchedEffect` workaround) | Works |
+| Drag reliability | Native | Occasional missed events (JBR bug) | Reliable |
+| True fullscreen | Broken (doesn't cover taskbar) | Broken (doesn't cover taskbar) | **Fixed** — native Win32 fullscreen (`newFullscreenControls()`) |
+| Fullscreen sliding title bar | No | No | Yes (`newFullscreenControls()`) |
+| DWM dark mode sync | No | No | Yes (`DWMWA_USE_IMMERSIVE_DARK_MODE`, caption/border color) |
+| RTL support | No custom title bar | Yes (no hot-swap, restart required) | Yes (live hot-swap) |
+| JDK requirement | Any | JBR only | Any |
+| Fallback (no native lib) | N/A | N/A | Compose `windowDragHandler()` (no WndProc subclass) |
 
-On **Windows**, the JBR module uses the native min/max/close buttons, while the JNI module draws its own window controls with Compose (SVG icons matching the Windows style).
+### Linux
 
-On **Linux**, the window is fully undecorated in both modules. They render their own close/minimize/maximize buttons using SVG icons adapted to the desktop environment (GNOME Adwaita or KDE Breeze). The window shape is also clipped to rounded corners to match the native look.
+| Feature | Compose `Window()` | `decorated-window-jbr` | `decorated-window-jni` |
+|---|---|---|---|
+| Custom title bar content | No | Yes (fully undecorated) | Yes (fully undecorated) |
+| Window controls | WM-provided | Compose `WindowControlArea` (SVG) | Compose `WindowControlArea` (SVG) |
+| Desktop environment styling | WM-provided | GNOME Adwaita / KDE Breeze icons | GNOME Adwaita / KDE Breeze icons |
+| Window shape | WM-provided | Rounded corners (GNOME 12dp, KDE 5dp top only) | Rounded corners (GNOME 12dp, KDE 5dp top only) |
+| Title bar drag | WM-provided | `JBR.getWindowMove()` | `_NET_WM_MOVERESIZE` via JNI or Compose fallback |
+| Double-click maximize | WM-provided | Compose detection | Compose detection |
+| True fullscreen | WM-provided | Compose `WindowPlacement.Fullscreen` | Native `_NET_WM_STATE_FULLSCREEN` via JNI |
+| Fullscreen sliding title bar | No | No | Yes (`newFullscreenControls()`) |
+| RTL support | No custom title bar | Yes (hot-swap) | Yes (hot-swap) |
+| JDK requirement | Any | JBR only | Any |
+| Fallback (no native lib) | N/A | N/A | Compose `windowDragHandler()` |
+
+### Summary
+
+| Capability | Compose `Window()` | JBR | JNI |
+|---|:---:|:---:|:---:|
+| Custom title bar | | ✅ | ✅ |
+| Works on any JDK | ✅ | | ✅ |
+| GraalVM native-image | ✅ | | ✅ |
+| No resize artifacts (macOS) | | ✅ | ✅ |
+| No resize artifacts (Windows) | | | ✅ |
+| True fullscreen (Windows) | | | ✅ |
+| Native fullscreen (Linux) | | | ✅ |
+| DWM dark mode sync (Windows) | | | ✅ |
+| 26pt corner radius (macOS) | | | ✅ |
+| Fullscreen sliding title bar (all platforms) | | | ✅ |
+| macOS native fullscreen controls | | ✅ | ✅ |
+| RTL live hot-swap (all platforms) | | | ✅ |
+| Dialog centering on parent | | ✅ | ✅ |
+| Battle-tested | ✅ | ✅ | |
 
 ## Components
 

--- a/example/src/main/kotlin/com/example/demo/Main.kt
+++ b/example/src/main/kotlin/com/example/demo/Main.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -40,8 +41,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.WindowPlacement
@@ -55,6 +58,8 @@ import com.example.demo.icons.RadixEnterFullScreen
 import com.example.demo.icons.RadixExitFullScreen
 import com.example.demo.icons.TablerCoffee
 import com.example.demo.icons.TablerCoffeeOff
+import com.example.demo.icons.TablerTextDirectionLtr
+import com.example.demo.icons.TablerTextDirectionRtl
 import com.example.demo.icons.VscodeCodiconsColorMode
 import io.github.kdroidfilter.nucleus.aot.runtime.AotRuntime
 import io.github.kdroidfilter.nucleus.core.runtime.DeepLinkHandler
@@ -145,6 +150,8 @@ fun main(args: Array<String>) {
                     baseScheme
                 }
 
+            var isRtl by remember { mutableStateOf(false) }
+
             MaterialTheme(colorScheme = colorScheme) {
                 val state =
                     rememberWindowState(
@@ -156,133 +163,145 @@ fun main(args: Array<String>) {
                     onCloseRequest = ::exitApplication,
                     title = "Nucleus Demo",
                 ) {
-                    var tabs by remember { mutableStateOf(listOf("Main.kt", "Build.gradle", "README.md", "Settings")) }
-                    var selectedTab by remember { mutableStateOf("Main.kt") }
-
-                    MaterialTitleBar(modifier = Modifier.newFullscreenControls().macOSLargeCornerRadius()) { _ ->
-                        val titleBarAlignment =
-                            if (Platform.Current == Platform.MacOS) Alignment.End else Alignment.Start
-
-                        TitleBarIconButton(
-                            imageVector =
-                                when (themeMode) {
-                                    ThemeMode.System -> VscodeCodiconsColorMode
-                                    ThemeMode.Dark -> MaterialIconsDark_mode
-                                    ThemeMode.Light -> MaterialIconsLight_mode
-                                },
-                            contentDescription = "Toggle theme",
-                            modifier = Modifier.align(titleBarAlignment),
-                            onClick = { themeMode = themeMode.next() },
-                        )
-                        TitleBarIconButton(
-                            imageVector = MaterialIconsInfo,
-                            contentDescription = "System info",
-                            modifier = Modifier.align(titleBarAlignment),
-                            onClick = { showInfoDialog = true },
-                        )
-
-                        var caffeineActive by remember {
-                            mutableStateOf(EnergyManager.isScreenAwakeActive())
+                    CompositionLocalProvider(
+                        LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr,
+                    ) {
+                        var tabs by remember {
+                            mutableStateOf(listOf("Main.kt", "Build.gradle", "README.md", "Settings"))
                         }
-                        TitleBarIconButton(
-                            imageVector = if (caffeineActive) TablerCoffee else TablerCoffeeOff,
-                            contentDescription = if (caffeineActive) "Disable caffeine" else "Enable caffeine",
-                            modifier = Modifier.align(titleBarAlignment),
-                            onClick = {
-                                if (caffeineActive) {
-                                    EnergyManager.releaseScreenAwake()
-                                } else {
-                                    EnergyManager.keepScreenAwake()
-                                }
-                                caffeineActive = EnergyManager.isScreenAwakeActive()
-                            },
-                        )
-                        val isFullscreen = state.placement == WindowPlacement.Fullscreen
-                        TitleBarIconButton(
-                            imageVector = if (isFullscreen) RadixExitFullScreen else RadixEnterFullScreen,
-                            contentDescription = if (isFullscreen) "Exit fullscreen" else "Enter fullscreen",
-                            modifier = Modifier.align(titleBarAlignment),
-                            onClick = {
-                                if (isFullscreen) {
-                                    // NativeFullscreenWindowState restores the previous placement internally.
-                                    // Setting any non-Fullscreen value on the delegate triggers the exit.
-                                    state.placement = WindowPlacement.Floating
-                                } else {
-                                    state.placement = WindowPlacement.Fullscreen
-                                }
-                            },
-                        )
-                        DraggableTabs(
-                            tabs = tabs,
-                            selectedTab = selectedTab,
-                            onSelect = { selectedTab = it },
-                            onReorder = { from, to ->
-                                tabs =
-                                    tabs.toMutableList().apply {
-                                        add(to, removeAt(from))
+                        var selectedTab by remember { mutableStateOf("Main.kt") }
+
+                        MaterialTitleBar(modifier = Modifier.newFullscreenControls().macOSLargeCornerRadius()) { _ ->
+                            val titleBarAlignment =
+                                if (Platform.Current == Platform.MacOS) Alignment.End else Alignment.Start
+
+                            TitleBarIconButton(
+                                imageVector =
+                                    when (themeMode) {
+                                        ThemeMode.System -> VscodeCodiconsColorMode
+                                        ThemeMode.Dark -> MaterialIconsDark_mode
+                                        ThemeMode.Light -> MaterialIconsLight_mode
+                                    },
+                                contentDescription = "Toggle theme",
+                                modifier = Modifier.align(titleBarAlignment),
+                                onClick = { themeMode = themeMode.next() },
+                            )
+                            TitleBarIconButton(
+                                imageVector = MaterialIconsInfo,
+                                contentDescription = "System info",
+                                modifier = Modifier.align(titleBarAlignment),
+                                onClick = { showInfoDialog = true },
+                            )
+
+                            var caffeineActive by remember {
+                                mutableStateOf(EnergyManager.isScreenAwakeActive())
+                            }
+                            TitleBarIconButton(
+                                imageVector = if (caffeineActive) TablerCoffee else TablerCoffeeOff,
+                                contentDescription = if (caffeineActive) "Disable caffeine" else "Enable caffeine",
+                                modifier = Modifier.align(titleBarAlignment),
+                                onClick = {
+                                    if (caffeineActive) {
+                                        EnergyManager.releaseScreenAwake()
+                                    } else {
+                                        EnergyManager.keepScreenAwake()
                                     }
-                            },
-                            modifier = Modifier.align(Alignment.CenterHorizontally),
-                        )
-                    }
-                    LaunchedEffect(restoreRequestCount) {
-                        if (restoreRequestCount > 0) {
-                            window.toFront()
-                            window.requestFocus()
+                                    caffeineActive = EnergyManager.isScreenAwakeActive()
+                                },
+                            )
+                            val isFullscreen = state.placement == WindowPlacement.Fullscreen
+                            TitleBarIconButton(
+                                imageVector = if (isFullscreen) RadixExitFullScreen else RadixEnterFullScreen,
+                                contentDescription = if (isFullscreen) "Exit fullscreen" else "Enter fullscreen",
+                                modifier = Modifier.align(titleBarAlignment),
+                                onClick = {
+                                    if (isFullscreen) {
+                                        // NativeFullscreenWindowState restores the previous placement internally.
+                                        // Setting any non-Fullscreen value on the delegate triggers the exit.
+                                        state.placement = WindowPlacement.Floating
+                                    } else {
+                                        state.placement = WindowPlacement.Fullscreen
+                                    }
+                                },
+                            )
+                            TitleBarIconButton(
+                                imageVector = if (isRtl) TablerTextDirectionRtl else TablerTextDirectionLtr,
+                                contentDescription = if (isRtl) "Switch to LTR" else "Switch to RTL",
+                                modifier = Modifier.align(titleBarAlignment),
+                                onClick = { isRtl = !isRtl },
+                            )
+                            DraggableTabs(
+                                tabs = tabs,
+                                selectedTab = selectedTab,
+                                onSelect = { selectedTab = it },
+                                onReorder = { from, to ->
+                                    tabs =
+                                        tabs.toMutableList().apply {
+                                            add(to, removeAt(from))
+                                        }
+                                },
+                                modifier = Modifier.align(Alignment.CenterHorizontally),
+                            )
                         }
-                    }
-
-                    // Energy efficiency: enable when minimized or unfocused
-                    var isWindowFocused by remember { mutableStateOf(window.isFocused) }
-                    DisposableEffect(window) {
-                        val listener =
-                            object : WindowFocusListener {
-                                override fun windowGainedFocus(e: WindowEvent?) {
-                                    isWindowFocused = true
-                                }
-
-                                override fun windowLostFocus(e: WindowEvent?) {
-                                    isWindowFocused = false
-                                }
+                        LaunchedEffect(restoreRequestCount) {
+                            if (restoreRequestCount > 0) {
+                                window.toFront()
+                                window.requestFocus()
                             }
-                        window.addWindowFocusListener(listener)
-                        onDispose { window.removeWindowFocusListener(listener) }
-                    }
-                    LaunchedEffect(state.isMinimized, isWindowFocused) {
-                        if (state.isMinimized || !isWindowFocused) {
-                            EnergyManager.enableEfficiencyMode()
-                        } else {
-                            EnergyManager.disableEfficiencyMode()
                         }
-                    }
 
-                    app()
+                        // Energy efficiency: enable when minimized or unfocused
+                        var isWindowFocused by remember { mutableStateOf(window.isFocused) }
+                        DisposableEffect(window) {
+                            val listener =
+                                object : WindowFocusListener {
+                                    override fun windowGainedFocus(e: WindowEvent?) {
+                                        isWindowFocused = true
+                                    }
 
-                    if (showInfoDialog) {
-                        MaterialDecoratedDialog(
-                            onCloseRequest = { showInfoDialog = false },
-                            state = DialogState(size = DpSize(400.dp, 250.dp)),
-                            title = "System Info",
-                        ) {
-                            MaterialDialogTitleBar { _ ->
-                                Text(
-                                    title,
-                                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                )
+                                    override fun windowLostFocus(e: WindowEvent?) {
+                                        isWindowFocused = false
+                                    }
+                                }
+                            window.addWindowFocusListener(listener)
+                            onDispose { window.removeWindowFocusListener(listener) }
+                        }
+                        LaunchedEffect(state.isMinimized, isWindowFocused) {
+                            if (state.isMinimized || !isWindowFocused) {
+                                EnergyManager.enableEfficiencyMode()
+                            } else {
+                                EnergyManager.disableEfficiencyMode()
                             }
-                            Surface(modifier = Modifier.fillMaxSize()) {
-                                Column(
-                                    modifier = Modifier.fillMaxSize().padding(24.dp),
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.Center,
-                                ) {
-                                    Text("OS: ${System.getProperty("os.name")} ${System.getProperty("os.arch")}")
+                        }
+
+                        app()
+
+                        if (showInfoDialog) {
+                            MaterialDecoratedDialog(
+                                onCloseRequest = { showInfoDialog = false },
+                                state = DialogState(size = DpSize(400.dp, 250.dp)),
+                                title = "System Info",
+                            ) {
+                                MaterialDialogTitleBar { _ ->
                                     Text(
-                                        "Java: ${System.getProperty("java.version")}" +
-                                            " (${System.getProperty("java.vendor")})",
+                                        title,
+                                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                                        color = MaterialTheme.colorScheme.onSurface,
                                     )
-                                    Text("Runtime: ${System.getProperty("java.runtime.name", "Unknown")}")
+                                }
+                                Surface(modifier = Modifier.fillMaxSize()) {
+                                    Column(
+                                        modifier = Modifier.fillMaxSize().padding(24.dp),
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.Center,
+                                    ) {
+                                        Text("OS: ${System.getProperty("os.name")} ${System.getProperty("os.arch")}")
+                                        Text(
+                                            "Java: ${System.getProperty("java.version")}" +
+                                                " (${System.getProperty("java.vendor")})",
+                                        )
+                                        Text("Runtime: ${System.getProperty("java.runtime.name", "Unknown")}")
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

- **macOS live resize**: enable `presentsWithTransaction` on `CAMetalLayer` during `viewWillStartLiveResize` / `viewDidEndLiveResize` to eliminate image freeze/stretching
- **RTL traffic-light buttons**: full native RTL support on macOS — traffic-light buttons move to the right edge, constraints and fullscreen buttons mirror correctly, with live hot-swap via `LocalLayoutDirection`
- **Title bar RTL padding fix**: resolve double-mirroring issue where `PaddingValues(start=...)` was resolved to left/right then mirrored again by `placeRelative` — now uses `LayoutDirection.Ltr` for inset calculation
- **Example RTL toggle**: new title bar button to switch between LTR/RTL using existing `TablerTextDirection` icons
- **Platform comparison docs**: per-platform comparison tables (macOS, Windows, Linux) for Compose `Window()` vs JBR vs JNI

## Test plan

- [ ] macOS: resize the window by dragging edges — content should render smoothly without freezing
- [ ] macOS: toggle RTL in the example — traffic-light buttons should move to the right edge
- [ ] macOS: verify RTL works in both windowed and fullscreen modes
- [ ] macOS: verify the title bar inset (padding for traffic lights) moves to the correct side in RTL
- [ ] Windows/Linux: verify no regressions in title bar behavior
- [ ] Verify ktlint and detekt pass