### PR TITLE
feat: add controlButtonsDirection to DialogTitleBar

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBarImpl.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBarImpl.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 
@@ -14,6 +16,7 @@ fun DecoratedDialogScope.DialogTitleBarImpl(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: LayoutDirection = LocalLayoutDirection.current,
     applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
     onPlace: (() -> Unit)? = null,
     backgroundContent: @Composable () -> Unit = {},
@@ -26,6 +29,7 @@ fun DecoratedDialogScope.DialogTitleBarImpl(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlButtonsDirection,
         applyTitleBar = applyTitleBar,
         onPlace = onPlace,
         backgroundContent = backgroundContent,

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
@@ -22,23 +22,26 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
     val dialogState = state
 
     DialogTitleBarImpl(
-        modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
-            if (
-                this.currentEvent.button == PointerButton.Primary &&
-                this.currentEvent.changes.any { changed -> !changed.isConsumed }
-            ) {
-                JBR.getWindowMove()?.startMovingTogetherWithMouse(window, MouseEvent.BUTTON1)
-            }
-        },
-        gradientStartColor,
-        linuxStyle,
-        { _, _ ->
+        modifier =
+            modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+                if (
+                    this.currentEvent.button == PointerButton.Primary &&
+                    this.currentEvent.changes.any { changed -> !changed.isConsumed }
+                ) {
+                    JBR.getWindowMove()?.startMovingTogetherWithMouse(window, MouseEvent.BUTTON1)
+                }
+            },
+        gradientStartColor = gradientStartColor,
+        style = linuxStyle,
+        controlButtonsDirection = controlButtonsDirection.resolve(),
+        applyTitleBar = { _, _ ->
             if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
                 PaddingValues(end = 4.dp)
             } else {

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
@@ -19,18 +18,21 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
 
     WindowMouseEventEffect(titleBar)
 
-    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    val controlDir = controlButtonsDirection.resolve()
+    val isRtl = controlDir == LayoutDirection.Rtl
 
     DialogTitleBarImpl(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlDir,
         applyTitleBar = { height, _ ->
             titleBar.putProperty("controls.rtl", isRtl)
             titleBar.height = height.value

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
@@ -22,19 +21,21 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
 
     WindowMouseEventEffect(titleBar)
 
-    val layoutDirection = LocalLayoutDirection.current
-    val isRtl = layoutDirection == LayoutDirection.Rtl
+    val controlDir = controlButtonsDirection.resolve()
+    val isRtl = controlDir == LayoutDirection.Rtl
 
     DialogTitleBarImpl(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlDir,
         applyTitleBar = { height, _ ->
             titleBar.putProperty("controls.rtl", isRtl)
             titleBar.height = height.value

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
@@ -16,6 +16,7 @@ fun DecoratedDialogScope.DialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val dialogTitleBarInfo = LocalDialogTitleBarInfo.current
@@ -26,9 +27,12 @@ fun DecoratedDialogScope.DialogTitleBar(
         LocalTitleBarInfo provides titleBarInfo,
     ) {
         when (Platform.Current) {
-            Platform.Linux -> LinuxDialogTitleBar(modifier, gradientStartColor, style, content)
-            Platform.Windows -> WindowsDialogTitleBar(modifier, gradientStartColor, style, content)
-            Platform.MacOS -> MacOSDialogTitleBar(modifier, gradientStartColor, style, content)
+            Platform.Linux ->
+                LinuxDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+            Platform.Windows ->
+                WindowsDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+            Platform.MacOS ->
+                MacOSDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
             Platform.Unknown ->
                 error("DialogTitleBar is not supported on this platform(${System.getProperty("os.name")})")
         }

--- a/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDialogTitleBar.kt
+++ b/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDialogTitleBar.kt
@@ -3,6 +3,7 @@ package io.github.kdroidfilter.nucleus.window.jewel
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
 import io.github.kdroidfilter.nucleus.window.DecoratedDialogScope
 import io.github.kdroidfilter.nucleus.window.DecoratedDialogState
 import io.github.kdroidfilter.nucleus.window.DialogTitleBar
@@ -13,6 +14,7 @@ import io.github.kdroidfilter.nucleus.window.TitleBarScope
 fun DecoratedDialogScope.JewelDialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val style = rememberJewelTitleBarStyle()
@@ -20,6 +22,7 @@ fun DecoratedDialogScope.JewelDialogTitleBar(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlButtonsDirection,
         content = content,
     )
 }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
@@ -24,12 +24,13 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     if (JniLinuxWindowBridge.isLoaded) {
-        NativeLinuxDialogTitleBar(modifier, gradientStartColor, style, content)
+        NativeLinuxDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
     } else {
-        FallbackLinuxDialogTitleBar(modifier, gradientStartColor, style, content)
+        FallbackLinuxDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
     }
 }
 
@@ -42,6 +43,7 @@ private fun DecoratedDialogScope.NativeLinuxDialogTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
+    controlButtonsDirection: ControlButtonsDirection,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
@@ -51,6 +53,7 @@ private fun DecoratedDialogScope.NativeLinuxDialogTitleBar(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = linuxStyle,
+        controlButtonsDirection = controlButtonsDirection.resolve(),
         applyTitleBar = { _, _ ->
             if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
                 PaddingValues(end = 4.dp)
@@ -96,6 +99,7 @@ private fun DecoratedDialogScope.FallbackLinuxDialogTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
+    controlButtonsDirection: ControlButtonsDirection,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
@@ -115,6 +119,7 @@ private fun DecoratedDialogScope.FallbackLinuxDialogTitleBar(
             },
         gradientStartColor = gradientStartColor,
         style = linuxStyle,
+        controlButtonsDirection = controlButtonsDirection.resolve(),
         applyTitleBar = { _, _ ->
             if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
                 PaddingValues(end = 4.dp)

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
@@ -19,6 +19,7 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     DisposableEffect(window) {
@@ -32,6 +33,7 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
         modifier = modifier.titleBarHitTestHandler(window),
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlButtonsDirection.resolve(),
         applyTitleBar = { height, _ ->
             JniMacWindowUtil.applyWindowProperties(window)
 

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
@@ -19,6 +19,7 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     if (JniWindowsDecorationBridge.isLoaded) {
@@ -33,6 +34,7 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlButtonsDirection.resolve(),
         applyTitleBar = { _, _ -> PaddingValues(0.dp) },
         backgroundContent = {
             Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
@@ -16,6 +16,7 @@ fun DecoratedDialogScope.DialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val dialogTitleBarInfo = LocalDialogTitleBarInfo.current
@@ -26,9 +27,12 @@ fun DecoratedDialogScope.DialogTitleBar(
         LocalTitleBarInfo provides titleBarInfo,
     ) {
         when (Platform.Current) {
-            Platform.Linux -> LinuxDialogTitleBar(modifier, gradientStartColor, style, content)
-            Platform.Windows -> WindowsDialogTitleBar(modifier, gradientStartColor, style, content)
-            Platform.MacOS -> MacOSDialogTitleBar(modifier, gradientStartColor, style, content)
+            Platform.Linux ->
+                LinuxDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+            Platform.Windows ->
+                WindowsDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+            Platform.MacOS ->
+                MacOSDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
             Platform.Unknown ->
                 error("DialogTitleBar is not supported on this platform(${System.getProperty("os.name")})")
         }

--- a/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialDialogTitleBar.kt
+++ b/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialDialogTitleBar.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
 import io.github.kdroidfilter.nucleus.window.DecoratedDialogScope
 import io.github.kdroidfilter.nucleus.window.DecoratedDialogState
 import io.github.kdroidfilter.nucleus.window.DialogTitleBar
@@ -14,6 +15,7 @@ import io.github.kdroidfilter.nucleus.window.TitleBarScope
 fun DecoratedDialogScope.MaterialDialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val style = rememberMaterialTitleBarStyle(MaterialTheme.colors)
@@ -21,6 +23,7 @@ fun DecoratedDialogScope.MaterialDialogTitleBar(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlButtonsDirection,
         content = content,
     )
 }

--- a/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialDialogTitleBar.kt
+++ b/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialDialogTitleBar.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
 import io.github.kdroidfilter.nucleus.window.DecoratedDialogScope
 import io.github.kdroidfilter.nucleus.window.DecoratedDialogState
 import io.github.kdroidfilter.nucleus.window.DialogTitleBar
@@ -14,6 +15,7 @@ import io.github.kdroidfilter.nucleus.window.TitleBarScope
 fun DecoratedDialogScope.MaterialDialogTitleBar(
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val style = rememberMaterialTitleBarStyle(MaterialTheme.colorScheme)
@@ -21,6 +23,7 @@ fun DecoratedDialogScope.MaterialDialogTitleBar(
         modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
+        controlButtonsDirection = controlButtonsDirection,
         content = content,
     )
 }


### PR DESCRIPTION
## Summary
- Add `controlButtonsDirection` parameter to `DialogTitleBar` and propagate through the entire chain
- **Core**: `DialogTitleBarImpl` forwards to `GenericTitleBarImpl`
- **JNI**: `DialogTitleBar`, `LinuxDialogTitleBar`, `WindowsDialogTitleBar`, `MacOSDialogTitleBar`
- **JBR**: `DialogTitleBar`, `LinuxDialogTitleBar`, `WindowsDialogTitleBar`, `MacOSDialogTitleBar`
- **Wrappers**: `JewelDialogTitleBar`, Material 2 `MaterialDialogTitleBar`, Material 3 `MaterialDialogTitleBar`
- Aligns dialog title bars with the existing `TitleBar` API

## Test plan
- [x] All decorated-window modules compile
- [x] detekt + ktlint pass
- [x] preMerge passes (only pre-existing `:example` JVM target issue)
- [ ] Verify dialog close button respects `ControlButtonsDirection` in an RTL app