### PR TITLE
fix: place control buttons before content in title bar layout

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
@@ -229,10 +229,12 @@ class TitleBarMeasurePolicy(
             var leftUsed = leftInset
             var rightUsed = rightInset
 
-            // Start items: leading edge of the content direction
-            placeableGroups[Alignment.Start]?.forEach { (_, placeable) ->
+            // End items (control buttons) first — they claim the extreme edge
+            // before Start items, so they always stay at their designated side
+            // even when content and controls share the same edge.
+            placeableGroups[Alignment.End]?.forEach { (_, placeable) ->
                 val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
-                if (contentIsRtl) {
+                if (controlsOnRight) {
                     placeable.place(boxWidth - rightUsed - placeable.width, y)
                     rightUsed += placeable.width
                 } else {
@@ -241,10 +243,10 @@ class TitleBarMeasurePolicy(
                 }
             }
 
-            // End items (control buttons): trailing edge of the control buttons direction
-            placeableGroups[Alignment.End]?.forEach { (_, placeable) ->
+            // Start items: leading edge of the content direction
+            placeableGroups[Alignment.Start]?.forEach { (_, placeable) ->
                 val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
-                if (controlsOnRight) {
+                if (contentIsRtl) {
                     placeable.place(boxWidth - rightUsed - placeable.width, y)
                     rightUsed += placeable.width
                 } else {


### PR DESCRIPTION
## Summary
- Place End-aligned items (control buttons) **before** Start-aligned items in `TitleBarMeasurePolicy`
- Fixes buttons being pushed inward when content and controls share the same edge (e.g. RTL app with LTR control buttons, or LTR app with RTL controls)
- Affects all platforms (Windows, Linux, macOS) via the shared `decorated-window-core` module

## Test plan
- [x] `decorated-window-core` compiles
- [x] `decorated-window-jni` compiles
- [x] `decorated-window-jbr` compiles
- [x] detekt + ktlint pass
- [ ] Verify in RTL app with `ControlButtonsDirection.System` that buttons are on the correct side