### PR TITLE
feat: add backgroundContent slot to TitleBar and MaterialTitleBar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# ComposeDeskKit (Nucleus)
+
+A multi-module Gradle plugin and runtime library toolkit for shipping production-ready JVM desktop applications on macOS, Windows, and Linux.
+
+## Project Structure
+
+- `core-runtime` - Executable type detection, single instance, deep links, platform detection
+- `aot-runtime` - AOT cache mode detection for JDK 25+ (Project Leyden)
+- `updater-runtime` - Auto-update engine (GitHub/S3), SHA-512 verification, progress tracking
+- `darkmode-detector` - Reactive OS dark mode detection via JNI
+- `system-color` - Reactive system accent color and high contrast detection via JNI
+- `energy-manager` - Energy efficiency & screen-awake APIs
+- `native-ssl` / `native-http` / `native-http-okhttp` / `native-http-ktor` - OS trust store integration
+- `linux-hidpi` - Native HiDPI scale detection on Linux
+- `graalvm-runtime` - GraalVM native-image bootstrap
+- `decorated-window-core` / `-jbr` / `-jni` / `-material` - Custom window decorations
+- `plugin-build/plugin` - Gradle plugin for packaging & distribution
+- `example` / `jewel-sample` / `sample-cmp` - Sample applications
+
+## Build & Run
+
+```bash
+./gradlew run                                    # Run example app
+./gradlew packageDistributionForCurrentOS        # Package for current OS
+./gradlew packageReleaseDistributionForCurrentOS # Release build with ProGuard
+./gradlew preMerge                               # Full CI verification
+./gradlew reformatAll                            # Format all code
+```
+
+## Key Technologies
+
+- Kotlin 2.0+ with Compose Desktop
+- JNA/JNA-Platform for native interop (JNI bridges for macOS, Windows, Linux)
+- JBR (JetBrains Runtime) API
+- Gradle 8+ with version catalog (`gradle/libs.versions.toml`)
+- Detekt + KtLint for code quality
+
+## Development Notes
+
+- Target: JDK 17+ runtime, JDK 25+ recommended for AOT
+- JNI code: be careful with macOS ARC/retain and weak references (recent crash fixes in PRs #97–#101)
+- Native modules use platform-specific JNI implementations — test on each OS
+- Plugin is published via included build in `plugin-build/`
+- Version catalog is the source of truth for all dependency versions

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
@@ -24,6 +24,7 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
@@ -59,6 +60,7 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
                 PaddingValues(0.dp)
             }
         },
+        backgroundContent = backgroundContent,
     ) { currentState ->
         WindowControlArea(window, currentState, linuxStyle)
         content(currentState)

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -60,6 +60,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     val newFullscreenControls =
@@ -111,6 +112,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
                 MacUtil.updateFullScreenButtons(window)
             }
         },
+        backgroundContent = backgroundContent,
         content = content,
     )
 }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
@@ -27,6 +27,7 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
@@ -44,7 +45,10 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
             JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
             PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
         },
-        backgroundContent = { Spacer(modifier = modifier.fillMaxSize().customTitleBarMouseEventHandler(titleBar)) },
+        backgroundContent = {
+            Spacer(modifier = modifier.fillMaxSize().customTitleBarMouseEventHandler(titleBar))
+            backgroundContent()
+        },
     ) { state ->
         content(state)
     }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.kt
@@ -13,12 +13,13 @@ fun DecoratedWindowScope.TitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     when (Platform.Current) {
-        Platform.Linux -> LinuxTitleBar(modifier, gradientStartColor, style, content)
-        Platform.Windows -> WindowsTitleBar(modifier, gradientStartColor, style, content)
-        Platform.MacOS -> MacOSTitleBar(modifier, gradientStartColor, style, content)
+        Platform.Linux -> LinuxTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
+        Platform.Windows -> WindowsTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
+        Platform.MacOS -> MacOSTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
         Platform.Unknown ->
             error("TitleBar is not supported on this platform(${System.getProperty("os.name")})")
     }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
@@ -27,12 +27,13 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     if (JniLinuxWindowBridge.isLoaded) {
-        NativeLinuxTitleBar(modifier, gradientStartColor, style, content)
+        NativeLinuxTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
     } else {
-        FallbackLinuxTitleBar(modifier, gradientStartColor, style, content)
+        FallbackLinuxTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
     }
 }
 
