### PR TITLE
feat: expand L1 library metadata with agent-captured entries

### DIFF
--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/coil.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/coil.json
@@ -1,0 +1,16 @@
+{
+    "_meta": {
+        "description": "Coil image loading library",
+        "matchPackages": [
+            "coil3"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "coil3.RealImageLoader"
+        },
+        {
+            "type": "coil3.compose.internal.DeferredDispatchCoroutineDispatcher"
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/compose-mediaplayer.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/compose-mediaplayer.json
@@ -1,0 +1,22 @@
+{
+    "_meta": {
+        "description": "Compose MediaPlayer Windows (MediaFoundation via JNA)",
+        "matchPackages": [
+            "io.github.kdroidfilter.composemediaplayer"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "io.github.kdroidfilter.composemediaplayer.windows.MediaFoundationLib",
+            "allDeclaredFields": true,
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true,
+            "jniAccessible": true
+        },
+        {
+            "type": "io.github.kdroidfilter.composemediaplayer.windows.MediaFoundationLib$NativeVideoMetadata",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/compose-ui.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/compose-ui.json
@@ -28,6 +28,9 @@
         },
         {
             "type": "androidx.compose.ui.scene.skia.WindowSkiaLayerComponent$contentComponent$1"
+        },
+        {
+            "type": "androidx.compose.ui.awt.SwingInteropViewGroup"
         }
     ]
 }

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/compose-webview-wry.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/compose-webview-wry.json
@@ -1,0 +1,275 @@
+{
+    "_meta": {
+        "description": "Compose WebView (Wry/UniFFI) native bindings",
+        "matchPackages": [
+            "io.github.kdroidfilter.webview.wry"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "io.github.kdroidfilter.webview.wry.IntegrityCheckingUniffiLib",
+            "allDeclaredMethods": true,
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true,
+            "jniAccessible": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiLib",
+            "allDeclaredMethods": true,
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true,
+            "jniAccessible": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.ForeignBytesStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.ForeignBytesStruct$ByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.RustBufferStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.RustBufferStruct$ByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.RustBufferStruct$ByReference",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiCallbackInterfaceFree",
+            "methods": [{"name": "callback", "parameterTypes": ["long"]}]
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiCallbackInterfaceJavaScriptCallbackMethod0",
+            "methods": [{"name": "callback", "parameterTypes": ["long", "io.github.kdroidfilter.webview.wry.RustBufferStruct$ByValue", "com.sun.jna.Pointer", "io.github.kdroidfilter.webview.wry.UniffiRustCallStatusStruct$ByReference"]}]
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiCallbackInterfaceNativeLoggerMethod0"
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiCallbackInterfaceNavigationHandlerMethod0",
+            "methods": [{"name": "callback", "parameterTypes": ["long", "io.github.kdroidfilter.webview.wry.RustBufferStruct$ByValue", "com.sun.jna.ptr.ByteByReference", "io.github.kdroidfilter.webview.wry.UniffiRustCallStatusStruct$ByReference"]}]
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiRustCallStatusStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiRustCallStatusStruct$ByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiRustCallStatusStruct$ByReference",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStruct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructF32Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructF32Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructF64Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructF64Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructI8Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructI8Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructI16Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructI16Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructI32Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructI32Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructI64Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructI64Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructU8Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructU8Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructU16Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructU16Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructU32Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructU32Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructU64Struct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructU64Struct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructPointerStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructPointerStruct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructRustBufferStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructRustBufferStruct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructVoidStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiForeignFutureStructVoidStruct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiVTableCallbackInterfaceJavaScriptCallbackStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiVTableCallbackInterfaceJavaScriptCallbackStruct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiVTableCallbackInterfaceNativeLoggerStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiVTableCallbackInterfaceNativeLoggerStruct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiVTableCallbackInterfaceNavigationHandlerStruct",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.UniffiVTableCallbackInterfaceNavigationHandlerStruct$UniffiByValue",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.WryWebViewPanel"
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.uniffiCallbackInterfaceJavaScriptCallback$onResult"
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.uniffiCallbackInterfaceJavaScriptCallback$uniffiFree"
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.uniffiCallbackInterfaceNativeLogger$handleLog"
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.uniffiCallbackInterfaceNativeLogger$uniffiFree"
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.uniffiCallbackInterfaceNavigationHandler$handleNavigation"
+        },
+        {
+            "type": "io.github.kdroidfilter.webview.wry.uniffiCallbackInterfaceNavigationHandler$uniffiFree"
+        }
+    ],
+    "resources": [
+        {"glob": "linux-x86-64/libcomposewebview_wry.so"},
+        {"glob": "darwin-x86-64/libcomposewebview_wry.dylib"},
+        {"glob": "darwin-aarch64/libcomposewebview_wry.dylib"}
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/composetray.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/composetray.json
@@ -1,0 +1,48 @@
+{
+    "_meta": {
+        "description": "ComposeTray system tray library",
+        "matchPackages": [
+            "com.kdroid.composetray"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "com.kdroid.composetray.lib.windows.StdCallCallback",
+            "methods": [
+                {
+                    "name": "invoke",
+                    "parameterTypes": [
+                        "com.kdroid.composetray.lib.windows.WindowsNativeTrayMenuItem"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "com.kdroid.composetray.lib.windows.WindowsNativeTrayMenuItem",
+            "fields": [
+                {"name": "cb"},
+                {"name": "checked"},
+                {"name": "disabled"},
+                {"name": "icon_path"},
+                {"name": "submenu"},
+                {"name": "text"}
+            ],
+            "methods": [
+                {"name": "<init>", "parameterTypes": []}
+            ]
+        },
+        {
+            "type": "com.kdroid.composetray.lib.windows.WindowsNativeTrayMenuItem[]"
+        },
+        {
+            "type": "com.kdroid.composetray.lib.windows.WindowsTrayManager$initializeNativeMenuItem$1$callback$1"
+        },
+        {
+            "type": {
+                "proxy": [
+                    "com.kdroid.composetray.lib.windows.WindowsNativeTrayLibrary"
+                ]
+            }
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/filekit.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/filekit.json
@@ -37,6 +37,68 @@
                     "io.github.vinceglb.filekit.dialogs.platform.mac.foundation.FoundationLibrary"
                 ]
             }
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.util.GuidFixed$CLSID",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.util.GuidFixed$IID",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.jna.ModalWindow",
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.jna.FileDialog",
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.jna.FileOpenDialog",
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.jna.FileSaveDialog",
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.jna.FileOperation",
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShellItem",
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShellItemArray",
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes$COMDLG_FILTERSPEC",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes$PROPERTYKEY",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": {
+                "proxy": [
+                    "io.github.vinceglb.filekit.dialogs.platform.windows.jna.Shell32"
+                ]
+            }
         }
     ]
 }

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/index.txt
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/index.txt
@@ -1,5 +1,9 @@
 android-compat.json
+coil.json
+compose-mediaplayer.json
 compose-ui.json
+compose-webview-wry.json
+composetray.json
 filekit.json
 intellij-compat.json
 jdk-awt.json
@@ -11,9 +15,13 @@ jdk-management.json
 jdk-text-resources.json
 jdk-xml.json
 jna.json
+jna-platform-win32.json
+knotify.json
 kotlin-coroutines.json
 kotlinx-io.json
 ktor.json
+platformtools.json
 sentry.json
 skia-skiko.json
 slf4j.json
+sqlite-jdbc.json

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jdk-core.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jdk-core.json
@@ -4,8 +4,32 @@
     },
     "reflection": [
         {
+            "type": "boolean"
+        },
+        {
             "type": "boolean[]",
             "jniAccessible": true
+        },
+        {
+            "type": "byte"
+        },
+        {
+            "type": "double"
+        },
+        {
+            "type": "float"
+        },
+        {
+            "type": "int"
+        },
+        {
+            "type": "long"
+        },
+        {
+            "type": "short"
+        },
+        {
+            "type": "void"
         },
         {
             "type": "byte[]",
@@ -48,6 +72,12 @@
                         "java.lang.String"
                     ]
                 }
+            ]
+        },
+        {
+            "type": "java.io.IOException",
+            "methods": [
+                {"name": "<init>", "parameterTypes": ["java.lang.String"]}
             ]
         },
         {
@@ -557,6 +587,12 @@
             "type": "java.util.concurrent.ScheduledThreadPoolExecutor"
         },
         {
+            "type": "sun.util.resources.LocaleNames"
+        },
+        {
+            "type": "sun.util.resources.cldr.LocaleNames"
+        },
+        {
             "type": "sun.launcher.LauncherHelper",
             "jniAccessible": true,
             "fields": [
@@ -582,6 +618,14 @@
         {
             "module": "java.base",
             "glob": "jdk/internal/icu/impl/data/icudt*/*.nrm"
+        },
+        {
+            "module": "java.base",
+            "glob": "jdk/internal/icu/impl/data/icudt*/*.icu"
+        },
+        {
+            "module": "java.base",
+            "glob": "sun/net/idn/uidna.spp"
         },
         {
             "module": "java.logging",

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jdk-crypto.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jdk-crypto.json
@@ -67,6 +67,12 @@
             ]
         },
         {
+            "type": "com.sun.crypto.provider.HKDFKeyDerivation$HKDFSHA256",
+            "methods": [
+                {"name": "<init>", "parameterTypes": ["javax.crypto.KDFParameters"]}
+            ]
+        },
+        {
             "type": "com.sun.crypto.provider.HmacCore$HmacSHA256",
             "methods": [
                 {
@@ -101,6 +107,18 @@
         },
         {
             "type": "java.security.interfaces.RSAPublicKey"
+        },
+        {
+            "type": "sun.security.provider.JavaKeyStore$DualFormatJKS",
+            "methods": [
+                {"name": "<init>", "parameterTypes": []}
+            ]
+        },
+        {
+            "type": "sun.security.provider.JavaKeyStore$JKS",
+            "methods": [
+                {"name": "<init>", "parameterTypes": []}
+            ]
         },
         {
             "type": "sun.security.pkcs12.PKCS12KeyStore",

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jna-platform-win32.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jna-platform-win32.json
@@ -1,0 +1,180 @@
+{
+    "_meta": {
+        "description": "JNA Platform Win32 types (Kernel32, User32, Shell32, Ole32, WinDef, WinUser, Guid, COM)",
+        "matchPackages": [
+            "com.sun.jna.platform.win32"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "com.sun.jna.platform.win32.Advapi32",
+            "jniAccessible": true,
+            "allPublicMethods": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.Advapi32Util",
+            "allPublicMethods": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.Kernel32",
+            "jniAccessible": true,
+            "allPublicMethods": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.User32",
+            "jniAccessible": true,
+            "allPublicMethods": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.Shell32",
+            "jniAccessible": true,
+            "allPublicMethods": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.Ole32",
+            "allDeclaredMethods": true,
+            "allPublicMethods": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.W32APIOptions",
+            "allPublicFields": true,
+            "allPublicMethods": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinNT$HANDLE",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinNT$HRESULT",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.BaseTSD$ULONG_PTR",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$ATOM",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$HBRUSH",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$HCURSOR",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$HICON",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$HINSTANCE",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$HMODULE",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$HWND",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$LPARAM",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$LRESULT",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$POINT",
+            "fields": [{"name": "x"}, {"name": "y"}],
+            "methods": [{"name": "<init>", "parameterTypes": ["com.sun.jna.Pointer"]}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinDef$WPARAM",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinReg$HKEY",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinReg$HKEYByReference",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinUser$HHOOK",
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinUser$LowLevelMouseProc",
+            "methods": [{"name": "callback", "parameterTypes": ["int", "com.sun.jna.platform.win32.WinDef$WPARAM", "com.sun.jna.platform.win32.WinUser$MSLLHOOKSTRUCT"]}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinUser$MSG",
+            "fields": [{"name": "hWnd"}, {"name": "lParam"}, {"name": "message"}, {"name": "pt"}, {"name": "time"}, {"name": "wParam"}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinUser$MSLLHOOKSTRUCT",
+            "fields": [{"name": "dwExtraInfo"}, {"name": "flags"}, {"name": "mouseData"}, {"name": "pt"}, {"name": "time"}],
+            "methods": [{"name": "<init>", "parameterTypes": []}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinUser$WNDCLASSEX",
+            "fields": [{"name": "cbClsExtra"}, {"name": "cbSize"}, {"name": "cbWndExtra"}, {"name": "hCursor"}, {"name": "hIcon"}, {"name": "hIconSm"}, {"name": "hInstance"}, {"name": "hbrBackground"}, {"name": "lpfnWndProc"}, {"name": "lpszClassName"}, {"name": "lpszMenuName"}, {"name": "style"}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.WinUser$WindowProc",
+            "methods": [{"name": "callback", "parameterTypes": ["com.sun.jna.platform.win32.WinDef$HWND", "int", "com.sun.jna.platform.win32.WinDef$WPARAM", "com.sun.jna.platform.win32.WinDef$LPARAM"]}]
+        },
+        {
+            "type": "com.sun.jna.platform.win32.Guid$CLSID",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.Guid$GUID",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.Guid$GUID$ByReference",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.Guid$IID",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.Guid$REFIID",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "com.sun.jna.platform.win32.COM.Unknown",
+            "allDeclaredFields": true,
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": {"proxy": ["com.sun.jna.platform.win32.Advapi32"]}
+        },
+        {
+            "type": {"proxy": ["com.sun.jna.platform.win32.Kernel32"]}
+        },
+        {
+            "type": {"proxy": ["com.sun.jna.platform.win32.User32"]}
+        },
+        {
+            "type": {"proxy": ["com.sun.jna.platform.win32.Shell32"]}
+        },
+        {
+            "type": {"proxy": ["com.sun.jna.platform.win32.Ole32"]}
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jna.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/jna.json
@@ -67,20 +67,222 @@
             "allPublicConstructors": true
         },
         {
-            "type": "com.sun.jna.Structure",
-            "allPublicMethods": true
-        },
-        {
             "type": "com.sun.jna.Callback",
             "allPublicMethods": true
         },
         {
+            "type": "com.sun.jna.CallbackProxy",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "callback",
+                    "parameterTypes": ["java.lang.Object[]"]
+                }
+            ]
+        },
+        {
             "type": "com.sun.jna.CallbackReference",
-            "allPublicMethods": true
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "getCallback",
+                    "parameterTypes": ["java.lang.Class", "com.sun.jna.Pointer", "boolean"]
+                },
+                {
+                    "name": "getFunctionPointer",
+                    "parameterTypes": ["com.sun.jna.Callback", "boolean"]
+                },
+                {
+                    "name": "getNativeString",
+                    "parameterTypes": ["java.lang.Object", "boolean"]
+                },
+                {
+                    "name": "initializeThread",
+                    "parameterTypes": ["com.sun.jna.Callback", "com.sun.jna.CallbackReference$AttachOptions"]
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.CallbackReference$AttachOptions",
+            "jniAccessible": true
+        },
+        {
+            "type": "com.sun.jna.IntegerType",
+            "jniAccessible": true,
+            "fields": [
+                { "name": "value" }
+            ]
+        },
+        {
+            "type": "com.sun.jna.JNIEnv",
+            "jniAccessible": true
         },
         {
             "type": "com.sun.jna.Native",
-            "allPublicMethods": true
+            "jniAccessible": true,
+            "allDeclaredFields": true,
+            "allDeclaredMethods": true,
+            "allDeclaredConstructors": true
+        },
+        {
+            "type": "com.sun.jna.NativeMapped",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "toNative",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.PointerType",
+            "jniAccessible": true,
+            "fields": [
+                { "name": "pointer" }
+            ]
+        },
+        {
+            "type": "com.sun.jna.Structure",
+            "jniAccessible": true,
+            "fields": [
+                { "name": "memory" },
+                { "name": "typeInfo" }
+            ],
+            "methods": [
+                {
+                    "name": "autoRead",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "autoWrite",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "getTypeInfo",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "newInstance",
+                    "parameterTypes": ["java.lang.Class", "long"]
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.Structure$ByValue",
+            "jniAccessible": true
+        },
+        {
+            "type": "com.sun.jna.Structure$FFIType",
+            "fields": [
+                { "name": "alignment" },
+                { "name": "elements" },
+                { "name": "size" },
+                { "name": "type" }
+            ],
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.Structure$FFIType$FFITypes",
+            "jniAccessible": true,
+            "fields": [
+                { "name": "ffi_type_double" },
+                { "name": "ffi_type_float" },
+                { "name": "ffi_type_longdouble" },
+                { "name": "ffi_type_pointer" },
+                { "name": "ffi_type_sint16" },
+                { "name": "ffi_type_sint32" },
+                { "name": "ffi_type_sint64" },
+                { "name": "ffi_type_sint8" },
+                { "name": "ffi_type_uint16" },
+                { "name": "ffi_type_uint32" },
+                { "name": "ffi_type_uint64" },
+                { "name": "ffi_type_uint8" },
+                { "name": "ffi_type_void" }
+            ]
+        },
+        {
+            "type": "com.sun.jna.Structure$FFIType$size_t",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.WString",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": ["java.lang.String"]
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.Library",
+            "jniAccessible": true
+        },
+        {
+            "type": "com.sun.jna.win32.StdCallLibrary",
+            "jniAccessible": true
+        },
+        {
+            "type": "com.sun.jna.ptr.IntByReference",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.ptr.PointerByReference",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.ptr.ByteByReference",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.ptr.FloatByReference",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true,
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "com.sun.jna.ptr.LongByReference",
+            "allDeclaredFields": true,
+            "allDeclaredConstructors": true,
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": []
+                }
+            ]
         }
+    ],
+    "resources": [
+        {"glob": "com/sun/jna/**"}
     ]
 }

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/knotify.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/knotify.json
@@ -1,0 +1,51 @@
+{
+    "_meta": {
+        "description": "KNotify Windows toast notification library",
+        "matchPackages": [
+            "io.github.kdroidfilter.knotify"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.callbacks.ToastActivatedActionCallback",
+            "methods": [{"name": "invoke", "parameterTypes": ["com.sun.jna.Pointer", "int"]}]
+        },
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.callbacks.ToastActivatedCallback",
+            "methods": [{"name": "invoke", "parameterTypes": ["com.sun.jna.Pointer"]}]
+        },
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.callbacks.ToastDismissedCallback",
+            "methods": [{"name": "invoke", "parameterTypes": ["com.sun.jna.Pointer", "int"]}]
+        },
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.callbacks.ToastFailedCallback"
+        },
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.provider.WindowsNotificationProvider$createCallbacks$activatedActionCallback$1"
+        },
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.provider.WindowsNotificationProvider$createCallbacks$activatedCallback$1"
+        },
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.provider.WindowsNotificationProvider$createCallbacks$dismissedCallback$1"
+        },
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.provider.WindowsNotificationProvider$createCallbacks$failedCallback$1"
+        },
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.nativeintegration.WinToastLibC",
+            "allDeclaredMethods": true
+        },
+        {
+            "type": "io.github.kdroidfilter.knotify.platform.windows.nativeintegration.ExtendedUser32",
+            "allDeclaredMethods": true
+        },
+        {
+            "type": {"proxy": ["io.github.kdroidfilter.knotify.platform.windows.nativeintegration.WinToastLibC"]}
+        },
+        {
+            "type": {"proxy": ["io.github.kdroidfilter.knotify.platform.windows.nativeintegration.ExtendedUser32"]}
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/kotlin-coroutines.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/kotlin-coroutines.json
@@ -7,6 +7,9 @@
             "type": "kotlin.SafePublicationLazyImpl"
         },
         {
+            "type": "kotlinx.atomicfu.AtomicLong"
+        },
+        {
             "type": "kotlin.coroutines.SafeContinuation"
         },
         {

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/ktor.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/ktor.json
@@ -48,6 +48,9 @@
         },
         {
             "type": "io.ktor.utils.io.pool.DefaultPool"
+        },
+        {
+            "type": "io.ktor.client.plugins.logging.HttpClientCallLogger"
         }
     ]
 }

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/platformtools.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/platformtools.json
@@ -1,0 +1,17 @@
+{
+    "_meta": {
+        "description": "KDroid PlatformTools (clipboard, etc.)",
+        "matchPackages": [
+            "io.github.kdroidfilter.platformtools"
+        ]
+    },
+    "reflection": [
+        {
+            "type": {
+                "proxy": [
+                    "io.github.kdroidfilter.platformtools.clipboardmanager.windows.User32Extended"
+                ]
+            }
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/sqlite-jdbc.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/sqlite-jdbc.json
@@ -1,0 +1,28 @@
+{
+    "_meta": {
+        "description": "SQLite JDBC NativeDB JNI bindings",
+        "matchPackages": [
+            "org.sqlite"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "org.sqlite.core.NativeDB",
+            "jniAccessible": true,
+            "fields": [
+                {"name": "busyHandler"},
+                {"name": "commitListener"},
+                {"name": "pointer"},
+                {"name": "progressHandler"},
+                {"name": "updateListener"}
+            ],
+            "methods": [
+                {"name": "stringToUtf8ByteArray", "parameterTypes": ["java.lang.String"]},
+                {"name": "throwex", "parameterTypes": ["java.lang.String"]}
+            ]
+        },
+        {
+            "type": "java.sql.SQLException"
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/windows-reachability-metadata.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/windows-reachability-metadata.json
@@ -2115,6 +2115,16 @@
             "type": "sun.awt.windows.WCanvasPeer"
         },
         {
+            "type": "sun.awt.windows.WClipboard",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "lostSelectionOwnershipImpl",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
             "type": "sun.awt.windows.WComponentPeer",
             "jniAccessible": true,
             "fields": [


### PR DESCRIPTION
## Summary
- Add 8 new L1 library metadata files: coil, compose-mediaplayer, compose-webview-wry (UniFFI), composetray, jna-platform-win32, knotify, platformtools, sqlite-jdbc
- Update 7 existing L1 files: jdk-core (primitives, IOException, UnsatisfiedLinkError, LocaleNames, ICU/IDN resources), jdk-crypto (HKDF, JavaKeyStore), jna (full JNI-accessible core entries + `com/sun/jna/**` resource glob), filekit (Windows JNA dialog types), compose-ui (SwingInteropViewGroup), ktor (HttpClientCallLogger), kotlin-coroutines (AtomicLong)
- Add `sun.awt.windows.WClipboard` JNI entry to Windows L3 platform metadata
- Update `index.txt` with all 27 metadata files sorted alphabetically

## Test plan
- [ ] Verify `preMerge` passes
- [ ] Build a GraalVM native image for a project using these libraries and confirm no missing reflection/JNI errors
- [ ] Validate all JSON files parse correctly (`python -m json.tool`)