### PR TITLE
fix(jni): correct DecoratedDialog centering on parent window

### DIFF
--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedDialog.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedDialog.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.WindowPosition
@@ -28,25 +28,18 @@ fun DecoratedDialog(
 ) {
     val undecorated = Platform.Linux == Platform.Current || Platform.Windows == Platform.Current
 
-    // Centre the dialog on its parent window by computing the position
-    // before DialogWindow is composed.  This avoids any visible jump because
-    // DialogWindow reads state.position and applies it immediately.
-    val density = LocalDensity.current
+    // Centre the dialog on its parent window before DialogWindow is composed.
+    // AWT window coordinates and Compose Dp are 1:1 for window positioning,
+    // so we can mix parent AWT bounds with state.size.value directly.
     remember(state) {
         val parent =
             java.awt.KeyboardFocusManager
                 .getCurrentKeyboardFocusManager()
                 .focusedWindow
-        if (parent != null && state.position == WindowPosition.PlatformDefault) {
-            val dialogWidthPx = with(density) { state.size.width.toPx() }
-            val dialogHeightPx = with(density) { state.size.height.toPx() }
-            val x = parent.x + (parent.width - dialogWidthPx) / 2
-            val y = parent.y + (parent.height - dialogHeightPx) / 2
-            state.position =
-                WindowPosition(
-                    x = with(density) { x.toDp() },
-                    y = with(density) { y.toDp() },
-                )
+        if (parent != null && !state.position.isSpecified) {
+            val x = parent.x + (parent.width - state.size.width.value) / 2f
+            val y = parent.y + (parent.height - state.size.height.value) / 2f
+            state.position = WindowPosition(x = x.dp, y = y.dp)
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix condition: use `!state.position.isSpecified` instead of `== PlatformDefault` — `DialogState` defaults to `Aligned(Center)`, not `PlatformDefault`, so the centering logic was always skipped
- Fix unit mismatch: use `state.size.width.value` (raw Dp float) instead of `density.toPx()` — AWT window coordinates and Compose Dp are 1:1 for window positioning

## Test plan
- [ ] Open a `DecoratedDialog` from a `DecoratedWindow` on macOS — dialog should appear centered on parent
- [ ] Move the parent window, reopen the dialog — should center on the new position
- [ ] Test on Windows and Linux