@@ -46,6 +47,7 @@ private fun DecoratedWindowScope.NativeLinuxTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
+    backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
@@ -96,6 +98,7 @@ private fun DecoratedWindowScope.NativeLinuxTitleBar(
             }
         },
         backgroundContent = {
+            backgroundContent()
             Spacer(
                 modifier =
                     Modifier
@@ -151,6 +154,7 @@ private fun DecoratedWindowScope.FallbackLinuxTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
+    backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
@@ -186,8 +190,8 @@ private fun DecoratedWindowScope.FallbackLinuxTitleBar(
                 PaddingValues(0.dp)
             }
         },
-        // Compose-based drag replaces JBR.getWindowMove()
         backgroundContent = {
+            backgroundContent()
             Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
         },
     ) { currentState ->

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -41,6 +41,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     val useNewFullscreenControls = modifier.hasNewFullscreenControls()
@@ -206,6 +207,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
         },
         backgroundContent = {
             Spacer(modifier = Modifier.fillMaxSize())
+            backgroundContent()
         },
         content = content,
     )

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
@@ -31,12 +31,13 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     if (JniWindowsDecorationBridge.isLoaded) {
-        NativeWindowsTitleBar(modifier, gradientStartColor, style, content)
+        NativeWindowsTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
     } else {
-        FallbackWindowsTitleBar(modifier, gradientStartColor, style, content)
+        FallbackWindowsTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
     }
 }
 
@@ -47,6 +48,7 @@ private fun DecoratedWindowScope.NativeWindowsTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
+    backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
     val isNativeFullscreen = LocalNativeFullscreen.current
