### PR TITLE
feat: add SystemNative control buttons direction

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/ControlButtonsDirection.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/ControlButtonsDirection.kt
@@ -53,6 +53,7 @@ internal fun nativeSystemLayoutDirection(): LayoutDirection {
     val language = System.getProperty("user.language") ?: return LayoutDirection.Ltr
     val country = System.getProperty("user.country").orEmpty()
     val variant = System.getProperty("user.variant").orEmpty()
+
     @Suppress("DEPRECATION")
     val nativeLocale = java.util.Locale(language, country, variant)
     return if (ComponentOrientation.getOrientation(nativeLocale).isLeftToRight) {


### PR DESCRIPTION
## Summary
- Add a new `SystemNative` enum value to `ControlButtonsDirection` that reads the native OS locale from JVM startup system properties (`user.language`, `user.country`, `user.variant`)
- Unlike `System` which uses `Locale.getDefault()`, `SystemNative` is immune to runtime `Locale.setDefault()` overrides and always reflects the real OS configuration
- Add `nativeSystemLayoutDirection()` internal helper reusable across the module

## Test plan
- [ ] Verify `SystemNative` returns correct direction on LTR system
- [ ] Verify `SystemNative` still returns OS direction after `Locale.setDefault()` override to RTL locale
- [ ] Verify existing `System` behavior is unchanged