### PR TITLE
fix: promote core-runtime to api scope in updater-runtime and system-color

### DIFF
--- a/system-color/build.gradle.kts
+++ b/system-color/build.gradle.kts
@@ -16,7 +16,7 @@ val publishVersion =
         ?: "1.0.0"
 
 dependencies {
-    compileOnly(project(":core-runtime"))
+    api(project(":core-runtime"))
     compileOnly(compose.desktop.common)
 }
 

--- a/updater-runtime/build.gradle.kts
+++ b/updater-runtime/build.gradle.kts
@@ -13,9 +13,9 @@ val publishVersion =
         ?: "1.0.0"
 
 dependencies {
-    implementation(project(":core-runtime"))
+    api(project(":core-runtime"))
     implementation(kotlin("stdlib"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+    implementation(libs.coroutines.core)
     testImplementation(libs.junit)
 }
 


### PR DESCRIPTION
## Summary
- **updater-runtime**: `implementation` → `api` for `core-runtime` — exposes `Platform` in `UpdateProvider` signatures and `ExecutableType` in `NucleusUpdater` companion object
- **system-color**: `compileOnly` → `api` for `core-runtime` — uses `Platform.Current` at runtime in public composables (`systemAccentColor()`, `isSystemAccentColorSupported()`, `isSystemInHighContrast()`)

Without `api` scope, consumers either can't compile against leaked types or hit `NoClassDefFoundError` at runtime.

## Test plan
- [ ] Verify `./gradlew preMerge` passes
- [ ] Confirm consumers of `updater-runtime` can reference `Platform` without adding `core-runtime` explicitly
- [ ] Confirm consumers of `system-color` get `core-runtime` transitively at runtime

