### PR TITLE
feat: typed DSL for GraalVM binary size optimizations and UPX

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -61,10 +61,17 @@ nucleus.application {
         jvmVendor = JvmVendorSpec.BELLSOFT
         imageName = "nucleus-sample"
         march = providers.gradleProperty("nativeMarch").getOrElse("compatibility")
+        optimization {
+            optimizeForSize = true
+            skipFlow = true
+        }
+        upx {
+            isEnabled = true
+            compressionLevel = 10
+        }
         buildArgs.addAll(
             "-H:+AddAllCharsets",
             "-Djava.awt.headless=false",
-            "-Os",
             "-H:-IncludeMethodData",
         )
         nativeImageConfigBaseDir.set(

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/GraalvmSettings.kt
@@ -30,6 +30,8 @@ abstract class GraalvmSettings
         val nativeImageConfigBaseDir: DirectoryProperty = objects.directoryProperty()
         val macOS: GraalvmMacOSSettings = objects.new()
         val metadataRepository: MetadataRepositorySettings = objects.new()
+        val optimization: GraalvmOptimizationSettings = objects.new()
+        val upx: UpxSettings = objects.new()
 
         fun macOS(fn: Action<GraalvmMacOSSettings>) {
             fn.execute(macOS)
@@ -37,6 +39,14 @@ abstract class GraalvmSettings
 
         fun metadataRepository(fn: Action<MetadataRepositorySettings>) {
             fn.execute(metadataRepository)
+        }
+
+        fun optimization(fn: Action<GraalvmOptimizationSettings>) {
+            fn.execute(optimization)
+        }
+
+        fun upx(fn: Action<UpxSettings>) {
+            fn.execute(upx)
         }
     }
 
@@ -77,4 +87,32 @@ abstract class MetadataRepositorySettings
          */
         val moduleToConfigVersion: MapProperty<String, String> =
             objects.mapProperty(String::class.java, String::class.java)
+    }
+
+abstract class GraalvmOptimizationSettings
+    @Inject
+    constructor(
+        objects: ObjectFactory,
+    ) {
+        /** Injects `-Os` to optimize for binary size. */
+        val optimizeForSize: Property<Boolean> = objects.notNullProperty(false)
+
+        /** Injects `-H:+TrackPrimitiveValues -H:+UsePredicates` (experimental). */
+        val skipFlow: Property<Boolean> = objects.notNullProperty(false)
+    }
+
+abstract class UpxSettings
+    @Inject
+    constructor(
+        objects: ObjectFactory,
+    ) {
+        /** Enable UPX compression of the native binary after compilation. */
+        val isEnabled: Property<Boolean> = objects.notNullProperty(false)
+
+        /** Path to the UPX executable. Resolved from PATH if not set. */
+        val executablePath: Property<String> = objects.nullableProperty()
+
+        /** Compression level (1-9, or 10 for --best). Defaults to 7. */
+        @Suppress("MagicNumber")
+        val compressionLevel: Property<Int> = objects.notNullProperty(7)
     }

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
@@ -41,6 +41,7 @@ private val graalvmDefaultJvmArgs: List<String> =
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 internal fun JvmApplicationContext.configureGraalvmApplication() {
     val graalvm = app.graalvm
+    validateGraalvmOptimizationSettings(graalvm)
     val javaToolchains = project.extensions.getByType(JavaToolchainService::class.java)
 
     val graalvmLauncher =
@@ -525,11 +526,58 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                         }
                     }
 
+                    // Optimization flags from DSL
+                    if (graalvm.optimization.optimizeForSize.get()) add("-Os")
+                    if (graalvm.optimization.skipFlow.get()) {
+                        add("-H:+TrackPrimitiveValues")
+                        add("-H:+UsePredicates")
+                    }
+
                     addAll(graalvm.buildArgs.get())
                 }
         }
 
+    // ── UPX compression ──
+
+    val upxCompress: TaskProvider<Exec>? =
+        if (graalvm.upx.isEnabled.get()) {
+            val upxExe =
+                if (graalvm.upx.executablePath.isPresent) {
+                    graalvm.upx.executablePath.get()
+                } else {
+                    resolveFromPath("upx")
+                        ?: error(
+                            "UPX executable not found on PATH. " +
+                                "Install UPX or set graalvm.upx.executablePath explicitly.",
+                        )
+                }
+            val level = graalvm.upx.compressionLevel.get()
+            val levelArg = if (level == UPX_BEST_LEVEL) "--best" else "-$level"
+
+            tasks.register<Exec>(
+                taskNameAction = "upx",
+                taskNameObject = "graalvmBinary",
+            ) {
+                description = "Compress native binary with UPX"
+                dependsOn(nativeImageCompile)
+                val binary = nativeCompileDir.map { it.file(binaryName.get()).asFile }
+                commandLine(
+                    buildList {
+                        add(upxExe)
+                        if (currentOS == OS.MacOS) add("--force-macos")
+                        add(levelArg)
+                        add(binary.get().absolutePath)
+                    },
+                )
+            }
+        } else {
+            null
+        }
+
     // ── Platform-specific packaging ──
