### PR TITLE
feat: patch macOS build version for GraalVM and sync JVM pipeline

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/GraalvmSettings.kt
@@ -47,6 +47,7 @@ abstract class GraalvmMacOSSettings
     ) {
         val cStubsSrc: RegularFileProperty = objects.fileProperty()
         val minimumSystemVersion: Property<String> = objects.notNullProperty("12.0")
+        val macOsSdkVersion: Property<String> = objects.notNullProperty("26.0")
     }
 
 /**

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/MacOsMachOPatcher.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/MacOsMachOPatcher.kt
@@ -1,0 +1,60 @@
+package io.github.kdroidfilter.nucleus.desktop.application.internal
+
+import org.gradle.api.logging.Logger
+import java.io.File
+
+/**
+ * Patches the LC_BUILD_VERSION of a Mach-O binary using vtool.
+ * Sets both the minimum deployment target (minos) and the SDK version,
+ * enabling SDK-gated AppKit features (e.g. Liquid Glass on macOS 26+).
+ *
+ * @return true if the patch succeeded, false if vtool is missing or failed.
+ */
+internal fun patchMachOBuildVersion(
+    binary: File,
+    minVersion: String,
+    sdkVersion: String,
+    logger: Logger,
+): Boolean {
+    val vtool = File("/usr/bin/vtool")
+    if (!vtool.exists()) {
+        logger.warn(
+            "vtool not found at /usr/bin/vtool — skipping macOS build version patch. " +
+                "Install Xcode Command Line Tools to enable this feature.",
+        )
+        return false
+    }
+
+    logger.lifecycle("Patching ${binary.name} LC_BUILD_VERSION: minos=$minVersion sdk=$sdkVersion")
+
+    // Remove existing code signature (vtool cannot modify signed binaries)
+    ProcessBuilder("codesign", "--remove-signature", binary.absolutePath)
+        .redirectErrorStream(true)
+        .start()
+        .waitFor()
+
+    val vtoolExit =
+        ProcessBuilder(
+            vtool.absolutePath,
+            "-set-build-version",
+            "macos",
+            minVersion,
+            sdkVersion,
+            "-tool",
+            "ld",
+            "0.0",
+            "-replace",
+            "-output",
+            binary.absolutePath,
+            binary.absolutePath,
+        ).redirectErrorStream(true)
+            .start()
+            .waitFor()
+
+    if (vtoolExit != 0) {
+        logger.warn("vtool exited with code $vtoolExit for ${binary.name} — build version patch may have failed")
+        return false
+    }
+
+    return true
+}

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
@@ -459,6 +459,11 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
 
             executable = nativeImageExe.get()
 
+            // Control the minos in LC_BUILD_VERSION at link time
+            if (currentOS == OS.MacOS) {
+                environment("MACOSX_DEPLOYMENT_TARGET", graalvm.macOS.minimumSystemVersion.get())
+            }
+
             doFirst {
                 outputDir.mkdirs()
             }
@@ -717,13 +722,46 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
             commandLine("bash", "-c", "strip -x '${macosDir.get().asFile.absolutePath}'/*.dylib")
         }
 