@@ -131,6 +133,7 @@ private fun DecoratedWindowScope.NativeWindowsTitleBar(
             PaddingValues(0.dp)
         },
         backgroundContent = {
+            backgroundContent()
             Spacer(
                 modifier =
                     Modifier
@@ -179,6 +182,7 @@ private fun DecoratedWindowScope.FallbackWindowsTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
+    backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
     val viewConfig = LocalViewConfiguration.current
@@ -206,6 +210,7 @@ private fun DecoratedWindowScope.FallbackWindowsTitleBar(
         style = style,
         applyTitleBar = { _, _ -> PaddingValues(0.dp) },
         backgroundContent = {
+            backgroundContent()
             Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
         },
     ) { currentState ->

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.kt
@@ -16,12 +16,13 @@ fun DecoratedWindowScope.TitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     when (Platform.Current) {
-        Platform.Linux -> LinuxTitleBar(modifier, gradientStartColor, style, content)
-        Platform.Windows -> WindowsTitleBar(modifier, gradientStartColor, style, content)
-        Platform.MacOS -> MacOSTitleBar(modifier, gradientStartColor, style, content)
+        Platform.Linux -> LinuxTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
+        Platform.Windows -> WindowsTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
+        Platform.MacOS -> MacOSTitleBar(modifier, gradientStartColor, style, backgroundContent, content)
         Platform.Unknown ->
             error("TitleBar is not supported on this platform(${System.getProperty("os.name")})")
     }

--- a/decorated-window-material/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialTitleBar.kt
+++ b/decorated-window-material/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialTitleBar.kt
@@ -14,6 +14,7 @@ import io.github.kdroidfilter.nucleus.window.TitleBarScope
 fun DecoratedWindowScope.MaterialTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     val style = rememberMaterialTitleBarStyle(MaterialTheme.colorScheme)
@@ -21,6 +22,7 @@ fun DecoratedWindowScope.MaterialTitleBar(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        backgroundContent = backgroundContent,
         content = content,
     )
 }

--- a/docs/runtime/decorated-window-material.md
+++ b/docs/runtime/decorated-window-material.md
@@ -79,20 +79,52 @@ MaterialDecoratedDialog(
 
 ### `MaterialTitleBar` / `MaterialDialogTitleBar`
 
-Material-styled title bars. They read `MaterialTheme.colorScheme` and build a `TitleBarStyle` from it. They accept the same `gradientStartColor` parameter as the base `TitleBar`.
+Material-styled title bars. They read `MaterialTheme.colorScheme` and build a `TitleBarStyle` from it. They accept the same `gradientStartColor` and `backgroundContent` parameters as the base `TitleBar`.
 
 ```kotlin
 MaterialTitleBar(
     modifier = Modifier
         .newFullscreenControls()   // sliding overlay title bar in fullscreen (all platforms)
         .macOSLargeCornerRadius(), // 26pt corner radius on macOS (Finder/Safari style)
-    gradientStartColor = Color.Unspecified, // optional gradient
+    gradientStartColor = Color.Unspecified, // optional horizontal gradient
+    backgroundContent = {},                // optional custom background layer
 ) { state ->
     // TitleBarScope content
 }
 ```
 
 See [Decorated Window — Fullscreen Title Bar](decorated-window.md#fullscreen-title-bar) for details on the sliding overlay behavior and the large corner radius modifier.
+
+#### Custom background with `backgroundContent`
+
+`backgroundContent` is a composable drawn behind the title bar content, on top of the base `background` fill. Use it to render shapes, gradients, or images that require full layout control. The lambda receives a `Box` scope sized to the full title bar area.
+
+A common use case is a diagonal color band on the leading edge — for example a branded accent that covers the native window controls area:
+
+```kotlin
+MaterialTitleBar(
+    backgroundContent = {
+        val brandColor = Color(0xFFD32F2F)
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val slantWidth = size.height * 4f
+            drawPath(
+                path = Path().apply {
+                    moveTo(0f, 0f)
+                    lineTo(slantWidth, 0f)
+                    lineTo(slantWidth - size.height, size.height)
+                    lineTo(0f, size.height)
+                    close()
+                },
+                color = brandColor,
+            )
+        }
+    },
+) { _ ->
+    // content
+}
+```
+
+This draws a solid red trapezoid from the left edge with a 45° diagonal cut. Adjust `size.height * N` to control the width.
 
 ## Color Mapping
 

--- a/docs/runtime/decorated-window.md
+++ b/docs/runtime/decorated-window.md
@@ -393,6 +393,52 @@ TitleBar(
 
 When `gradientStartColor` is `Color.Unspecified` (the default), the background is a solid color.
 
+## Custom Background
+
+The `TitleBar` composable accepts a `backgroundContent` parameter: a composable rendered inside the title bar `Box`, between the base background fill and the user content. This lets you draw arbitrary shapes, gradients, or images that need full layout access — things that cannot be expressed as a plain `Color` or a simple horizontal gradient.
+
+```kotlin
+TitleBar(
+    backgroundContent = {
+        // Drawn on top of the background fill, behind all title bar content.
+        // The Box is sized to the full title bar area.
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawRect(color = Color(0xFF6200EE), size = Size(size.width / 2, size.height))
+        }
+    },
+) { state ->
+    Text(title, modifier = Modifier.align(Alignment.CenterHorizontally))
+}
+```
+
+A typical use case is a **diagonal color band** on the leading edge, covering the native window controls area:
+
+```kotlin
+TitleBar(
+    backgroundContent = {
+        val brandColor = Color(0xFFD32F2F)
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val slantWidth = size.height * 4f
+            drawPath(
+                path = Path().apply {
+                    moveTo(0f, 0f)
+                    lineTo(slantWidth, 0f)
+                    lineTo(slantWidth - size.height, size.height)
+                    lineTo(0f, size.height)
+                    close()
+                },
+                color = brandColor,
+            )
+        }
+    },
+) { _ -> /* content */ }
+```
+
+This draws a solid trapezoid from the left edge with a 45° diagonal cut. Adjust `size.height * N` to control the width.
+
+!!! note "Interaction layer ordering"
+    On platforms that use a native `Spacer` for drag handling (Windows fallback, Linux), `backgroundContent` is composed **before** the drag `Spacer`, so pointer events pass through to the drag handler correctly.
+
 ## Fullscreen Title Bar
 
 ### `newFullscreenControls()` — Sliding Overlay Title Bar


### PR DESCRIPTION
## Summary

- Adds a `backgroundContent: @Composable () -> Unit` parameter (default empty) to `TitleBar` and `MaterialTitleBar`
- Propagates the new slot through all platform implementations: macOS, Windows, Linux — for both JBR and JNI backends
- On Windows, the background content is composed alongside the existing `customTitleBarMouseEventHandler` spacer
- Updates documentation for `decorated-window` and `decorated-window-material`
- Adds `CLAUDE.md` project instructions

## Test plan

- [x] Verify `TitleBar` with no `backgroundContent` arg behaves identically to before on macOS, Windows, Linux
- [x] Verify a custom `backgroundContent` (e.g. gradient `Box`) renders correctly behind controls on each platform
- [x] Verify `MaterialTitleBar` passes `backgroundContent` through correctly
- [x] Check JBR and JNI builds separately