+
+    // The compile dependency for copy tasks: UPX (if enabled) must run before packaging copies the binary.
+    val compileOrUpx: TaskProvider<out DefaultTask> = upxCompress ?: nativeImageCompile
 
     val packageGraalvmNative: TaskProvider<out DefaultTask> =
         when (currentOS) {
@@ -537,7 +585,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                 configureMacOsGraalvmPackaging(
                     graalvm,
                     graalvmHome,
-                    nativeImageCompile,
+                    compileOrUpx,
                     nativeCompileDir,
                     imageName,
                     unpackDefaultResources,
@@ -546,7 +594,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             OS.Windows ->
                 configureWindowsGraalvmPackaging(
                     graalvmHome,
-                    nativeImageCompile,
+                    compileOrUpx,
                     nativeCompileDir,
                     imageName,
                     packageUberJar,
@@ -554,7 +602,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             OS.Linux ->
                 configureLinuxGraalvmPackaging(
                     graalvmHome,
-                    nativeImageCompile,
+                    compileOrUpx,
                     nativeCompileDir,
                     imageName,
                     packageUberJar,
@@ -612,7 +660,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
 private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
     graalvm: GraalvmSettings,
     graalvmHome: org.gradle.api.provider.Provider<String>,
-    nativeImageCompile: TaskProvider<Exec>,
+    nativeImageCompile: TaskProvider<out DefaultTask>,
     nativeCompileDir: org.gradle.api.provider.Provider<org.gradle.api.file.Directory>,
     imageName: org.gradle.api.provider.Provider<String>,
     unpackDefaultResources: TaskProvider<AbstractUnpackDefaultApplicationResourcesTask>,
@@ -961,7 +1009,7 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
 @Suppress("LongParameterList")
 private fun JvmApplicationContext.configureWindowsGraalvmPackaging(
     graalvmHome: org.gradle.api.provider.Provider<String>,
-    nativeImageCompile: TaskProvider<Exec>,
+    nativeImageCompile: TaskProvider<out DefaultTask>,
     nativeCompileDir: org.gradle.api.provider.Provider<org.gradle.api.file.Directory>,
     imageName: org.gradle.api.provider.Provider<String>,
     packageUberJar: TaskProvider<Jar>,
@@ -1060,7 +1108,7 @@ private fun JvmApplicationContext.configureWindowsGraalvmPackaging(
 @Suppress("LongParameterList")
 private fun JvmApplicationContext.configureLinuxGraalvmPackaging(
     graalvmHome: org.gradle.api.provider.Provider<String>,
-    nativeImageCompile: TaskProvider<Exec>,
+    nativeImageCompile: TaskProvider<out DefaultTask>,
     nativeCompileDir: org.gradle.api.provider.Provider<org.gradle.api.file.Directory>,
     imageName: org.gradle.api.provider.Provider<String>,
     packageUberJar: TaskProvider<Jar>,
@@ -1287,3 +1335,32 @@ private fun JvmApplicationContext.configureGraalvmElectronBuilderPackaging(
         }
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════
+// Validation
+// ═══════════════════════════════════════════════════════════════════
+
+private const val UPX_MIN_LEVEL = 1
+private const val UPX_BEST_LEVEL = 10
+
+private fun JvmApplicationContext.validateGraalvmOptimizationSettings(graalvm: GraalvmSettings) {
+    val level = graalvm.upx.compressionLevel.get()
+    require(level in UPX_MIN_LEVEL..UPX_BEST_LEVEL) {
+        "upx.compressionLevel must be between $UPX_MIN_LEVEL and $UPX_BEST_LEVEL (10 = --best), got $level"
+    }
+    if (graalvm.optimization.skipFlow.get()) {
+        project.logger.lifecycle(
+            "GraalVM SkipFlow optimizations enabled (-H:+TrackPrimitiveValues -H:+UsePredicates). " +
+                "This is an experimental feature.",
+        )
+    }
+}
+
+/** Resolve an executable name from the system PATH, returning the absolute path or null. */
+private fun resolveFromPath(name: String): String? =
+    System
+        .getenv("PATH")
+        ?.splitToSequence(File.pathSeparator)
+        ?.map { File(it, name) }
+        ?.firstOrNull { it.isFile && it.canExecute() }
+        ?.absolutePath


### PR DESCRIPTION
## Summary

- Add `optimization {}` DSL block in `graalvm {}` with `optimizeForSize` (`-Os`) and `skipFlow` (`-H:+TrackPrimitiveValues -H:+UsePredicates`) properties
- Add `upx {}` DSL block with `isEnabled`, `executablePath`, and `compressionLevel` (1-9, 10 = `--best`) properties
- Register a conditional `upxGraalvmBinary` Exec task inserted between native-image compilation and platform packaging
- Automatically resolve UPX from system PATH and add `--force-macos` on macOS
- Validate compression level range and log experimental warning for SkipFlow
- Migrate example app from raw `-Os` buildArg to the new typed DSL with full optimizations

## Test plan

- [ ] `./gradlew help` — build compiles with new DSL
- [ ] `./gradlew nativeImageCompile --info` — verify `-Os`, `-H:+TrackPrimitiveValues`, `-H:+UsePredicates` in native-image command
- [ ] `./gradlew runGraalvmNative` — app launches with all optimizations enabled
- [ ] Verify UPX compresses the binary on macOS (with `--force-macos`)
- [ ] Test with `upx.isEnabled = false` — UPX task is not registered, packaging works as before
- [ ] Test invalid `compressionLevel` (e.g. 0 or 11) — build fails with clear error