+    // Patch LC_BUILD_VERSION on all Mach-O binaries and dylibs so that:
+    // - minos matches minimumSystemVersion (e.g. 12.0) for backward compatibility
+    // - sdk matches macOsSdkVersion (e.g. 26.0) to enable Liquid Glass
+    val patchMinVersion = graalvm.macOS.minimumSystemVersion
+    val patchSdkVersion = graalvm.macOS.macOsSdkVersion
+    val patchBuildVersion =
+        tasks.register<DefaultTask>(
+            taskNameAction = "patch",
+            taskNameObject = "graalvmBuildVersion",
+        ) {
+            description = "Patch LC_BUILD_VERSION on native binary and dylibs via vtool"
+            dependsOn(copyBinary, stripDylibs, copyJawtToLib, copySkikoLib)
+
+            inputs.property("minVersion", patchMinVersion)
+            inputs.property("sdkVersion", patchSdkVersion)
+
+            doLast {
+                val minVer = patchMinVersion.get()
+                val sdkVer = patchSdkVersion.get()
+                val macosDir = appBundleDir.get().dir("MacOS").asFile
+                val libDir = appBundleDir.get().dir("MacOS/lib").asFile
+
+                // Patch all Mach-O files: main binary + dylibs in MacOS/ and MacOS/lib/
+                sequenceOf(macosDir, libDir)
+                    .filter { it.isDirectory }
+                    .flatMap { dir -> dir.listFiles()?.asSequence() ?: emptySequence() }
+                    .filter { it.isFile && (it.extension == "dylib" || it.canExecute()) }
+                    .forEach { file ->
+                        patchMachOBuildVersion(file, minVer, sdkVer, logger)
+                    }
+            }
+        }
+
     val codesignDylibs =
         tasks.register<Exec>(
             taskNameAction = "codesign",
             taskNameObject = "graalvmDylibs",
         ) {
             description = "Re-sign dylibs after stripping (ad-hoc)"
-            dependsOn(stripDylibs)
+            dependsOn(patchBuildVersion)
             val macosDir = appBundleDir.map { it.dir("MacOS") }
             commandLine("bash", "-c", "codesign --force --sign - '${macosDir.get().asFile.absolutePath}'/*.dylib")
         }
