### PR TITLE
Add GraalVM drag-and-drop and file open handler metadata

### DIFF
--- a/graalvm-runtime/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.graalvm-runtime/reachability-metadata.json
+++ b/graalvm-runtime/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.graalvm-runtime/reachability-metadata.json
@@ -19,6 +19,14 @@
             "type": "androidx.compose.ui.awt.JLayeredPaneWithTransparencyHack"
         },
         {
+            "type": "androidx.compose.ui.draganddrop.DragAndDropEvent",
+            "fields": [
+                {
+                    "name": "nativeEvent"
+                }
+            ]
+        },
+        {
             "type": "androidx.compose.ui.scene.ComposeSceneMediator$InvisibleComponent"
         },
         {
@@ -4906,6 +4914,48 @@
             ]
         },
         {
+            "type": "sun.awt.dnd.SunDropTargetContextPeer",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "handleDropMessage",
+                    "parameterTypes": [
+                        "java.awt.Component",
+                        "int",
+                        "int",
+                        "int",
+                        "int",
+                        "long[]",
+                        "long"
+                    ]
+                },
+                {
+                    "name": "handleEnterMessage",
+                    "parameterTypes": [
+                        "java.awt.Component",
+                        "int",
+                        "int",
+                        "int",
+                        "int",
+                        "long[]",
+                        "long"
+                    ]
+                },
+                {
+                    "name": "handleMotionMessage",
+                    "parameterTypes": [
+                        "java.awt.Component",
+                        "int",
+                        "int",
+                        "int",
+                        "int",
+                        "long[]",
+                        "long"
+                    ]
+                }
+            ]
+        },
+        {
             "type": "sun.text.resources.FormatData"
         },
         {
@@ -4967,6 +5017,10 @@
         },
         {
             "glob": "*skiko*.sha256"
+        },
+        {
+            "module": "java.datatransfer",
+            "glob": "sun/datatransfer/resources/flavormap.properties"
         },
         {
             "bundle": "com.sun.org.apache.xml.internal.serializer.XMLEntities"

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/macos-reachability-metadata.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/macos-reachability-metadata.json
@@ -31,6 +31,13 @@
                     "parameterTypes": [
                         "int"
                     ]
+                },
+                {
+                    "name": "handleOpenFiles",
+                    "parameterTypes": [
+                        "java.util.List",
+                        "java.lang.String"
+                    ]
                 }
             ]
         },
@@ -892,6 +899,23 @@
                         "double",
                         "double",
                         "int"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "sun.lwawt.macosx.CDropTargetContextPeer",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "getDropTargetContextPeer",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "newData",
+                    "parameterTypes": [
+                        "long",
+                        "byte[]"
                     ]
                 }
             ]


### PR DESCRIPTION
## Summary
- Add reflection metadata for AWT drag-and-drop JNI callbacks and Compose `DragAndDropEvent` so apps no longer need custom `reachability-metadata.json` entries for drag-and-drop support
- Add `handleOpenFiles` to macOS `_AppEventHandler` for native file open handler support
- Add `flavormap.properties` resource for data transfer

### L1 (cross-platform, `graalvm-runtime`)
- `androidx.compose.ui.draganddrop.DragAndDropEvent` — `nativeEvent` field
- `sun.awt.dnd.SunDropTargetContextPeer` — `handleDropMessage`, `handleEnterMessage`, `handleMotionMessage`
- Resource `sun/datatransfer/resources/flavormap.properties`

### macOS L3 (platform-specific, plugin)
- `com.apple.eawt._AppEventHandler` — added `handleOpenFiles` method
- `sun.lwawt.macosx.CDropTargetContextPeer` — `getDropTargetContextPeer`, `newData`

## Context
Discovered while reviewing [terrakok/Mach-O-viewer#1](https://github.com/terrakok/Mach-O-viewer/pull/1) — the app needed a custom `reachability-metadata.json` with these entries for drag-and-drop to work in GraalVM native image. These are generic AWT/Compose types that should be shipped by Nucleus.

## Test plan
- [ ] Build a GraalVM native image of jewel-sample with drag-and-drop enabled
- [ ] Verify drag-and-drop works on macOS native image
- [ ] Verify `Desktop.setOpenFileHandler` works on macOS native image