### PR TITLE
fix: skip ZIP stapling to preserve blockmap for auto-updates

### DIFF
--- a/.github/workflows/release-desktop.yaml
+++ b/.github/workflows/release-desktop.yaml
@@ -235,17 +235,9 @@ jobs:
             --team-id "${{ secrets.MAC_NOTARIZATION_TEAM_ID }}" \
             --wait
 
-          # ZIP cannot be stapled directly — extract, staple .app, re-zip
-          echo "==> Extracting ZIP to staple .app"
-          STAPLE_WORK="$(mktemp -d)"
-          ditto -x -k "$ZIP" "$STAPLE_WORK"
-          APP_BUNDLE="$(find "$STAPLE_WORK" -maxdepth 1 -name '*.app' -type d | head -1)"
-          if [[ -n "$APP_BUNDLE" ]]; then
-            xcrun stapler staple "$APP_BUNDLE"
-            echo "==> Re-creating ZIP with stapled .app"
-            ditto -c -k --keepParent "$APP_BUNDLE" "$ZIP"
-          fi
-          rm -rf "$STAPLE_WORK"
+          # ZIP is NOT stapled: re-zipping would invalidate the blockmap and break
+          # differential auto-updates. Gatekeeper verifies notarization online anyway.
+          echo "==> Skipping staple for ZIP (preserves blockmap for auto-update)"
 
       - name: Cleanup keychain
         if: ${{ always() && env.HAS_SIGNING_CERTS == 'true' }}

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractNotarizationTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractNotarizationTask.kt
@@ -69,45 +69,16 @@ abstract class AbstractNotarizationTask
 
         private fun staple(packageFile: File) {
             if (packageFile.extension.equals("zip", ignoreCase = true)) {
-                stapleZip(packageFile)
-            } else {
-                runExternalTool(
-                    tool = MacUtils.xcrun,
-                    args = listOf("stapler", "staple", packageFile.absolutePath),
-                )
+                // ZIP files used for auto-update are not stapled: re-zipping after stapling
+                // would invalidate the blockmap and break differential updates.
+                // Notarization is still verified online by Gatekeeper without stapling.
+                logger.lifecycle("Skipping staple for ${packageFile.name} (ZIP auto-update artifact)")
+                return
             }
-        }
-
-        private fun stapleZip(zipFile: File) {
-            val ditto = File("/usr/bin/ditto")
-            val tmpDir = temporaryDir.resolve("staple-zip")
-            tmpDir.mkdirs()
-
-            try {
-                // Extract ZIP
-                logger.info("Extracting ZIP to staple inner .app bundle")
-                runExternalTool(tool = ditto, args = listOf("-x", "-k", zipFile.absolutePath, tmpDir.absolutePath))
-
-                // Find and staple the .app bundle
-                val appBundle =
-                    tmpDir.listFiles()?.firstOrNull { it.isDirectory && it.name.endsWith(".app") }
-                        ?: error("No .app bundle found inside ${zipFile.name}")
-
-                logger.info("Stapling ${appBundle.name}")
-                runExternalTool(
-                    tool = MacUtils.xcrun,
-                    args = listOf("stapler", "staple", appBundle.absolutePath),
-                )
-
-                // Re-create ZIP with stapled .app
-                logger.info("Re-creating ZIP with stapled .app")
-                runExternalTool(
-                    tool = ditto,
-                    args = listOf("-c", "-k", "--keepParent", appBundle.absolutePath, zipFile.absolutePath),
-                )
-            } finally {
-                tmpDir.deleteRecursively()
-            }
+            runExternalTool(
+                tool = MacUtils.xcrun,
+                args = listOf("stapler", "staple", packageFile.absolutePath),
+            )
         }
 
         private fun updateMetadataFiles(packageFile: File) {


### PR DESCRIPTION
## Summary

- **Skip stapling for ZIP artifacts** — re-zipping after stapling invalidated the blockmap and broke differential auto-updates
- **Preserve DMG stapling** — DMGs are stapled directly without re-packaging, so they remain unaffected
- ZIPs are still submitted to Apple for notarization; Gatekeeper verifies the ticket online without needing the staple embedded

## Changes

- `AbstractNotarizationTask.kt`: removed `stapleZip()` method, `staple()` now returns early for ZIP files with a log message
- `release-desktop.yaml`: removed extract/staple/re-zip block from the "Notarize ZIP" CI step

## Test plan

- [ ] Verify DMG notarization + stapling still works (`spctl --assess --type open --context context:primary-signature`)
- [ ] Verify ZIP is notarized but not stapled (`stapler validate` should fail, which is expected)
- [ ] Verify `latest-mac.yml` SHA-512 hash matches the ZIP artifact
- [ ] Verify blockmap-based differential update works correctly

Closes #70