@@ -734,7 +772,7 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
             taskNameObject = "graalvmRpath",
         ) {
             description = "Add @executable_path rpath to native image"
-            dependsOn(copyBinary)
+            dependsOn(patchBuildVersion)
             val binary = appBundleDir.map { it.file("MacOS/${imageName.get()}") }
             commandLine("install_name_tool", "-add_rpath", "@executable_path/.", binary.get().asFile.absolutePath)
             isIgnoreExitValue = true
@@ -944,6 +982,7 @@ private fun JvmApplicationContext.configureMacOsGraalvmPackaging(
             copyJawtToLib,
             copySkikoLib,
             stripDylibs,
+            patchBuildVersion,
             codesignDylibs,
             codesignBundle,
             fixRpath,

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -915,13 +915,14 @@ private fun JvmApplicationContext.configureRunTask(
         val sdkVersion = app.nativeDistributions.macOS.macOsSdkVersion
         if (sdkVersion != null) {
             val javaHome = app.javaHome
+            val minVersion = app.nativeDistributions.macOS.minimumSystemVersion ?: "10.13"
             // Run via a patched copy of the java binary (like ComposeDarwinUi).
             // We can't change JavaExec.executable or javaLauncher due to Gradle 9.4
             // finalization/validation, so we run the process manually in doFirst
             // and skip the JavaExec action.
             exec.doFirst {
                 val je = it as JavaExec
-                val patchedJava = getOrCreatePatchedJvm(javaHome, sdkVersion, je.logger)
+                val patchedJava = getOrCreatePatchedJvm(javaHome, minVersion, sdkVersion, je.logger)
                 val cmd = mutableListOf(patchedJava)
                 je.jvmArgs?.let { cmd.addAll(it) }
                 cmd.add("-cp")
@@ -1075,6 +1076,7 @@ private fun sandboxingJvmArgs(resourcesPath: String): List<String> =
  */
 private fun getOrCreatePatchedJvm(
     javaHome: String,
+    minVersion: String,
     sdkVersion: String,
     logger: org.gradle.api.logging.Logger,
 ): String {
@@ -1095,10 +1097,11 @@ private fun getOrCreatePatchedJvm(
     val patched = java.io.File(cacheDir, "bin/java")
     val stampFile = java.io.File(cacheDir, ".source_hash")
 
-    // Include sdkVersion in the cache key so changing the DSL property invalidates the cache
+    // Include minVersion+sdkVersion in the cache key so changing DSL properties invalidates the cache
     val sourceHash =
         javaBin.inputStream().use { stream ->
             java.security.MessageDigest.getInstance("SHA-256").let { md ->
+                md.update(minVersion.toByteArray())
                 md.update(sdkVersion.toByteArray())
                 @Suppress("MagicNumber")
                 val buf = ByteArray(8192)
@@ -1113,7 +1116,7 @@ private fun getOrCreatePatchedJvm(
         return patched.absolutePath
     }
 
-    logger.lifecycle("Patching JVM binary for macOS SDK $sdkVersion (Liquid Glass)...")
+    logger.lifecycle("Patching JVM binary: minos=$minVersion sdk=$sdkVersion (Liquid Glass)...")
     cacheDir.resolve("bin").mkdirs()
 
     // Mirror JAVA_HOME/lib so @loader_path/../lib resolves correctly
@@ -1136,7 +1139,7 @@ private fun getOrCreatePatchedJvm(
             "vtool",
             "-set-build-version",
             "macos",
-            "11.0",
+            minVersion,
             sdkVersion,
             "-tool",
             "ld",

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractJPackageTask.kt
@@ -595,9 +595,10 @@ abstract class AbstractJPackageTask
             // Patch the jpackage launcher's LC_BUILD_VERSION to claim the configured
             // macOS SDK version, enabling SDK-gated AppKit features (e.g. Liquid Glass).
             macOsSdkVersion.orNull?.let { sdkVersion ->
+                val minVersion = macMinimumSystemVersion.orNull ?: "10.13"
                 val launcher = appDir.resolve("Contents/MacOS/${packageName.get()}")
                 if (launcher.exists()) {
-                    patchMachOSdkVersion(launcher, sdkVersion)
+                    patchMachOSdkVersion(launcher, minVersion, sdkVersion)
                 }
             }
 
@@ -673,6 +674,7 @@ abstract class AbstractJPackageTask
 
         private fun patchMachOSdkVersion(
             binary: File,
+            minVersion: String,
             sdkVersion: String,
         ) {
             val vtool = File("/usr/bin/vtool")
@@ -683,21 +685,20 @@ abstract class AbstractJPackageTask
                 )
                 return
             }
-            logger.lifecycle("Patching ${binary.name} LC_BUILD_VERSION to macOS SDK $sdkVersion")
+            logger.lifecycle("Patching ${binary.name} LC_BUILD_VERSION: minos=$minVersion sdk=$sdkVersion")
             // Remove existing code signature (vtool cannot modify signed binaries)
             runExternalTool(
                 tool = File("/usr/bin/codesign"),
                 args = listOf("--remove-signature", binary.absolutePath),
                 checkExitCodeIsNormal = false,
             )
-            // Set build version: min deployment 11.0, SDK sdkVersion
             runExternalTool(
                 tool = vtool,
                 args =
                     listOf(
                         "-set-build-version",
                         "macos",
-                        "11.0",
+                        minVersion,
                         sdkVersion,
                         "-tool",
                         "ld",


### PR DESCRIPTION
## Summary

- **GraalVM pipeline**: add `macOsSdkVersion` DSL property, set `MACOSX_DEPLOYMENT_TARGET` on `nativeImageCompile`, and add a `patchGraalvmBuildVersion` task that patches all Mach-O binaries/dylibs via vtool (`minos` from `minimumSystemVersion`, `sdk` from `macOsSdkVersion`)
- **JVM pipeline**: replace hardcoded `"11.0"` minos in `AbstractJPackageTask.patchMachOSdkVersion` and `getOrCreatePatchedJvm` with the DSL `minimumSystemVersion` property, so plist `LSMinimumSystemVersion` and vtool minos stay synchronized
- **Shared utility**: extract `MacOsMachOPatcher.kt` for the GraalVM pipeline's vtool logic

## Test plan

- [x] `./gradlew :example:packageGraalvmNative` — builds successfully, `vtool -show-build` shows `minos=12.0 sdk=26.0` on binary and all dylibs
- [x] `./gradlew :example:packageDistributionForCurrentOS` — builds successfully, `vtool -show-build` shows `minos=10.13 sdk=26.0`
- [x] Configuration cache reused on second run
- [x] detekt + ktlint pass with no new violations