### PR TITLE
fix: build nativeImageCompile args at execution time

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
@@ -616,13 +616,19 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             val resolvedUberJar = uberJarFile.get().asFile.absolutePath
             val resolvedStubObj =
                 if (currentOS == OS.MacOS && compileStubs != null) {
-                    appTmpDir.get().file("graalvm/cursor_stub.o").asFile.absolutePath
+                    appTmpDir
+                        .get()
+                        .file("graalvm/cursor_stub.o")
+                        .asFile.absolutePath
                 } else {
                     null
                 }
             val resolvedResFile =
                 if (currentOS == OS.Windows && generateWindowsResources != null) {
-                    appTmpDir.get().file("graalvm/icon.res").asFile.absolutePath
+                    appTmpDir
+                        .get()
+                        .file("graalvm/icon.res")
+                        .asFile.absolutePath
                 } else {
                     null
                 }


### PR DESCRIPTION
## Summary
- Move `args` construction in `nativeImageCompile` from configuration time into `doFirst` (execution time)
- Fixes clean builds (CI) silently dropping static analysis (L4) and Oracle repo (L2) metadata because `exists()` checks evaluated before dependent tasks had run
- Local builds were unaffected since directories persisted from previous runs

## Test plan
- [ ] Clean build (`./gradlew clean packageGraalvmMsi`) includes all metadata layers
- [ ] Verify native binary size matches local builds
- [ ] CI produces working native binaries on all platforms