### PR TITLE
fix: restore pointer events to content area in fullscreen mode

### DIFF
--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
@@ -23,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
-
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
@@ -39,6 +37,7 @@ import io.github.kdroidfilter.nucleus.core.runtime.Platform
 import io.github.kdroidfilter.nucleus.window.utils.linux.JniLinuxWindowBridge
 import io.github.kdroidfilter.nucleus.window.utils.windows.JniWindowsDecorationBridge
 import io.github.kdroidfilter.nucleus.window.utils.windows.JniWindowsWindowUtil
+import java.awt.Frame
 
 /**
  * Composition local that indicates whether the window is currently in
@@ -68,7 +67,7 @@ internal class FullscreenTitleBarHolder {
 
 internal val LocalFullscreenTitleBarHolder = compositionLocalOf<FullscreenTitleBarHolder?> { null }
 
-@Suppress("FunctionNaming", "LongParameterList")
+@Suppress("FunctionNaming", "LongParameterList", "CyclomaticComplexMethod", "LongMethod")
 @Composable
 fun DecoratedWindow(
     onCloseRequest: () -> Unit,
@@ -157,18 +156,25 @@ fun DecoratedWindow(
         }
 
         Box(
-            modifier = if (isNativeFullscreen) {
-                Modifier.pointerInput(titleBarHolder.titleBarHeight) {
-                    val titleBarHeightPx = with(density) { titleBarHolder.titleBarHeight.toPx() }
-                    awaitPointerEventScope {
-                        while (true) {
-                            val event = awaitPointerEvent(PointerEventPass.Initial)
-                            val y = event.changes.firstOrNull()?.position?.y ?: continue
-                            fullscreenBarVisible = y < titleBarHeightPx
+            modifier =
+                if (isNativeFullscreen) {
+                    Modifier.pointerInput(titleBarHolder.titleBarHeight) {
+                        val titleBarHeightPx = with(density) { titleBarHolder.titleBarHeight.toPx() }
+                        awaitPointerEventScope {
+                            while (true) {
+                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                val y =
+                                    event.changes
+                                        .firstOrNull()
+                                        ?.position
+                                        ?.y ?: continue
+                                fullscreenBarVisible = y < titleBarHeightPx
+                            }
                         }
                     }
-                }
-            } else Modifier,
+                } else {
+                    Modifier
+                },
         ) {
             CompositionLocalProvider(
                 LocalNativeFullscreen provides isNativeFullscreen,
@@ -280,7 +286,10 @@ private fun FullscreenTitleBarOverlay(
  * Works on both Windows (Win32 fullscreen) and Linux (_NET_WM_STATE_FULLSCREEN).
  */
 @Composable
