### PR TITLE
fix: prevent crash on __weak NSWindow ref from JNI thread during disposal

### DIFF
--- a/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
+++ b/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
@@ -999,11 +999,19 @@ Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nati
     JNIEnv *env, jclass clazz, jlong nsWindowPtr) {
 
     if (nsWindowPtr == 0) return;
-    NSWindow *window = (__bridge NSWindow *)(void *)nsWindowPtr;
-    __weak NSWindow *weakWindow = window;
+    // Capture the raw pointer value — do NOT create a __weak reference here.
+    // This function is called from a Java thread, and if the NSWindow has
+    // already been deallocated on the main thread, creating a __weak
+    // reference would crash in objc_initWeak (EXC_BAD_ACCESS).
+    void *rawPtr = (void *)nsWindowPtr;
     dispatch_async(dispatch_get_main_queue(), ^{
         @autoreleasepool {
-            NSWindow *w = weakWindow;
+            // Verify the window is still alive by checking NSApp.windows.
+            NSWindow *w = nil;
+            NSWindow *candidate = (__bridge NSWindow *)rawPtr;
+            for (NSWindow *win in [NSApp windows]) {
+                if (win == candidate) { w = win; break; }
+            }
             if (!w) return;
             removeMenuBarMonitor(w);
             removeFullScreenButtons(w);
@@ -1169,12 +1177,22 @@ Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nati
     JNIEnv *env, jclass clazz, jlong nsWindowPtr) {
 
     if (nsWindowPtr == 0) return;
-    NSWindow *window = (__bridge NSWindow *)(void *)nsWindowPtr;
-    __weak NSWindow *weakWindow = window;
+    // Capture the raw pointer value — do NOT create a __weak reference here.
+    // This function is called from a Java thread, and if the NSWindow has
+    // already been deallocated on the main thread, creating a __weak
+    // reference would crash in objc_initWeak (EXC_BAD_ACCESS).
+    void *rawPtr = (void *)nsWindowPtr;
     dispatch_async(dispatch_get_main_queue(), ^{
         @autoreleasepool {
-            NSWindow *w = weakWindow;
-            if (w) removeMenuBarMonitor(w);
+            // Verify the window is still alive by checking NSApp.windows.
+            // Pointer comparison is safe even for freed pointers.
+            NSWindow *candidate = (__bridge NSWindow *)rawPtr;
+            for (NSWindow *w in [NSApp windows]) {
+                if (w == candidate) {
+                    removeMenuBarMonitor(w);
+                    return;
+                }
+            }
         }
     });
 }


### PR DESCRIPTION
## Summary
- **nativeRemoveMenuBarMonitor** and **nativeResetTitleBar** were creating `__weak NSWindow*` references on the AWT-EventQueue Java thread via `objc_initWeak`, which accesses the object's memory — crashing with `EXC_BAD_ACCESS` if the `NSWindow` was already deallocated on the main thread
- Replaced with raw pointer capture + `dispatch_async` to main thread, validating the window is still alive via `[NSApp windows]` pointer comparison before accessing it
- This is a follow-up to #97 which fixed a similar cleanup crash during fullscreen transitions

## Test plan
- [x] Launch the app and close the window rapidly — no crash
- [x] Enter/exit fullscreen repeatedly while closing — no crash
- [x] Verify menu bar monitor installs/removes correctly during fullscreen on non-notch displays
- [x] Verify title bar reset works correctly on window close