### PR TITLE
fix(macos): use NSLocale for RTL detection instead of NSApplication

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/ControlButtonsDirection.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/ControlButtonsDirection.kt
@@ -42,4 +42,4 @@ enum class ControlButtonsDirection {
  * `user.language` system property against known RTL languages.
  */
 internal fun nativeSystemLayoutDirection(): LayoutDirection =
-    if (NativeLayoutDirectionBridge.isSystemRTL()) LayoutDirection.Rtl else LayoutDirection.Ltr
+    if (NativeLayoutDirectionBridge.nativeIsRTL()) LayoutDirection.Rtl else LayoutDirection.Ltr

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/NativeLayoutDirectionBridge.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/NativeLayoutDirectionBridge.kt
@@ -4,22 +4,11 @@ import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
 
 private const val LIBRARY_NAME = "nucleus_layout_direction"
 
-// Known RTL languages used as fallback when the native library is unavailable
-private val RTL_LANGUAGES = setOf("ar", "he", "fa", "ur", "yi", "ps", "sd", "ckb", "ku", "ug", "syr", "dv")
-
 internal object NativeLayoutDirectionBridge {
-    private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeLayoutDirectionBridge::class.java)
-
-    val isLoaded: Boolean get() = loaded
+    init {
+        NativeLibraryLoader.load(LIBRARY_NAME, NativeLayoutDirectionBridge::class.java)
+    }
 
     @JvmStatic
     external fun nativeIsRTL(): Boolean
-
-    fun isSystemRTL(): Boolean =
-        if (loaded) {
-            nativeIsRTL()
-        } else {
-            val language = System.getProperty("user.language") ?: return false
-            language in RTL_LANGUAGES
-        }
 }

--- a/decorated-window-core/src/main/native/macos/NucleusLayoutDirectionBridge.m
+++ b/decorated-window-core/src/main/native/macos/NucleusLayoutDirectionBridge.m
@@ -1,12 +1,15 @@
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 #include <jni.h>
 
 JNIEXPORT jboolean JNICALL
 Java_io_github_kdroidfilter_nucleus_window_NativeLayoutDirectionBridge_nativeIsRTL(
     JNIEnv *env, jclass clazz) {
     @autoreleasepool {
-        return [NSApplication sharedApplication].userInterfaceLayoutDirection
-                   == NSUserInterfaceLayoutDirectionRightToLeft
+        NSString *language = [[NSLocale preferredLanguages] firstObject];
+        if (!language) return JNI_FALSE;
+        NSLocaleLanguageDirection direction =
+            [NSLocale characterDirectionForLanguage:language];
+        return direction == NSLocaleLanguageDirectionRightToLeft
                ? JNI_TRUE
                : JNI_FALSE;
     }

--- a/decorated-window-core/src/main/native/macos/build.sh
+++ b/decorated-window-core/src/main/native/macos/build.sh
@@ -30,7 +30,7 @@ mkdir -p "$OUT_DIR_ARM64" "$OUT_DIR_X64"
 COMMON_FLAGS=(
     -dynamiclib
     -I"$JNI_INCLUDE" -I"$JNI_INCLUDE_DARWIN"
-    -framework Cocoa
+    -framework Foundation
     -mmacosx-version-min=10.13
     -fobjc-arc
     -Oz -flto

--- a/menu-macos/src/main/kotlin/io/github/kdroidfilter/nucleus/menu/macos/NativeNsMenuBridge.kt
+++ b/menu-macos/src/main/kotlin/io/github/kdroidfilter/nucleus/menu/macos/NativeNsMenuBridge.kt
@@ -296,7 +296,9 @@ internal object NativeNsMenuBridge {
     @JvmStatic external fun nativeGetMainMenu(): Long
 
     @JvmStatic external fun nativeSetMainMenu(menuHandle: Long)
+
     @JvmStatic external fun nativeSetWindowsMenu(menuHandle: Long)
+
     @JvmStatic external fun nativeSetHelpMenu(menuHandle: Long)
 
     // ---- Menu submenu ----


### PR DESCRIPTION
## Summary
- **macOS RTL fix**: Replace `NSApplication.userInterfaceLayoutDirection` with `NSLocale.characterDirectionForLanguage:` — the old API reflects the app bundle's localizations, not the user's actual system locale, so it always returned LTR for apps without RTL `.lproj` bundles
- **Remove Kotlin fallback**: `NativeLayoutDirectionBridge` no longer falls back to `user.language` property check — native libraries are required on all platforms
- **Lighter native lib**: macOS dylib now links Foundation instead of Cocoa

## Test plan
- [x] Set macOS system language to Arabic or Hebrew and verify `SystemNative` / `System` control buttons direction is RTL
- [x] Verify LTR languages still return LTR
- [x] Verify Linux and Windows RTL detection is unaffected