### PR TITLE
fix: override state.size before Window for maximized start

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindowCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindowCore.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.offset
 import androidx.compose.ui.window.FrameWindowScope
 import androidx.compose.ui.window.WindowPlacement
-import androidx.compose.ui.window.WindowState
 import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.internal.insideBorder
 import io.github.kdroidfilter.nucleus.window.styling.LocalDecoratedWindowStyle
@@ -409,38 +408,6 @@ fun FrameWindowScope.DecoratedWindowBody(
             modifier = undecoratedWindowBorder,
             measurePolicy = DecoratedWindowMeasurePolicy,
         )
-    }
-}
-
-/**
- * Pre-sizes the AWT window to the screen work area when [state] has
- * [WindowPlacement.Maximized]. This ensures the first Compose/Skia frame
- * renders at the maximized dimensions, preventing the brief flash of a
- * default-sized window before the window manager processes the maximize.
- *
- * Must be called inside a [FrameWindowScope] (i.e. inside a `Window` block).
- */
-@Suppress("FunctionNaming")
-@Composable
-fun FrameWindowScope.PreSizeIfMaximized(state: WindowState) {
-    DisposableEffect(window) {
-        if (state.placement == WindowPlacement.Maximized) {
-            val gc = window.graphicsConfiguration
-            if (gc != null) {
-                val sb = gc.bounds
-                val insets =
-                    java.awt.Toolkit
-                        .getDefaultToolkit()
-                        .getScreenInsets(gc)
-                window.setBounds(
-                    sb.x + insets.left,
-                    sb.y + insets.top,
-                    sb.width - insets.left - insets.right,
-                    sb.height - insets.top - insets.bottom,
-                )
-            }
-        }
-        onDispose { }
     }
 }
 

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
@@ -38,6 +38,8 @@ import io.github.kdroidfilter.nucleus.window.utils.linux.JniLinuxWindowBridge
 import io.github.kdroidfilter.nucleus.window.utils.windows.JniWindowsDecorationBridge
 import io.github.kdroidfilter.nucleus.window.utils.windows.JniWindowsWindowUtil
 import java.awt.Frame
+import java.awt.GraphicsEnvironment
+import java.awt.Toolkit
 
 /**
  * Composition local that indicates whether the window is currently in
@@ -100,6 +102,27 @@ fun DecoratedWindow(
             state
         }
 
+    // ── First-frame maximized fix ──────────────────────────────────────
+    // When starting with WindowPlacement.Maximized, Compose's Window
+    // creates the AWT window at state.size (e.g. 800×600) and renders
+    // the first Skia frame at that size before the WM processes the
+    // maximize. Override state.size with the screen work area so the
+    // first frame matches the maximized dimensions.
+    remember(state) {
+        if (state.placement == WindowPlacement.Maximized) {
+            val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
+            val gc = ge.defaultScreenDevice.defaultConfiguration
+            val bounds = gc.bounds
+            val insets = Toolkit.getDefaultToolkit().getScreenInsets(gc)
+            val scale = gc.defaultTransform.scaleX.toFloat()
+            state.size =
+                DpSize(
+                    ((bounds.width - insets.left - insets.right) / scale).dp,
+                    ((bounds.height - insets.top - insets.bottom) / scale).dp,
+                )
+        }
+    }
+
     Window(
         onCloseRequest,
         windowState,
@@ -115,12 +138,6 @@ fun DecoratedWindow(
         onPreviewKeyEvent,
         onKeyEvent,
     ) {
-        // When starting maximized, pre-size the AWT window to the screen work
-        // area so the first Compose/Skia frame renders at the correct dimensions.
-        // Without this, the window briefly flashes at its default size before the
-        // WM processes the maximize.
-        PreSizeIfMaximized(state)
-
         if (useNativeFullscreen) {
             NativeFullscreenEffect(state, windowState)
             if (Platform.Current == Platform.Windows) {


### PR DESCRIPTION
## Summary
- Move the first-frame maximized flash fix from `PreSizeIfMaximized` (a `DisposableEffect` inside `Window`, which ran too late) to a `remember` block **before** `Window`, overriding `state.size` with the screen work area (bounds minus taskbar insets, scaled for DPI)
- Remove the now-unused `PreSizeIfMaximized` composable from `decorated-window-core`

## Test plan
- [x] Open an app with `WindowPlacement.Maximized` — verify no flash of a smaller window on first frame
- [x] Verify maximized window dimensions match the screen work area
- [ ] Test on Windows with different DPI scaling (100%, 125%, 150%)
- [x] Verify non-maximized windows are unaffected