### PR TITLE
Add Ktor CIO, SLF4J and common JDK resource metadata

### DIFF
--- a/graalvm-runtime/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.graalvm-runtime/reachability-metadata.json
+++ b/graalvm-runtime/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.graalvm-runtime/reachability-metadata.json
@@ -1145,6 +1145,49 @@
             "type": "com.sun.swing.internal.plaf.metal.resources.metal"
         },
         {
+            "type": "io.ktor.client.HttpClient"
+        },
+        {
+            "type": "io.ktor.client.call.HttpClientCall"
+        },
+        {
+            "type": "io.ktor.client.engine.HttpClientEngineBase"
+        },
+        {
+            "type": "io.ktor.client.engine.cio.Endpoint"
+        },
+        {
+            "type": "io.ktor.network.selector.InterestSuspensionsMap",
+            "allDeclaredFields": true
+        },
+        {
+            "type": "io.ktor.network.selector.LockFreeMPSCQueue"
+        },
+        {
+            "type": "io.ktor.network.selector.LockFreeMPSCQueueCore"
+        },
+        {
+            "type": "io.ktor.network.selector.SelectInterest[]"
+        },
+        {
+            "type": "io.ktor.network.selector.SelectableBase"
+        },
+        {
+            "type": "io.ktor.network.sockets.SocketBase"
+        },
+        {
+            "type": "io.ktor.serialization.kotlinx.json.KotlinxSerializationJsonExtensionProvider"
+        },
+        {
+            "type": "io.ktor.util.collections.CopyOnWriteHashMap"
+        },
+        {
+            "type": "io.ktor.utils.io.ByteChannel"
+        },
+        {
+            "type": "io.ktor.utils.io.pool.DefaultPool"
+        },
+        {
             "type": "java.awt.AWTEvent",
             "jniAccessible": true,
             "fields": [
@@ -3556,6 +3599,13 @@
             "type": "org.slf4j.Logger",
             "methods": [
                 {
+                    "name": "debug",
+                    "parameterTypes": [
+                        "java.lang.String",
+                        "java.lang.Throwable"
+                    ]
+                },
+                {
                     "name": "info",
                     "parameterTypes": [
                         "java.lang.String",
@@ -3588,6 +3638,9 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "org.slf4j.simple.SimpleServiceProvider"
         },
         {
             "type": "sun.awt.AWTAccessor",
@@ -4979,7 +5032,13 @@
     ],
     "resources": [
         {
+            "glob": "META-INF/MANIFEST.MF"
+        },
+        {
             "bundle": "com.sun.swing.internal.plaf.basic.resources.basic"
+        },
+        {
+            "bundle": "sun.util.logging.resources.logging"
         },
         {
             "bundle": "sun.awt.resources.awt"


### PR DESCRIPTION
## Summary
- Add 14 Ktor CIO client reflection types to L1 so apps using Ktor don't need custom metadata
- Add `org.slf4j.simple.SimpleServiceProvider` to L1 (very common SLF4J binding for desktop apps)
- Enrich `org.slf4j.Logger` with missing `debug(String, Throwable)` method
- Add `META-INF/MANIFEST.MF` glob and `sun.util.logging.resources.logging` bundle to L1 resources

### Ktor CIO types added
`HttpClient`, `HttpClientCall`, `HttpClientEngineBase`, `Endpoint`, `InterestSuspensionsMap`, `LockFreeMPSCQueue`, `LockFreeMPSCQueueCore`, `SelectInterest[]`, `SelectableBase`, `SocketBase`, `KotlinxSerializationJsonExtensionProvider`, `CopyOnWriteHashMap`, `ByteChannel`, `DefaultPool`

## Context
Discovered while auditing Zayit's `reachability-metadata.json` — these entries were duplicated across all 3 platform-specific metadata files and are generic enough to ship in Nucleus L1.

## Test plan
- [ ] Build a GraalVM native image of an app using Ktor CIO client
- [ ] Verify HTTP requests work correctly in native image
- [ ] Verify SLF4J Simple logging works in native image