### PR TITLE
fix(dmg): prevent self-copy destruction of background image

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -512,8 +512,13 @@ abstract class AbstractElectronBuilderPackageTask
             if (source == null || !source.isFile) return null
             assetsDir.mkdirs()
             val dest = File(assetsDir, "$baseName.${source.extension}")
-            source.copyTo(dest, overwrite = true)
-            logger.info("Copied DMG asset: ${source.absolutePath} → ${dest.absolutePath}")
+            // Skip copy when source is already the destination (e.g. padDmgBackgroundForTitleBar
+            // wrote directly into assetsDir). Kotlin's copyTo(overwrite=true) deletes the target
+            // before copying, which destroys the source when they are the same file (issue #166).
+            if (source.canonicalPath != dest.canonicalPath) {
+                source.copyTo(dest, overwrite = true)
+                logger.info("Copied DMG asset: ${source.absolutePath} → ${dest.absolutePath}")
+            }
             return "dmg-assets/${dest.name}"
         }
 


### PR DESCRIPTION
## Summary

- Fix `FileNotFoundException` when DMG background image (`.tiff` or `.png`) is configured via `dmg { background.set(...) }`
- Root cause: `padDmgBackgroundForTitleBar` writes the padded image directly into `dmg-assets/`, then `copyDmgAsset` tries to copy that file onto itself — Kotlin's `copyTo(overwrite=true)` deletes the target first, destroying the source
- Added a `canonicalPath` check in `copyDmgAsset` to skip the copy when source and destination are the same file

## Test plan

- [x] `packageDmg` with `.tiff` background — pass
- [x] `packageDmg` with `.png` background (clean build) — pass
- [x] `packageReleaseDmg` with `.tiff` background — pass
- [x] `dmg-assets/` correctly populated after build
- [x] `packaging-metadata.json` references correct asset path
- [x] Existing `DmgBackgroundPaddingTest` unit tests pass
- [x] ktlint clean

Closes #166