### PR TITLE
fix: include generic provider in publish mode detection

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -294,7 +294,7 @@ abstract class AbstractElectronBuilderPackageTask
 
         private fun resolvePublishFlag(): String {
             val publish = distributions?.publish
-            val anyProviderEnabled = publish != null && (publish.github.enabled || publish.s3.enabled)
+            val anyProviderEnabled = publish != null && (publish.github.enabled || publish.s3.enabled || publish.generic.enabled)
             if (!anyProviderEnabled) {
                 logger.info("No publish provider enabled, using publish mode: never")
                 return "never"


### PR DESCRIPTION
## Summary
- `resolvePublishFlag()` in `AbstractElectronBuilderPackageTask` only checked `github.enabled` and `s3.enabled`, missing `generic.enabled`
- When using the generic publish provider, electron-builder was always invoked with `--publish never`, preventing `latest.yml` / `latest-*.yml` generation on all platforms

## Test plan
- [ ] Configure a project with `generic` publish provider and `publishMode = Always`
- [ ] Run `packageDistributionForCurrentOS` and verify `latest.yml` is generated in the output directory

Closes #93