### PR TITLE
fix(plugin): remove invalid Fast compression and warn on AppImage + Maximum

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,9 +183,14 @@ nativeDistributions {
 | Level | Description |
 |-------|-------------|
 | `CompressionLevel.Store` | No compression |
-| `CompressionLevel.Fast` | Fast compression |
 | `CompressionLevel.Normal` | Balanced (default) |
-| `CompressionLevel.Maximum` | Best compression |
+| `CompressionLevel.Maximum` | Best compression (recommended for most formats) |
+
+!!! warning "AppImage and Maximum Compression"
+    Using `CompressionLevel.Maximum` with AppImage causes extremely slow startup times (60s+)
+    due to squashfs/FUSE decompression overhead. For AppImage targets, use `Normal` or `Store` instead.
+    Other formats (DMG, NSIS, DEB, RPM, etc.) are not affected.
+    See [electron-builder#7483](https://github.com/electron-userland/electron-builder/issues/7483) for details.
 
 ### Trusted CA Certificates
 

--- a/docs/targets/linux.md
+++ b/docs/targets/linux.md
@@ -99,6 +99,18 @@ linux {
 
 `AudioVideo`, `Development`, `Education`, `Game`, `Graphics`, `Network`, `Office`, `Science`, `Settings`, `System`, `Utility`
 
+### Compression
+
+AppImage startup time is heavily affected by the compression level. Using `CompressionLevel.Maximum` causes squashfs/FUSE decompression at every launch, resulting in startup times of **60 seconds or more**.
+
+| Compression Level | Startup Impact | Recommended |
+|---|---|---|
+| `Store` | Fastest startup, largest file | Testing |
+| `Normal` (default) | Good balance | **Production** |
+| `Maximum` | 60s+ startup, ~20% smaller | Not recommended |
+
+See [electron-builder#7483](https://github.com/electron-userland/electron-builder/issues/7483) for details.
+
 ### Build Requirements
 
 AppImage requires `fuse` (or `libfuse2`) on the build host. On Ubuntu:

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/CompressionLevel.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/CompressionLevel.kt
@@ -10,7 +10,6 @@ enum class CompressionLevel(
     internal val id: String,
 ) {
     Store("store"),
-    Fast("fast"),
     Normal("normal"),
     Maximum("maximum"),
 }

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -5,6 +5,7 @@
 
 package io.github.kdroidfilter.nucleus.desktop.application.tasks
 
+import io.github.kdroidfilter.nucleus.desktop.application.dsl.CompressionLevel
 import io.github.kdroidfilter.nucleus.desktop.application.dsl.JvmApplicationDistributions
 import io.github.kdroidfilter.nucleus.desktop.application.dsl.MacOSSigningSettings
 import io.github.kdroidfilter.nucleus.desktop.application.dsl.TargetFormat
@@ -370,6 +371,14 @@ abstract class AbstractElectronBuilderPackageTask
                 } else {
                     null
                 }
+
+            if (targetFormat == TargetFormat.AppImage && distributions.compressionLevel == CompressionLevel.Maximum) {
+                logger.warn(
+                    "AppImage with 'maximum' compression can cause extremely slow startup times (60s+) " +
+                        "due to squashfs/FUSE decompression overhead. Consider using 'normal' or 'store' instead. " +
+                        "See https://github.com/electron-userland/electron-builder/issues/7483",
+                )
+            }
 
             val configContent =
                 configGenerator.generateConfig(


### PR DESCRIPTION
## Summary
- Remove `CompressionLevel.Fast` which mapped to `"fast"` — not a valid electron-builder value (only `"store"`, `"normal"`, `"maximum"` are accepted)
- Add a build-time `logger.warn()` when AppImage is used with `CompressionLevel.Maximum`, as squashfs/FUSE decompression causes 60s+ startup times
- Document AppImage compression impact in `configuration.md` and `targets/linux.md`

Closes #158

## Test plan
- [x] Verify `CompressionLevel` enum only has `Store`, `Normal`, `Maximum`
- [x] Build an AppImage with `Maximum` compression and confirm the warning is logged
- [x] Build a non-AppImage format (DMG/NSIS/DEB) with `Maximum` and confirm no warning