### PR TITLE
feat: add controlButtonsDirection to Jewel and Material 2 title bars

### DIFF
--- a/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelTitleBar.kt
+++ b/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelTitleBar.kt
@@ -3,6 +3,7 @@ package io.github.kdroidfilter.nucleus.window.jewel
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
 import io.github.kdroidfilter.nucleus.window.DecoratedWindowScope
 import io.github.kdroidfilter.nucleus.window.DecoratedWindowState
 import io.github.kdroidfilter.nucleus.window.TitleBar
@@ -13,6 +14,7 @@ import io.github.kdroidfilter.nucleus.window.TitleBarScope
 fun DecoratedWindowScope.JewelTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
@@ -21,6 +23,7 @@ fun DecoratedWindowScope.JewelTitleBar(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlButtonsDirection,
         backgroundContent = backgroundContent,
         content = content,
     )

--- a/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialTitleBar.kt
+++ b/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialTitleBar.kt
@@ -4,16 +4,26 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
 import io.github.kdroidfilter.nucleus.window.DecoratedWindowScope
 import io.github.kdroidfilter.nucleus.window.DecoratedWindowState
 import io.github.kdroidfilter.nucleus.window.TitleBar
 import io.github.kdroidfilter.nucleus.window.TitleBarScope
 
+/**
+ * Material 2 themed title bar.
+ *
+ * @param controlButtonsDirection Controls which side the window control buttons
+ *   (close, minimize, maximize) are placed on, independently of the title bar
+ *   content direction. Defaults to [ControlButtonsDirection.Auto].
+ * @see ControlButtonsDirection
+ */
 @Suppress("FunctionNaming")
 @Composable
 fun DecoratedWindowScope.MaterialTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
@@ -22,6 +32,7 @@ fun DecoratedWindowScope.MaterialTitleBar(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlButtonsDirection,
         backgroundContent = backgroundContent,
         content = content,
     )


### PR DESCRIPTION
## Summary
- Add `controlButtonsDirection` parameter to `JewelTitleBar` and Material 2 `MaterialTitleBar`
- Forward it to the underlying `TitleBar` composable so consumers can control window button placement independently of content layout direction
- Aligns Jewel and Material 2 APIs with Material 3, which already exposed this parameter

## Test plan
- [x] `decorated-window-jewel` compiles
- [x] `decorated-window-material2` compiles
- [x] `decorated-window-material3` compiles (unchanged, already had the param)
- [ ] Verify window control buttons respect `ControlButtonsDirection.System` in an RTL app