### PR TITLE
fix: sync control buttons layout direction with controlButtonsDirection

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
@@ -52,6 +52,14 @@ private const val GRADIENT_MIDPOINT = 0.5f
 
 val LocalContentColor = staticCompositionLocalOf { Color.Black }
 
+/**
+ * The resolved layout direction for window control buttons.
+ * Provided by [GenericTitleBarImpl] so that control button composables
+ * can apply this as [LocalLayoutDirection] around their content,
+ * independently of the app's content direction.
+ */
+val LocalControlButtonsDirection = staticCompositionLocalOf { LayoutDirection.Ltr }
+
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
 fun GenericTitleBarImpl(
@@ -104,6 +112,7 @@ fun GenericTitleBarImpl(
             content = {
                 CompositionLocalProvider(
                     LocalContentColor provides style.colors.content,
+                    LocalControlButtonsDirection provides controlButtonsDirection,
                 ) {
                     val scope = TitleBarScopeImpl(titleBarInfo.title, titleBarInfo.icon)
                     scope.content(state)

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlArea.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlArea.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -18,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
@@ -36,75 +38,77 @@ fun TitleBarScope.WindowControlArea(
     isFullscreen: Boolean = false,
     onExitFullscreen: (() -> Unit)? = null,
 ) {
-    val icons = linuxTitleBarIcons()
+    CompositionLocalProvider(LocalLayoutDirection provides LocalControlButtonsDirection.current) {
+        val icons = linuxTitleBarIcons()
 
-    // Close button (placed first with Alignment.End, so it's rightmost)
-    // On KDE, focused windows show a softer pink hover, unfocused show bright red
-    val closeHover = if (state.isActive) icons.closeHoverFocused else icons.closeHover
-    val closePressed = if (state.isActive) icons.closePressedFocused else icons.closePressed
-    ControlButton(
-        onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
-        state = state,
-        icon = icons.close,
-        iconHover = closeHover,
-        iconPressed = closePressed,
-        contentDescription = "Close",
-        style = style,
-    )
-
-    // In fullscreen: show maximize icon but click exits fullscreen
-    if (isFullscreen && onExitFullscreen != null) {
+        // Close button (placed first with Alignment.End, so it's rightmost)
+        // On KDE, focused windows show a softer pink hover, unfocused show bright red
+        val closeHover = if (state.isActive) icons.closeHoverFocused else icons.closeHover
+        val closePressed = if (state.isActive) icons.closePressedFocused else icons.closePressed
         ControlButton(
-            onClick = onExitFullscreen,
+            onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
             state = state,
-            icon = icons.maximize,
-            iconHover = icons.maximizeHover,
-            iconPressed = icons.maximizePressed,
-            contentDescription = "Exit fullscreen",
+            icon = icons.close,
+            iconHover = closeHover,
+            iconPressed = closePressed,
+            contentDescription = "Close",
             style = style,
         )
-    } else {
-        // Maximize/Restore button (only if resizable)
-        val frame = window as? Frame
-        if (frame != null && frame.isResizable) {
-            if (state.isMaximized) {
-                ControlButton(
-                    onClick = { frame.extendedState = Frame.NORMAL },
-                    state = state,
-                    icon = icons.restore,
-                    iconHover = icons.restoreHover,
-                    iconPressed = icons.restorePressed,
-                    contentDescription = "Restore",
-                    style = style,
-                )
-            } else {
-                ControlButton(
-                    onClick = { frame.extendedState = Frame.MAXIMIZED_BOTH },
-                    state = state,
-                    icon = icons.maximize,
-                    iconHover = icons.maximizeHover,
-                    iconPressed = icons.maximizePressed,
-                    contentDescription = "Maximize",
-                    style = style,
-                )
+
+        // In fullscreen: show maximize icon but click exits fullscreen
+        if (isFullscreen && onExitFullscreen != null) {
+            ControlButton(
+                onClick = onExitFullscreen,
+                state = state,
+                icon = icons.maximize,
+                iconHover = icons.maximizeHover,
+                iconPressed = icons.maximizePressed,
+                contentDescription = "Exit fullscreen",
+                style = style,
+            )
+        } else {
+            // Maximize/Restore button (only if resizable)
+            val frame = window as? Frame
+            if (frame != null && frame.isResizable) {
+                if (state.isMaximized) {
+                    ControlButton(
+                        onClick = { frame.extendedState = Frame.NORMAL },
+                        state = state,
+                        icon = icons.restore,
+                        iconHover = icons.restoreHover,
+                        iconPressed = icons.restorePressed,
+                        contentDescription = "Restore",
+                        style = style,
+                    )
+                } else {
+                    ControlButton(
+                        onClick = { frame.extendedState = Frame.MAXIMIZED_BOTH },
+                        state = state,
+                        icon = icons.maximize,
+                        iconHover = icons.maximizeHover,
+                        iconPressed = icons.maximizePressed,
+                        contentDescription = "Maximize",
+                        style = style,
+                    )
+                }
             }
         }
-    }
 
-    // Minimize button (placed last with Alignment.End, so it's leftmost)
-    ControlButton(
-        onClick = {
-            (window as? Frame)?.let {
-                it.extendedState = it.extendedState or Frame.ICONIFIED
-            }
-        },
-        state = state,
-        icon = icons.minimize,
-        iconHover = icons.minimizeHover,
-        iconPressed = icons.minimizePressed,
-        contentDescription = "Minimize",
-        style = style,
-    )
+        // Minimize button (placed last with Alignment.End, so it's leftmost)
+        ControlButton(
+            onClick = {
+                (window as? Frame)?.let {
+                    it.extendedState = it.extendedState or Frame.ICONIFIED
+                }
+            },
+            state = state,
+            icon = icons.minimize,
+            iconHover = icons.minimizeHover,
+            iconPressed = icons.minimizePressed,
+            contentDescription = "Minimize",
+            style = style,
+        )
+    }
 }
 
 /**
@@ -118,20 +122,22 @@ fun TitleBarScope.DialogCloseButton(
     state: DecoratedDialogState,
     style: TitleBarStyle,
 ) {
-    val icons = linuxTitleBarIcons()
-    val windowState = state.toDecoratedWindowState()
-    val closeHover = if (windowState.isActive) icons.closeHoverFocused else icons.closeHover
-    val closePressed = if (windowState.isActive) icons.closePressedFocused else icons.closePressed
+    CompositionLocalProvider(LocalLayoutDirection provides LocalControlButtonsDirection.current) {
+        val icons = linuxTitleBarIcons()
+        val windowState = state.toDecoratedWindowState()
+        val closeHover = if (windowState.isActive) icons.closeHoverFocused else icons.closeHover
+        val closePressed = if (windowState.isActive) icons.closePressedFocused else icons.closePressed
 
-    ControlButton(
-        onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
-        state = windowState,
-        icon = icons.close,
-        iconHover = closeHover,
-        iconPressed = closePressed,
-        contentDescription = "Close",
-        style = style,
-    )
+        ControlButton(
+            onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
+            state = windowState,
+            icon = icons.close,
+            iconHover = closeHover,
+            iconPressed = closePressed,
+            contentDescription = "Close",
+            style = style,
+        )
+    }
 }
 
 @Suppress("FunctionNaming", "LongParameterList")

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowsWindowControlArea.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowsWindowControlArea.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -20,6 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 import io.github.kdroidfilter.nucleus.window.utils.windows.windowsTitleBarIcons
@@ -56,64 +58,66 @@ fun TitleBarScope.WindowsWindowControlArea(
     isFullscreen: Boolean = false,
     onExitFullscreen: (() -> Unit)? = null,
 ) {
-    val icons = windowsTitleBarIcons()
+    CompositionLocalProvider(LocalLayoutDirection provides LocalControlButtonsDirection.current) {
+        val icons = windowsTitleBarIcons()
 
-    // Close button (placed first with Alignment.End, so it's rightmost)
-    WindowsCaptionButton(
-        onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
-        state = state,
-        style = style,
-        icon = if (state.isActive) icons.close else icons.closeInactive,
-        iconHover = icons.closeHover,
-        contentDescription = "Close",
-        isCloseButton = true,
-    )
-
-    // In fullscreen: show exit-fullscreen button instead of maximize/restore
-    if (isFullscreen && onExitFullscreen != null) {
+        // Close button (placed first with Alignment.End, so it's rightmost)
         WindowsCaptionButton(
-            onClick = onExitFullscreen,
+            onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
             state = state,
             style = style,
-            icon = if (state.isActive) icons.exitFullscreen else icons.exitFullscreenInactive,
-            contentDescription = "Exit fullscreen",
+            icon = if (state.isActive) icons.close else icons.closeInactive,
+            iconHover = icons.closeHover,
+            contentDescription = "Close",
+            isCloseButton = true,
         )
-    } else {
-        // Maximize/Restore button (only if resizable)
-        val frame = window as? Frame
-        if (frame != null && frame.isResizable) {
-            if (state.isMaximized) {
-                WindowsCaptionButton(
-                    onClick = { frame.extendedState = Frame.NORMAL },
-                    state = state,
-                    style = style,
-                    icon = if (state.isActive) icons.restore else icons.restoreInactive,
-                    contentDescription = "Restore",
-                )
-            } else {
-                WindowsCaptionButton(
-                    onClick = { frame.extendedState = Frame.MAXIMIZED_BOTH },
-                    state = state,
-                    style = style,
-                    icon = if (state.isActive) icons.maximize else icons.maximizeInactive,
-                    contentDescription = "Maximize",
-                )
+
+        // In fullscreen: show exit-fullscreen button instead of maximize/restore
+        if (isFullscreen && onExitFullscreen != null) {
+            WindowsCaptionButton(
+                onClick = onExitFullscreen,
+                state = state,
+                style = style,
+                icon = if (state.isActive) icons.exitFullscreen else icons.exitFullscreenInactive,
+                contentDescription = "Exit fullscreen",
+            )
+        } else {
+            // Maximize/Restore button (only if resizable)
+            val frame = window as? Frame
+            if (frame != null && frame.isResizable) {
+                if (state.isMaximized) {
+                    WindowsCaptionButton(
+                        onClick = { frame.extendedState = Frame.NORMAL },
+                        state = state,
+                        style = style,
+                        icon = if (state.isActive) icons.restore else icons.restoreInactive,
+                        contentDescription = "Restore",
+                    )
+                } else {
+                    WindowsCaptionButton(
+                        onClick = { frame.extendedState = Frame.MAXIMIZED_BOTH },
+                        state = state,
+                        style = style,
+                        icon = if (state.isActive) icons.maximize else icons.maximizeInactive,
+                        contentDescription = "Maximize",
+                    )
+                }
             }
         }
-    }
 
-    // Minimize button
-    WindowsCaptionButton(
-        onClick = {
-            (window as? Frame)?.let {
-                it.extendedState = it.extendedState or Frame.ICONIFIED
-            }
-        },
-        state = state,
-        style = style,
-        icon = if (state.isActive) icons.minimize else icons.minimizeInactive,
-        contentDescription = "Minimize",
-    )
+        // Minimize button
+        WindowsCaptionButton(
+            onClick = {
+                (window as? Frame)?.let {
+                    it.extendedState = it.extendedState or Frame.ICONIFIED
+                }
+            },
+            state = state,
+            style = style,
+            icon = if (state.isActive) icons.minimize else icons.minimizeInactive,
+            contentDescription = "Minimize",
+        )
+    }
 }
 
 /**
@@ -127,18 +131,20 @@ fun TitleBarScope.WindowsDialogCloseButton(
     state: DecoratedDialogState,
     style: TitleBarStyle,
 ) {
-    val icons = windowsTitleBarIcons()
-    val windowState = state.toDecoratedWindowState()
+    CompositionLocalProvider(LocalLayoutDirection provides LocalControlButtonsDirection.current) {
+        val icons = windowsTitleBarIcons()
+        val windowState = state.toDecoratedWindowState()
 
-    WindowsCaptionButton(
-        onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
-        state = windowState,
-        style = style,
-        icon = if (windowState.isActive) icons.close else icons.closeInactive,
-        iconHover = icons.closeHover,
-        contentDescription = "Close",
-        isCloseButton = true,
-    )
+        WindowsCaptionButton(
+            onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
+            state = windowState,
+            style = style,
+            icon = if (windowState.isActive) icons.close else icons.closeInactive,
+            iconHover = icons.closeHover,
+            contentDescription = "Close",
+            isCloseButton = true,
+        )
+    }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)


### PR DESCRIPTION
## Summary
- Add `LocalControlButtonsDirection` composition local, provided by `GenericTitleBarImpl` with the resolved `controlButtonsDirection`
- Wrap `WindowControlArea` (Linux), `WindowsWindowControlArea` (Windows), `DialogCloseButton`, and `WindowsDialogCloseButton` with `CompositionLocalProvider(LocalLayoutDirection provides LocalControlButtonsDirection.current)`
- Fixes RTL apps where control buttons inherited the app's RTL direction instead of following the configured `controlButtonsDirection`

## Test plan
- [x] `decorated-window-core` compiles
- [x] `decorated-window-jni` compiles
- [x] `decorated-window-jbr` compiles
- [x] detekt + ktlint pass on `decorated-window-core`
- [ ] Verify in an RTL app with `ControlButtonsDirection.System` that buttons render correctly