### PR TITLE
fix: set executableName for JVM electron-builder MSI packaging

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -728,7 +728,16 @@ private fun JvmApplicationContext.configureElectronBuilderPackageTask(
     )
 
     packageTask.packageName.set(packageNameProvider)
-    packageTask.executableName.set(packageNameProvider)
+    packageTask.executableName.set(
+        project.provider {
+            val dist = app.nativeDistributions
+            when (currentOS) {
+                OS.Linux -> dist.linux.packageName
+                OS.Windows -> dist.windows.packageName
+                OS.MacOS -> dist.macOS.packageName
+            } ?: dist.packageName ?: project.name
+        },
+    )
     packageTask.packageVersion.set(packageVersionFor(packageTask.targetFormat))
     packageTask.linuxIconFile.set(
         app.nativeDistributions.linux.iconFile

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -1050,7 +1050,7 @@ abstract class AbstractElectronBuilderPackageTask
 
             val relativePath = launcher.relativeTo(appDir).path
 
-            val aliasName = launcherName.toNpmPackageName()
+            val aliasName = executableName.orNull ?: launcherName.toNpmPackageName()
             val aliasFile = appDir.resolve(aliasName)
             if (aliasFile.exists()) return
 


### PR DESCRIPTION
## Summary

- Set `executableName` on the electron-builder task in the JVM packaging path (`configureJvmApplication.kt`), matching what the GraalVM path already does
- Fixes MSI builds failing with WiX `LGHT0094: The identifier 'File:mainExecutable' could not be found`

**Root cause:** Without `executableName`, electron-builder falls back to the lowercase `package.json` name (e.g. `seforimapp`) to identify the main `.exe`, but jpackage creates `SeforimApp.exe` (from `packageNameProvider`). The case mismatch prevents WiX from assigning the `mainExecutable` component ID, causing the linker to fail.

## Test plan

- [ ] Build MSI on Windows with a project that has no top-level `packageName` in `nativeDistributions`
- [ ] Verify NSIS still works (regression check)
- [ ] Verify GraalVM path is unaffected