### PR TITLE
feat: add jdk.accessibility and java.net.http to default jlink modules

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -85,8 +85,6 @@ nucleus.application {
     }
 
     nativeDistributions {
-        modules("jdk.accessibility", "java.net.http")
-
         targetFormats(*TargetFormat.entries.toTypedArray())
         appResourcesRootDir.set(project.layout.projectDirectory.dir("resources"))
 

--- a/jewel-sample/build.gradle.kts
+++ b/jewel-sample/build.gradle.kts
@@ -126,7 +126,6 @@ nucleus.application {
     }
 
     nativeDistributions {
-        modules("jdk.accessibility", "java.net.http")
         compressionLevel = CompressionLevel.Maximum
         targetFormats(TargetFormat.Dmg, TargetFormat.Nsis, TargetFormat.Deb)
 

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/JvmApplicationDistributions.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/JvmApplicationDistributions.kt
@@ -15,6 +15,8 @@ internal val DEFAULT_RUNTIME_MODULES =
         "java.base",
         "java.desktop",
         "java.logging",
+        "java.net.http",
+        "jdk.accessibility",
         "jdk.crypto.ec",
     )
 


### PR DESCRIPTION
## Summary
- Add `jdk.accessibility` and `java.net.http` to `DEFAULT_RUNTIME_MODULES` so all Nucleus consumers get them out of the box
- Remove now-redundant `modules()` calls from `example` and `jewel-sample` build scripts

## Test plan
- [ ] Verify `./gradlew preMerge` passes
- [ ] Package a sample app and confirm both modules are present in the runtime image