### PR TITLE
fix(signing): pass --mac-app-store to jpackage for sandboxed builds

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -794,8 +794,11 @@ internal fun JvmApplicationContext.configurePlatformSettings(
                         }
                     },
                 )
-                // PKG is always treated as App Store — ignore the deprecated user setting.
-                packageTask.macAppStore.set(packageTask.targetFormat.isStoreFormat)
+                // The jpackage task always builds a RawAppImage, so targetFormat.isStoreFormat
+                // is always false. Use the sandboxed flag instead: sandboxed distributable feeds
+                // store formats (PKG) and must pass --mac-app-store to jpackage so it searches
+                // for the correct certificate type ("3rd Party Mac Developer Application").
+                packageTask.macAppStore.set(sandboxed)
                 packageTask.macAppCategory.set(mac.appCategory)
                 packageTask.macMinimumSystemVersion.set(mac.minimumSystemVersion)
                 val defaultAppEntitlements =


### PR DESCRIPTION
## Summary

- The `configurePlatformSettings` function set `macAppStore` from `targetFormat.isStoreFormat`, but the jpackage task always builds a `RawAppImage` (never a store format directly), so this was **always false**
- This meant `--mac-app-store` was never passed to jpackage, causing it to search for a `"Developer ID Application"` certificate instead of `"3rd Party Mac Developer Application"` — breaking signing for users with App Store certificates
- Use the `sandboxed` flag instead, which correctly reflects whether the distributable feeds store formats (PKG)

Fixes #103

## Test plan

- [x] Plugin compiles successfully
- [x] `jewel-sample:createDistributable` — non-sandboxed jpackage builds correctly
- [x] `sample-cmp:createDistributable` — non-sandboxed jpackage builds correctly
- [x] `jewel-sample:packageDmg` — electron-builder packaging with ad-hoc signing works
- [x] `example:createSandboxedDistributable --dry-run` — sandboxed task graph is valid
- [ ] Build a sandboxed PKG with a "3rd Party Mac Developer Application" certificate and verify jpackage finds it