-private fun FrameWindowScope.NativeFullscreenEffect(state: WindowState, windowState: WindowState) {
+private fun FrameWindowScope.NativeFullscreenEffect(
+    state: WindowState,
+    windowState: WindowState,
+) {
     LaunchedEffect(state, window) {
         var isNativeFullscreen = false
         // Track the last non-Fullscreen placement so we can restore it correctly
@@ -313,6 +322,18 @@ private fun FrameWindowScope.NativeFullscreenEffect(state: WindowState, windowSt
                     Platform.Windows -> {
                         val hwnd = JniWindowsWindowUtil.getHwnd(window)
                         if (hwnd != 0L) JniWindowsDecorationBridge.nativeSetFullscreen(hwnd, false)
+                        // Safety net: ensure AWT's extendedState matches the
+                        // restored placement. SetWindowPlacement sends the proper
+                        // WM_SIZE events, but AWT may still miss the maximize
+                        // notification if it processed an intermediate resize
+                        // during style restoration. Explicitly setting extendedState
+                        // guarantees DecoratedWindowState.isMaximized stays in sync.
+                        if (lastNonFullscreenPlacement == WindowPlacement.Maximized) {
+                            window.extendedState = Frame.MAXIMIZED_BOTH
+                        } else {
+                            window.extendedState =
+                                window.extendedState and Frame.MAXIMIZED_BOTH.inv()
+                        }
                     }
                     Platform.Linux -> {
                         JniLinuxWindowBridge.nativeSetFullscreen(window, false)
@@ -356,18 +377,19 @@ private fun FrameWindowScope.NativeFullscreenSyncEffect(
     windowState: WindowState,
 ) {
     DisposableEffect(window) {
-        val listener = object : java.awt.event.ComponentAdapter() {
-            override fun componentResized(e: java.awt.event.ComponentEvent) {
-                if (state.placement != WindowPlacement.Fullscreen) return
-                val hwnd = JniWindowsWindowUtil.getHwnd(window)
-                if (hwnd != 0L && !JniWindowsDecorationBridge.nativeIsFullscreen(hwnd)) {
-                    val previous =
-                        (windowState as? NativeFullscreenWindowState)
-                            ?.placementBeforeFullscreen ?: WindowPlacement.Floating
-                    state.placement = previous
+        val listener =
+            object : java.awt.event.ComponentAdapter() {
+                override fun componentResized(e: java.awt.event.ComponentEvent) {
+                    if (state.placement != WindowPlacement.Fullscreen) return
+                    val hwnd = JniWindowsWindowUtil.getHwnd(window)
+                    if (hwnd != 0L && !JniWindowsDecorationBridge.nativeIsFullscreen(hwnd)) {
+                        val previous =
+                            (windowState as? NativeFullscreenWindowState)
+                                ?.placementBeforeFullscreen ?: WindowPlacement.Floating
+                        state.placement = previous
+                    }
                 }
             }
-        }
         window.addComponentListener(listener)
         onDispose { window.removeComponentListener(listener) }
     }

--- a/decorated-window-jni/src/main/native/windows/nucleus_windows_decoration.c
+++ b/decorated-window-jni/src/main/native/windows/nucleus_windows_decoration.c
@@ -862,16 +862,27 @@ Java_io_github_kdroidfilter_nucleus_window_utils_windows_JniWindowsDecorationBri
     } else {
         if (!state->isFullscreen) return; /* already not fullscreen */
 
-        /* Clear fullscreen flag BEFORE SetWindowLongW so every
-         * WM_NCCALCSIZE triggered by style restoration immediately
+        /* Clear fullscreen flag BEFORE style restoration so every
+         * WM_NCCALCSIZE triggered by the changes below immediately
          * uses the normal path (title-bar extension, resize borders). */
         state->isFullscreen = FALSE;
 
-        /* Restore window styles */
-        SetWindowLongW(hwnd, GWL_STYLE, state->savedStyle);
+        /* Restore extended styles first (no size/position side-effects). */
         SetWindowLongW(hwnd, GWL_EXSTYLE, state->savedExStyle);
 
-        /* Restore window placement (maximized/normal state + position) */
+        /* Restore the main style WITHOUT WS_MAXIMIZE initially.
+         * If we set WS_MAXIMIZE via SetWindowLongW, Windows constrains
+         * the window to the work area and sends WM_SIZE(SIZE_RESTORED)
+         * instead of WM_SIZE(SIZE_MAXIMIZED). AWT then misses the
+         * maximize event and Frame.getExtendedState() stays stale.
+         * SetWindowPlacement with SW_SHOWMAXIMIZED goes through the
+         * proper maximize code path and sends the correct events. */
+        LONG restoreStyle = state->savedStyle & ~(LONG)WS_MAXIMIZE;
+        SetWindowLongW(hwnd, GWL_STYLE, restoreStyle);
+
+        /* Restore window placement (maximized/normal state + position).
+         * For SW_SHOWMAXIMIZED this re-applies WS_MAXIMIZE internally
+         * and sends WM_SIZE(SIZE_MAXIMIZED) so AWT detects it. */
         SetWindowPlacement(hwnd, &state->savedPlacement);
 
         /* Remove topmost and force frame recalculation */


### PR DESCRIPTION
## Root cause

`FullscreenTitleBarOverlay` rendered an invisible `Box(fillMaxSize().pointerInput(...))` as a **sibling** of `DecoratedWindowBody` in the Compose tree. In Compose, when siblings overlap, the one with the highest Z-order wins hit testing **exclusively** — lower Z-order siblings receive no pointer events. Since this invisible box covered the entire screen, all clicks in the content area were swallowed by it and never reached `DecoratedWindowBody`.

The title bar worked only because its own `Box` was rendered *after* the invisible tracker within the overlay (higher Z-order within that subtree), so it won hit testing in the title bar zone.

## Fix

- Move pointer position tracking to the **parent `Box`** in `DecoratedWindow` using `PointerEventPass.Initial`.  
  A parent receives all pointer events in the `Initial` pass regardless of which child wins hit testing, so this reads the cursor Y position without blocking any content clicks.
- Remove the full-screen invisible `Box` child from `FullscreenTitleBarOverlay`.
- `FullscreenTitleBarOverlay` now receives `visible: Boolean` from the parent and only renders the animated sliding bar — no pointer interception.
- Reset `fullscreenBarVisible` to `false` via `LaunchedEffect` when exiting fullscreen.

## Test plan

- [ ] Enter fullscreen — content area receives clicks normally
- [ ] Move mouse to top of screen — title bar slides down
- [ ] Click title bar buttons while in fullscreen
- [ ] Move mouse away from title bar — it slides back up
- [ ] Exit fullscreen — window behaves normally