### PR TITLE
feat: add runGraalvmNative task and remove release build type

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,8 @@
 ### New Features
 
 - **Automatic resource inclusion for GraalVM native-image** — `graalvm-runtime` now ships a `native-image.properties` that auto-includes all `.svg`, `.ttf`, `.otf` resources, `nucleus/native/*` JNI libraries, and `META-INF/services/*` descriptors via glob patterns. Projects no longer need to run the tracing agent just to discover icon and font resources — they are embedded in the native binary automatically. The tracing agent is still required for reflection, JNI, resource bundles, and non-standard resources. See [Automatic Resource Inclusion](graalvm-native-image.md#automatic-resource-inclusion).
+- **`runGraalvmNative` task** — New Gradle task that builds and runs the GraalVM native image directly, without packaging into an installer. Useful for quick iteration during development.
+- **Remove release build type for GraalVM** — GraalVM native-image tasks no longer have `release` variants (`packageReleaseGraalvmNative`, etc.). ProGuard is redundant with native-image's closed-world dead code elimination and harmful because it can rename classes referenced in `reachability-metadata.json`. See [No Release Build Type](graalvm-native-image.md#no-release-build-type).
 
 ---
 

--- a/docs/graalvm-native-image.md
+++ b/docs/graalvm-native-image.md
@@ -275,6 +275,7 @@ The [`decorated-window-jni`](runtime/decorated-window.md) module was specificall
 |------|-------------|
 | `runWithNativeAgent` | Run the app with the GraalVM tracing agent to collect reflection metadata |
 | `packageGraalvmNative` | Compile and package the application as a native binary |
+| `runGraalvmNative` | Build and run the native image directly |
 | `packageGraalvmDeb` | Package the native image as a `.deb` installer (Linux) |
 | `packageGraalvmDmg` | Package the native image as a `.dmg` installer (macOS) |
 | `packageGraalvmNsis` | Package the native image as an NSIS `.exe` installer (Windows) |
@@ -285,6 +286,9 @@ The [`decorated-window-jni`](runtime/decorated-window.md) module was specificall
 
 # Build the raw native image
 ./gradlew packageGraalvmNative
+
+# Build and run the native image
+./gradlew runGraalvmNative
 
 # Build platform-specific installers (requires Node.js for electron-builder)
 ./gradlew packageGraalvmDeb    # Linux
@@ -385,6 +389,15 @@ jobs:
 ```
 
 See [CI/CD](ci-cd.md#graalvm-native-image-release) for the full release workflow with publishing to GitHub Releases.
+
+## No Release Build Type
+
+Unlike standard JVM builds, GraalVM native-image builds **do not have a release variant**. There is no `packageReleaseGraalvmNative` or `runReleaseGraalvmNative` task. This is intentional:
+
+- **ProGuard is redundant** — GraalVM native-image already performs closed-world dead code elimination at compile time. Running ProGuard beforehand provides no additional size benefit.
+- **ProGuard is harmful** — ProGuard can rename or remove classes that are referenced in `reachability-metadata.json`, causing runtime crashes. Maintaining both ProGuard keep rules and reflection metadata is error-prone.
+
+All GraalVM tasks use the default (non-ProGuard) build type. Use `-Os` in `buildArgs` for size optimization.
 
 ## Best Practices
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -153,6 +153,7 @@ nucleus.application {
 |------|-------------|
 | `runWithNativeAgent` | Run with GraalVM tracing agent to collect reflection metadata |
 | `packageGraalvmNative` | Compile as native binary |
+| `runGraalvmNative` | Build and run the native image directly |
 | `packageGraalvmDeb` / `packageGraalvmDmg` / `packageGraalvmNsis` | Package native image as installer |
 
 ### Utility

--- a/graalvm-runtime/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.graalvm-runtime/native-image.properties
+++ b/graalvm-runtime/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.graalvm-runtime/native-image.properties
@@ -1,3 +1,4 @@
-Args = -H:IncludeResources=.*\\.(svg|ttf|otf) \
+Args = -H:+UnlockExperimentalVMOptions \
+       -H:IncludeResources=.*\\.(svg|ttf|otf) \
        -H:IncludeResources=nucleus/native/.* \
        -H:IncludeResources=META-INF/services/.*

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureDesktop.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureDesktop.kt
@@ -24,9 +24,6 @@ internal fun configureDesktop(
                 .getOrElse(false)
         ) {
             appData.configureGraalvmApplication()
-            appData
-                .copy(buildType = appInternal.data.buildTypes.release)
-                .configureGraalvmApplication()
         }
     }
 

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
@@ -449,6 +449,44 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                 )
         }
 
+    // ── Run the native image ──
+
+    tasks.register<Exec>(
+        taskNameAction = "run",
+        taskNameObject = "graalvmNative",
+    ) {
+        description = "Build and run the GraalVM native image"
+        dependsOn(packageGraalvmNative)
+
+        val binaryFile =
+            when (currentOS) {
+                OS.MacOS -> {
+                    val dir =
+                        appTmpDir.map {
+                            it.dir("graalvm/output/${packageNameProvider.get()}.app/Contents/MacOS")
+                        }
+                    dir.map { it.file(imageName.get()) }
+                }
+                OS.Windows -> {
+                    val dir =
+                        appTmpDir.map {
+                            it.dir("graalvm/output/${packageNameProvider.get()}")
+                        }
+                    dir.map { it.file(binaryName.get()) }
+                }
+                OS.Linux -> {
+                    val dir =
+                        appTmpDir.map {
+                            it.dir("graalvm/output/${packageNameProvider.get()}")
+                        }
+                    dir.map { it.file(imageName.get()) }
+                }
+            }
+
+        executable = binaryFile.get().asFile.absolutePath
+        args = app.args
+    }
+
     // ── Electron-builder integration ──
 
     configureGraalvmElectronBuilderPackaging(packageGraalvmNative, unpackDefaultResources, imageName)


### PR DESCRIPTION
## Summary

- **`runGraalvmNative` task** — builds and runs the GraalVM native image directly, without packaging into an installer. Useful for quick iteration during development.
- **Remove release build type for GraalVM** — removes all `releaseGraalvm*` task variants. ProGuard is redundant (native-image does its own dead code elimination) and harmful (renames classes referenced in `reachability-metadata.json`).
- **Unlock experimental VM options** — adds `-H:+UnlockExperimentalVMOptions` to `native-image.properties` to suppress warnings for `-H:IncludeResources` patterns.

## Test plan

- [x] `preMerge` passes (ktlint, detekt, compile)
- [ ] Run `./gradlew runGraalvmNative` on a sample project with GraalVM installed
- [ ] Verify `packageReleaseGraalvmNative` no longer exists
- [ ] Verify no experimental option warnings during native-image build