### PR TITLE
fix(jbr): reliable title bar drag via clientRegion hit testing

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindowCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindowCore.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.Layout
@@ -155,10 +156,15 @@ value class DecoratedWindowState(
     }
 }
 
-data class TitleBarInfo(
-    val title: String,
-    val icon: Painter?,
-)
+@Stable
+class TitleBarInfo(
+    title: String,
+    icon: Painter?,
+) {
+    var title by mutableStateOf(title)
+    var icon by mutableStateOf(icon)
+    val clientRegions: MutableMap<String, Rect> = mutableMapOf()
+}
 
 val LocalTitleBarInfo: ProvidableCompositionLocal<TitleBarInfo> =
     compositionLocalOf {
@@ -372,8 +378,12 @@ fun FrameWindowScope.DecoratedWindowBody(
         javax.swing.SwingUtilities.invokeLater { applyRecursive(window) }
     }
 
+    val titleBarInfo = remember { TitleBarInfo(title, icon) }
+    LaunchedEffect(title) { titleBarInfo.title = title }
+    LaunchedEffect(icon) { titleBarInfo.icon = icon }
+
     CompositionLocalProvider(
-        LocalTitleBarInfo provides TitleBarInfo(title, icon),
+        LocalTitleBarInfo provides titleBarInfo,
         LocalLayoutDirection provides platformLayoutDirection,
     ) {
         Layout(

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
+import io.github.kdroidfilter.nucleus.window.utils.WindowMouseEventEffect
 
 @Suppress("FunctionNaming")
 @Composable
@@ -22,10 +23,12 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
 ) {
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
 
+    WindowMouseEventEffect(titleBar)
+
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
 
     DialogTitleBarImpl(
-        modifier = modifier.customTitleBarMouseEventHandler(titleBar),
+        modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
         applyTitleBar = { height, _ ->

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
@@ -14,6 +14,7 @@ import com.jetbrains.JBR
 import io.github.kdroidfilter.nucleus.window.internal.isDark
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
+import io.github.kdroidfilter.nucleus.window.utils.WindowMouseEventEffect
 
 @Suppress("FunctionNaming")
 @Composable
@@ -24,6 +25,9 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
+
+    WindowMouseEventEffect(titleBar)
+
     val layoutDirection = LocalLayoutDirection.current
     val isRtl = layoutDirection == LayoutDirection.Rtl
 
@@ -42,7 +46,7 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
                 PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
             }
         },
-        backgroundContent = { Spacer(modifier = modifier.fillMaxSize().customTitleBarMouseEventHandler(titleBar)) },
+        backgroundContent = { Spacer(modifier = Modifier.fillMaxSize()) },
         content = content,
     )
 }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
@@ -2,6 +2,8 @@ package io.github.kdroidfilter.nucleus.window
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
@@ -16,9 +18,12 @@ fun DecoratedDialogScope.DialogTitleBar(
     style: TitleBarStyle = LocalTitleBarStyle.current,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
-    val titleBarInfo = LocalDialogTitleBarInfo.current
+    val dialogTitleBarInfo = LocalDialogTitleBarInfo.current
+    val titleBarInfo = remember { TitleBarInfo(dialogTitleBarInfo.title, dialogTitleBarInfo.icon) }
+    LaunchedEffect(dialogTitleBarInfo.title) { titleBarInfo.title = dialogTitleBarInfo.title }
+    LaunchedEffect(dialogTitleBarInfo.icon) { titleBarInfo.icon = dialogTitleBarInfo.icon }
     CompositionLocalProvider(
-        LocalTitleBarInfo provides TitleBarInfo(titleBarInfo.title, titleBarInfo.icon),
+        LocalTitleBarInfo provides titleBarInfo,
     ) {
         when (Platform.Current) {
             Platform.Linux -> LinuxDialogTitleBar(modifier, gradientStartColor, style, content)

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
+import io.github.kdroidfilter.nucleus.window.utils.WindowMouseEventEffect
 import io.github.kdroidfilter.nucleus.window.utils.macos.MacUtil
 
 fun Modifier.newFullscreenControls(newControls: Boolean = true): Modifier =
@@ -86,10 +87,12 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
 
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
 
+    WindowMouseEventEffect(titleBar)
+
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
 
     TitleBarImpl(
-        modifier = modifier.customTitleBarMouseEventHandler(titleBar),
+        modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
         applyTitleBar = { height, titleBarState ->

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
@@ -7,19 +7,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.PointerEventPass
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
-import com.jetbrains.WindowDecorations.CustomTitleBar
 import io.github.kdroidfilter.nucleus.window.internal.isDark
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.isActive
+import io.github.kdroidfilter.nucleus.window.utils.WindowMouseEventEffect
 
 @Suppress("FunctionNaming")
 @Composable
@@ -31,6 +26,8 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
+
+    WindowMouseEventEffect(titleBar)
 
     val layoutDirection = LocalLayoutDirection.current
     val isRtl = layoutDirection == LayoutDirection.Rtl
@@ -46,34 +43,10 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
             PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
         },
         backgroundContent = {
-            Spacer(modifier = modifier.fillMaxSize().customTitleBarMouseEventHandler(titleBar))
+            Spacer(modifier = Modifier.fillMaxSize())
             backgroundContent()
         },
     ) { state ->
         content(state)
     }
 }
-
-internal fun Modifier.customTitleBarMouseEventHandler(titleBar: CustomTitleBar): Modifier =
-    pointerInput(Unit) {
-        val currentContext = currentCoroutineContext()
-        awaitPointerEventScope {
-            var inUserControl = false
-            while (currentContext.isActive) {
-                val event = awaitPointerEvent(PointerEventPass.Main)
-                event.changes.forEach {
-                    if (!it.isConsumed && !inUserControl) {
-                        titleBar.forceHitTest(false)
-                    } else {
-                        if (event.type == PointerEventType.Press) {
-                            inUserControl = true
-                        }
-                        if (event.type == PointerEventType.Release) {
-                            inUserControl = false
-                        }
-                        titleBar.forceHitTest(true)
-                    }
-                }
-            }
-        }
-    }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/ClientRegionHelper.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/ClientRegionHelper.kt
@@ -1,0 +1,154 @@
+package io.github.kdroidfilter.nucleus.window.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.GlobalPositionAwareModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.unit.toSize
+import com.jetbrains.WindowDecorations
+import io.github.kdroidfilter.nucleus.window.DecoratedDialogScope
+import io.github.kdroidfilter.nucleus.window.DecoratedWindowScope
+import io.github.kdroidfilter.nucleus.window.LocalTitleBarInfo
+import io.github.kdroidfilter.nucleus.window.TitleBarInfo
+import java.awt.Window
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+
+/**
+ * Registers a composable element as a client region within a decorated window's title bar.
+ *
+ * Client regions are interactive areas of the title bar that should respond to mouse events
+ * as if they were part of the window's client area, rather than the draggable title bar.
+ * This is essential for interactive title bar controls like buttons, menus, or other widgets
+ * that should not trigger window dragging.
+ *
+ * @param key A unique identifier for this client region. Should be unique within the same
+ *   window's title bar.
+ * @return A modified [Modifier] that registers this composable as a client region.
+ */
+fun Modifier.clientRegion(key: String): Modifier = then(RegisterClientRegionElement(key))
+
+private data class RegisterClientRegionElement(
+    private val key: String,
+) : ModifierNodeElement<RegisterClientRegionNode>() {
+    override fun create() = RegisterClientRegionNode(key)
+
+    override fun update(node: RegisterClientRegionNode) {
+        node.updateKey(key)
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "registerRegion"
+        properties["key"] = key
+    }
+}
+
+private class RegisterClientRegionNode(
+    var key: String,
+) : Modifier.Node(),
+    GlobalPositionAwareModifierNode,
+    CompositionLocalConsumerModifierNode {
+    private var titleBarInfo: TitleBarInfo? = null
+
+    override fun onAttach() {
+        titleBarInfo = currentValueOf(LocalTitleBarInfo)
+    }
+
+    override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+        val info = titleBarInfo ?: return
+        val rect = Rect(coordinates.positionInWindow(), coordinates.size.toSize())
+
+        info.clientRegions[key] = rect
+    }
+
+    override fun onDetach() {
+        titleBarInfo?.clientRegions?.remove(key)
+        titleBarInfo = null
+    }
+
+    fun updateKey(newKey: String) {
+        if (key == newKey) return
+
+        val region = titleBarInfo?.clientRegions?.remove(key)
+
+        if (region != null) {
+            titleBarInfo?.clientRegions[newKey] = region
+        }
+
+        key = newKey
+    }
+}
+
+/**
+ * Sets up mouse event handling for interactive title bar regions in a decorated window.
+ *
+ * This effect monitors mouse movements and clicks on the window, determining whether the
+ * cursor is over a client region (interactive title bar element) or the draggable title bar
+ * itself. It communicates hit test results to the platform's window decorations system.
+ *
+ * @param titleBar The platform window decorations object that receives hit test updates.
+ */
+@Composable
+internal fun DecoratedWindowScope.WindowMouseEventEffect(titleBar: WindowDecorations.CustomTitleBar) {
+    WindowMouseEventEffectImpl(window, titleBar)
+}
+
+@Composable
+internal fun DecoratedDialogScope.WindowMouseEventEffect(titleBar: WindowDecorations.CustomTitleBar) {
+    WindowMouseEventEffectImpl(window, titleBar)
+}
+
+@Composable
+private fun WindowMouseEventEffectImpl(
+    window: Window,
+    titleBar: WindowDecorations.CustomTitleBar,
+) {
+    val titleBarInfo = LocalTitleBarInfo.current
+
+    DisposableEffect(window, window.graphicsConfiguration, titleBar) {
+        val graphicsConfig = window.graphicsConfiguration
+        val scaleX = graphicsConfig?.defaultTransform?.scaleX ?: 1.0
+        val scaleY = graphicsConfig?.defaultTransform?.scaleY ?: 1.0
+        val listener =
+            object : MouseAdapter() {
+                override fun mousePressed(e: MouseEvent) {
+                    updateHitTest(e)
+                }
+
+                override fun mouseReleased(e: MouseEvent) {
+                    updateHitTest(e)
+                }
+
+                override fun mouseDragged(e: MouseEvent) {
+                    updateHitTest(e)
+                }
+
+                override fun mouseMoved(e: MouseEvent) {
+                    updateHitTest(e)
+                }
+
+                private fun updateHitTest(e: MouseEvent) {
+                    val point = Offset(x = (e.x * scaleX).toFloat(), y = (e.y * scaleY).toFloat())
+
+                    val isClientRegion = titleBarInfo.clientRegions.any { it.value.contains(point) }
+
+                    titleBar.forceHitTest(isClientRegion)
+                }
+            }
+        window.addMouseListener(listener)
+        window.addMouseMotionListener(listener)
+
+        onDispose {
+            window.removeMouseListener(listener)
+            window.removeMouseMotionListener(listener)
+        }
+    }
+}

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
@@ -221,9 +221,13 @@ private fun BoxScope.FullscreenTitleBarRenderers(
             { content -> content() }
         }
 
+    val titleBarInfo = remember { TitleBarInfo(title, icon) }
+    LaunchedEffect(title) { titleBarInfo.title = title }
+    LaunchedEffect(icon) { titleBarInfo.icon = icon }
+
     if (isNativeFullscreen) {
         wrapper {
-            CompositionLocalProvider(LocalTitleBarInfo provides TitleBarInfo(title, icon)) {
+            CompositionLocalProvider(LocalTitleBarInfo provides titleBarInfo) {
                 FullscreenTitleBarOverlay(
                     holder = titleBarHolder,
                     visible = fullscreenBarVisible,
@@ -237,7 +241,7 @@ private fun BoxScope.FullscreenTitleBarRenderers(
     // (newFullscreenControls sets holder.content during macOS fullscreen)
     if (!isNativeFullscreen && titleBarHolder.content != null) {
         wrapper {
-            CompositionLocalProvider(LocalTitleBarInfo provides TitleBarInfo(title, icon)) {
+            CompositionLocalProvider(LocalTitleBarInfo provides titleBarInfo) {
                 Box(modifier = Modifier.align(Alignment.TopCenter)) {
                     titleBarHolder.content?.invoke()
                 }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
@@ -2,6 +2,8 @@ package io.github.kdroidfilter.nucleus.window
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
@@ -16,9 +18,12 @@ fun DecoratedDialogScope.DialogTitleBar(
     style: TitleBarStyle = LocalTitleBarStyle.current,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
-    val titleBarInfo = LocalDialogTitleBarInfo.current
+    val dialogTitleBarInfo = LocalDialogTitleBarInfo.current
+    val titleBarInfo = remember { TitleBarInfo(dialogTitleBarInfo.title, dialogTitleBarInfo.icon) }
+    LaunchedEffect(dialogTitleBarInfo.title) { titleBarInfo.title = dialogTitleBarInfo.title }
+    LaunchedEffect(dialogTitleBarInfo.icon) { titleBarInfo.icon = dialogTitleBarInfo.icon }
     CompositionLocalProvider(
-        LocalTitleBarInfo provides TitleBarInfo(titleBarInfo.title, titleBarInfo.icon),
+        LocalTitleBarInfo provides titleBarInfo,
     ) {
         when (Platform.Current) {
             Platform.Linux -> LinuxDialogTitleBar(modifier, gradientStartColor, style, content)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+- **`Modifier.clientRegion()` for JBR title bar hit testing** — New modifier function that registers composable elements as interactive client regions within a `DecoratedWindow`'s title bar. Client regions receive mouse events (clicks, presses) instead of triggering window dragging. Uses AWT-level mouse listeners with precise coordinate-based hit testing, replacing the old pointer-event-based `customTitleBarMouseEventHandler`. See [Decorated Window](runtime/decorated-window.md).
+
+### Bug Fixes
+
+- **Fix title bar drag on Windows (`decorated-window-jbr`)** — Window dragging via the title bar no longer occasionally fails on the first attempt when another window has focus. The new `WindowMouseEventEffect` approach uses AWT mouse listeners for reliable hit-test forwarding to JBR's `CustomTitleBar`, fixing the intermittent missed drag events. ([#53](https://github.com/kdroidFilter/Nucleus/issues/53))
+
+---
+
 ## v1.4.0
 
 **Released: 2026-03-09**

--- a/docs/runtime/decorated-window.md
+++ b/docs/runtime/decorated-window.md
@@ -29,12 +29,11 @@ Both `decorated-window-jbr` and `decorated-window-jni` expose **the same public 
 
 Uses JetBrains' official `CustomTitleBar` API. This is the more **battle-tested** option, backed by the same code that powers IntelliJ IDEA and other JetBrains products. Requires JBR.
 
-However, there are a few known issues on **Windows**:
+However, there is a known issue on **Windows**:
 
 - The window **cannot open in maximized state** directly — you need to use a `LaunchedEffect` with a short delay after the window appears, then set `WindowPlacement.Maximized`
-- Title bar drag events are **occasionally missed**, causing the window to not follow the cursor during drag
 
-These are upstream JBR bugs, not Nucleus bugs. The module throws an `IllegalStateException` at startup if JBR is not detected.
+This is an upstream JBR bug, not a Nucleus bug. The module throws an `IllegalStateException` at startup if JBR is not detected.
 
 !!! tip
     When running via `./gradlew run`, Gradle uses the JDK configured in your toolchain. Make sure it is a JBR distribution if using this module.
@@ -167,12 +166,12 @@ The following tables compare a standard Compose `Window()`, the JBR module (`dec
 |---|---|---|---|
 | Custom title bar content | No | Yes (JBR `CustomTitleBar`) | Yes (JNI DLL, WndProc subclass) |
 | Window controls | Native | Native min/max/close | Compose-drawn (SVG icons, Windows style) |
-| Title bar drag | Native | JBR `forceHitTest` | Native DLL or Compose fallback |
+| Title bar drag | Native | JBR `forceHitTest` + `clientRegion` | Native DLL or Compose fallback |
 | Double-click maximize | Native | Native (via JBR `CustomTitleBar`) | Compose detection |
 | Window snapping / tiling | Native | Native | Native (via `WM_NCLBUTTONDOWN` + `HTCAPTION`) |
 | Resize white flash | White flash on dark themes | White flash on dark themes | **Fixed** — `WM_ERASEBKGND` fill + `SWP_NOCOPYBITS` + DWM color sync |
 | Open in maximized state | Works | Broken (requires `LaunchedEffect` workaround) | Works |
-| Drag reliability | Native | Occasional missed events (JBR bug) | Reliable |
+| Drag reliability | Native | Reliable (`clientRegion` hit-test) | Reliable |
 | True fullscreen | Broken (doesn't cover taskbar) | Broken (doesn't cover taskbar) | **Fixed** — native Win32 fullscreen (`newFullscreenControls()`) |
 | Fullscreen sliding title bar | No | No | Yes (`newFullscreenControls()`) |
 | DWM dark mode sync | No | No | Yes (`DWMWA_USE_IMMERSIVE_DARK_MODE`, caption/border color) |
@@ -314,6 +313,40 @@ TitleBar { state ->
 ```
 
 Centered content is automatically shifted to avoid overlapping with start/end content.
+
+### `Modifier.clientRegion()` — Interactive Title Bar Regions
+
+When you place interactive elements (buttons, dropdowns, etc.) inside a `TitleBar`, they need to receive mouse events instead of triggering window dragging. The `clientRegion` modifier registers a composable as an interactive area within the title bar, so the platform's hit-test system knows to treat it as a clickable region rather than a drag surface.
+
+This is particularly important with `decorated-window-jbr`, where the old pointer-event-based approach could occasionally miss drag events on Windows. The new `clientRegion` modifier uses AWT-level mouse listeners with precise coordinate-based hit testing, which is more reliable.
+
+```kotlin
+TitleBar { state ->
+    // This dropdown is marked as a client region — clicks go to
+    // the dropdown, not to the window drag handler.
+    Dropdown(
+        modifier = Modifier.align(Alignment.Start).clientRegion("main_menu"),
+        menuContent = { /* ... */ },
+    ) {
+        Text("File")
+    }
+
+    Text(title, modifier = Modifier.align(Alignment.CenterHorizontally))
+
+    // This icon button is also a client region.
+    IconButton(
+        onClick = { /* ... */ },
+        modifier = Modifier.align(Alignment.End).clientRegion("settings"),
+    ) {
+        Icon(Icons.Default.Settings, contentDescription = "Settings")
+    }
+}
+```
+
+The `key` parameter must be unique within the same window's title bar. When the composable is removed from the composition, its region is automatically unregistered.
+
+!!! note "`decorated-window-jbr` only"
+    The `clientRegion` modifier is provided by `decorated-window-jbr`. The `decorated-window-jni` module handles hit testing differently (via native platform APIs) and does not need this modifier — interactive elements in the title bar work automatically.
 
 ## Styling
 


### PR DESCRIPTION
## Summary

- **Replace `customTitleBarMouseEventHandler`** with AWT-level `WindowMouseEventEffect` and new `Modifier.clientRegion()` API for registering interactive title bar areas
- **Fix intermittent drag failures on Windows** — the old Compose `pointerInput`-based approach missed events when the window didn't have focus at press time; the new AWT mouse listeners receive all events unconditionally
- **Adapt `TitleBarInfo`** from `data class` to `@Stable class` with `mutableStateOf` properties and a `clientRegions` map, with `remember`/`LaunchedEffect` pattern applied consistently across JBR, JNI, and core modules

Ported from [JetBrains/intellij-community#3362](https://github.com/JetBrains/intellij-community/pull/3362) (JEWEL-368).

Closes https://github.com/kdroidFilter/Nucleus/issues/53

## Changed files

| Module | Changes |
|--------|---------|
| `decorated-window-core` | `TitleBarInfo` → `@Stable class` with `mutableStateOf` + `clientRegions` map; `DecoratedWindowBody` uses `remember`/`LaunchedEffect` |
| `decorated-window-jbr` | New `ClientRegionHelper.kt` (`clientRegion` modifier + `WindowMouseEventEffect`); updated macOS/Windows/Dialog title bars |
| `decorated-window-jni` | Adapted to new `TitleBarInfo` type (`remember`/`LaunchedEffect`); no behavior change |
| `docs` | Updated decorated-window docs + changelog |

## Test plan

- [ ] Windows: verify title bar drag works reliably when clicking from an unfocused window
- [ ] Windows: verify interactive elements (buttons, dropdowns) in title bar still receive clicks
- [ ] macOS: verify title bar drag and interactive elements work correctly
- [ ] Linux: verify no regression (Linux uses undecorated window, not affected by this change)
- [ ] JNI module: verify no regression (no behavior change, only type adaptation)