### PR TITLE
fix: eliminate resize flash on DecoratedDialog (Windows)

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedDialogCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedDialogCore.kt
@@ -235,17 +235,45 @@ fun DialogWindowScope.DecoratedDialogBody(
 
     // Sync the AWT window background with the title bar color so that the
     // native window surface matches during resize (avoids white flash).
+    // On Windows, Skiko's ContextHandler.draw() clears to Color.WHITE when
+    // SkiaLayer.transparency == false (the default). For dark themes we call
+    // setTransparency(true) so it clears to TRANSPARENT instead, which renders
+    // as opaque black on the DirectX surface (DXGI_ALPHA_MODE_IGNORE).
+    val isWindows = remember { System.getProperty("os.name").startsWith("Windows", ignoreCase = true) }
     val titleBarBackground = LocalTitleBarStyle.current.colors.background
     LaunchedEffect(window, titleBarBackground) {
         val awtColor = java.awt.Color(titleBarBackground.toArgb(), true)
+        val isDark =
+            titleBarBackground.red * 0.299f +
+                titleBarBackground.green * 0.587f +
+                titleBarBackground.blue * 0.114f < 0.5f
 
         fun applyRecursive(c: java.awt.Component) {
             c.background = awtColor
+            // [Skiko #1141] Remove this once stable Compose uses Skiko with
+            //  https://github.com/JetBrains/skiko/pull/1141 —
+            //  ContextHandler.draw() always clears to TRANSPARENT now and
+            //  SkiaLayer.update() fills with the AWT background color instead.
+            // Windows only: set SkiaLayer transparency to match the theme so
+            // Skiko clears to TRANSPARENT (opaque black) instead of WHITE.
+            // NoSuchMethodException just means this component is not SkiaLayer.
+            if (isWindows) {
+                try {
+                    c.javaClass
+                        .getMethod("setTransparency", Boolean::class.javaPrimitiveType)
+                        .invoke(c, isDark)
+                } catch (_: NoSuchMethodException) {
+                    // Not SkiaLayer
+                } catch (_: Exception) {
+                    // Ignore other reflection errors
+                }
+            }
             if (c is java.awt.Container) {
                 c.components.forEach { applyRecursive(it) }
             }
         }
         applyRecursive(window)
+        javax.swing.SwingUtilities.invokeLater { applyRecursive(window) }
     }
 
     CompositionLocalProvider(LocalDialogTitleBarInfo provides DialogTitleBarInfo(title, icon)) {

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
@@ -26,7 +28,18 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
         DisposableEffect(window) {
             val hwnd = JniWindowsWindowUtil.getHwnd(window)
             if (hwnd != 0L) JniWindowsDecorationBridge.nativeApplyDialogStyle(hwnd)
-            onDispose { }
+            onDispose {
+                val h = JniWindowsWindowUtil.getHwnd(window)
+                if (h != 0L) JniWindowsDecorationBridge.nativeUninstallDecoration(h)
+            }
+        }
+
+        val titleBarBackground = style.colors.background
+        LaunchedEffect(window, titleBarBackground) {
+            val hwnd = JniWindowsWindowUtil.getHwnd(window)
+            if (hwnd != 0L) {
+                JniWindowsDecorationBridge.nativeSetBackgroundColor(hwnd, titleBarBackground.toArgb())
+            }
         }
     }
 

--- a/decorated-window-jni/src/main/native/windows/nucleus_windows_decoration.c
+++ b/decorated-window-jni/src/main/native/windows/nucleus_windows_decoration.c
@@ -751,10 +751,53 @@ Java_io_github_kdroidfilter_nucleus_window_utils_windows_JniWindowsDecorationBri
     return hwnd;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Lightweight WndProc for dialogs: only handles WM_ERASEBKGND and    */
+/*  WM_WINDOWPOSCHANGING to prevent resize flash.                      */
+/* ------------------------------------------------------------------ */
+static LRESULT CALLBACK dialogDecoWndProc(
+    HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    DecoState *state = getState(hwnd);
+    if (!state) return DefWindowProcW(hwnd, msg, wParam, lParam);
+
+    switch (msg) {
+
+    case WM_ERASEBKGND: {
+        HDC hdc = (HDC)wParam;
+        RECT rc;
+        GetClientRect(hwnd, &rc);
+        HBRUSH brush = CreateSolidBrush(state->bgColor);
+        FillRect(hdc, &rc, brush);
+        DeleteObject(brush);
+        return 1;
+    }
+
+    case WM_WINDOWPOSCHANGING: {
+        WINDOWPOS *wp = (WINDOWPOS *)lParam;
+        wp->flags |= SWP_NOCOPYBITS;
+        break;
+    }
+
+    case WM_NCDESTROY: {
+        WNDPROC origProc = state->originalWndProc;
+        RemovePropW(hwnd, PROP_NAME);
+        HeapFree(GetProcessHeap(), 0, state);
+        SetWindowLongPtrW(hwnd, GWLP_WNDPROC, (LONG_PTR)origProc);
+        return CallWindowProcW(origProc, hwnd, msg, wParam, lParam);
+    }
+
+    }
+
+    return CallWindowProcW(state->originalWndProc, hwnd, msg, wParam, lParam);
+}
+
 /* -------------------------------------------------------------- */
 /*  nativeApplyDialogStyle(long hwnd)                              */
 /*  Applies rounded corners + DWM shadow to an undecorated popup   */
 /*  dialog window (WS_POPUP without WS_CAPTION).                   */
+/*  Also subclasses the WndProc to handle WM_ERASEBKGND and        */
+/*  WM_WINDOWPOSCHANGING (SWP_NOCOPYBITS) to prevent resize flash. */
 /*  DWMWA_WINDOW_CORNER_PREFERENCE (33) + DWMWCP_ROUND (2) are    */
 /*  Windows 11 22000+ only; silently ignored on older Windows.     */
 /* -------------------------------------------------------------- */
@@ -764,6 +807,21 @@ Java_io_github_kdroidfilter_nucleus_window_utils_windows_JniWindowsDecorationBri
 {
     HWND hwnd = (HWND)(uintptr_t)hwndLong;
     if (!hwnd || !IsWindow(hwnd)) return;
+
+    /* Idempotent: if already installed, nothing to do */
+    if (getState(hwnd)) return;
+
+    /* Allocate per-HWND state for WM_ERASEBKGND background fill */
+    DecoState *state = (DecoState *)HeapAlloc(
+        GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(DecoState));
+    if (!state) return;
+
+    SetPropW(hwnd, PROP_NAME, (HANDLE)state);
+
+    /* Subclass with lightweight dialog WndProc */
+    LONG_PTR prevWndProc = SetWindowLongPtrW(
+        hwnd, GWLP_WNDPROC, (LONG_PTR)dialogDecoWndProc);
+    state->originalWndProc = (WNDPROC)prevWndProc;
 
     /* Request rounded corners (Windows 11+, silently ignored on older) */
     DWORD preference = 2; /* DWMWCP_ROUND */


### PR DESCRIPTION
## Summary
- Add lightweight `dialogDecoWndProc` in JNI native code that handles `WM_ERASEBKGND` (custom brush fill) and `WM_WINDOWPOSCHANGING` (`SWP_NOCOPYBITS`) to prevent white flash during dialog resize
- `nativeApplyDialogStyle` now installs a WndProc subclass with per-HWND `DecoState`, enabling `nativeSetBackgroundColor` for dialogs
- Sync native background fill color from title bar style in `DialogTitleBar.Windows.kt` with proper cleanup via `nativeUninstallDecoration`
- Port `setTransparency` Skiko workaround from `DecoratedWindowCore` to `DecoratedDialogCore` so SkiaLayer clears to `TRANSPARENT` in dark mode instead of `WHITE`

## Test plan
- [ ] Open a DecoratedDialog in dark theme on Windows, resize → no white flash on edges
- [ ] Open a DecoratedDialog in light theme on Windows, resize → no visual artifacts
- [ ] Close and reopen the dialog → WndProc cleanup works correctly
- [ ] Verify no regression on DecoratedWindow resize behavior
- [ ] Verify Linux/macOS are unaffected (Windows-only code paths)