### PR TITLE
feat: add FileKit GraalVM metadata and complete JDK/JNA entries

### DIFF
--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/filekit.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/filekit.json
@@ -1,0 +1,42 @@
+{
+    "_meta": {
+        "description": "FileKit file dialog library (VinceGlb)",
+        "matchPackages": [
+            "io.github.vinceglb.filekit"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.awt.AwtFileSaver$saveFile$2$dialog$2"
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.mac.foundation.Foundation$initRunnableSupport$callback$1",
+            "methods": [
+                {
+                    "name": "callback",
+                    "parameterTypes": [
+                        "io.github.vinceglb.filekit.dialogs.platform.mac.foundation.ID",
+                        "java.lang.String",
+                        "io.github.vinceglb.filekit.dialogs.platform.mac.foundation.ID"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.mac.foundation.ID",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": {
+                "proxy": [
+                    "io.github.vinceglb.filekit.dialogs.platform.mac.foundation.FoundationLibrary"
+                ]
+            }
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/index.txt
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/index.txt
@@ -1,5 +1,6 @@
 android-compat.json
 compose-ui.json
+filekit.json
 intellij-compat.json
 jdk-awt.json
 jdk-core.json

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jdk-core.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jdk-core.json
@@ -211,6 +211,9 @@
             "type": "java.lang.Number"
         },
         {
+            "type": "java.lang.Object[]"
+        },
+        {
             "type": "java.lang.Object",
             "jniAccessible": true,
             "methods": [
@@ -240,6 +243,18 @@
                     "name": "<init>",
                     "parameterTypes": [
                         "short"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "java.lang.UnsatisfiedLinkError",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        "java.lang.String"
                     ]
                 }
             ]

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/macos-reachability-metadata.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/macos-reachability-metadata.json
@@ -112,7 +112,16 @@
             "jniAccessible": true
         },
         {
-            "type": "com.sun.jna.CallbackProxy"
+            "type": "com.sun.jna.CallbackProxy",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "callback",
+                    "parameterTypes": [
+                        "java.lang.Object[]"
+                    ]
+                }
+            ]
         },
         {
             "type": "com.sun.jna.CallbackReference",


### PR DESCRIPTION
## Summary
- Add new `filekit.json` library metadata for FileKit file dialog reflection (AwtFileSaver, Foundation bridge, ID constructor, FoundationLibrary proxy)
- Add `java.lang.Object[]` and `java.lang.UnsatisfiedLinkError` to `jdk-core.json`
- Enhance macOS `CallbackProxy` entry with `jniAccessible` flag and `callback(Object[])` method

## Test plan
- [ ] Verify `./gradlew preMerge` passes
- [ ] Test GraalVM native-image build with FileKit dependency on macOS
- [ ] Confirm file dialogs work correctly in native-image