### PR TITLE
fix(decorated-window): remove unused TitleBarIcons API

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/NucleusDecoratedWindowTheme.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/NucleusDecoratedWindowTheme.kt
@@ -13,7 +13,6 @@ import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowStyle
 import io.github.kdroidfilter.nucleus.window.styling.LocalDecoratedWindowStyle
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarColors
-import io.github.kdroidfilter.nucleus.window.styling.TitleBarIcons
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarMetrics
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 
@@ -96,7 +95,7 @@ object DecoratedWindowDefaults {
                     height = 40.dp,
                     titlePaneButtonSize = if (isKde) DpSize(28.dp, 28.dp) else DpSize(40.dp, 40.dp),
                 ),
-            icons = TitleBarIcons(),
+
         )
 
     fun darkTitleBarStyle(): TitleBarStyle =
@@ -124,6 +123,6 @@ object DecoratedWindowDefaults {
                     height = 40.dp,
                     titlePaneButtonSize = if (isKde) DpSize(28.dp, 28.dp) else DpSize(40.dp, 40.dp),
                 ),
-            icons = TitleBarIcons(),
+
         )
 }

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/styling/TitleBarStyling.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/styling/TitleBarStyling.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -14,7 +13,6 @@ import io.github.kdroidfilter.nucleus.window.DecoratedWindowState
 data class TitleBarStyle(
     val colors: TitleBarColors,
     val metrics: TitleBarMetrics,
-    val icons: TitleBarIcons,
 )
 
 data class TitleBarColors(
@@ -37,13 +35,6 @@ data class TitleBarMetrics(
     val gradientStartX: Dp = (-100).dp,
     val gradientEndX: Dp = 400.dp,
     val titlePaneButtonSize: DpSize = DpSize(40.dp, 40.dp),
-)
-
-data class TitleBarIcons(
-    val closeButton: Painter? = null,
-    val minimizeButton: Painter? = null,
-    val maximizeButton: Painter? = null,
-    val restoreButton: Painter? = null,
 )
 
 val LocalTitleBarStyle =

--- a/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelColorMapping.kt
+++ b/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelColorMapping.kt
@@ -11,7 +11,6 @@ import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowColors
 import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowMetrics
 import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarColors
-import io.github.kdroidfilter.nucleus.window.styling.TitleBarIcons
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarMetrics
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 import org.jetbrains.jewel.foundation.theme.JewelTheme
@@ -69,7 +68,7 @@ internal fun rememberJewelTitleBarStyle(): TitleBarStyle {
                     height = 40.dp,
                     titlePaneButtonSize = if (isKde) DpSize(28.dp, 28.dp) else DpSize(40.dp, 40.dp),
                 ),
-            icons = TitleBarIcons(),
+
         )
     }
 }

--- a/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialColorMapping.kt
+++ b/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialColorMapping.kt
@@ -11,7 +11,6 @@ import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowColors
 import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowMetrics
 import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarColors
-import io.github.kdroidfilter.nucleus.window.styling.TitleBarIcons
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarMetrics
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 
@@ -59,7 +58,7 @@ internal fun rememberMaterialTitleBarStyle(colors: Colors): TitleBarStyle {
                     height = 40.dp,
                     titlePaneButtonSize = if (isKde) DpSize(28.dp, 28.dp) else DpSize(40.dp, 40.dp),
                 ),
-            icons = TitleBarIcons(),
+
         )
     }
 }

--- a/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialColorMapping.kt
+++ b/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialColorMapping.kt
@@ -12,7 +12,6 @@ import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowColors
 import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowMetrics
 import io.github.kdroidfilter.nucleus.window.styling.DecoratedWindowStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarColors
-import io.github.kdroidfilter.nucleus.window.styling.TitleBarIcons
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarMetrics
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 
@@ -56,7 +55,7 @@ internal fun rememberMaterialTitleBarStyle(colorScheme: ColorScheme): TitleBarSt
                     height = 40.dp,
                     titlePaneButtonSize = if (isKde) DpSize(28.dp, 28.dp) else DpSize(40.dp, 40.dp),
                 ),
-            icons = TitleBarIcons(),
+
         )
     }
 

--- a/docs/runtime/decorated-window.md
+++ b/docs/runtime/decorated-window.md
@@ -397,7 +397,7 @@ val myTitleBarStyle = TitleBarStyle(
         border = MyTheme.colors.outline,
     ),
     metrics = TitleBarMetrics(height = 40.dp),
-    icons = TitleBarIcons(), // null = use platform defaults
+
 )
 
 NucleusDecoratedWindowTheme(


### PR DESCRIPTION
## Summary

- Remove `TitleBarIcons` data class and its `icons` field from `TitleBarStyle`
- Clean up all references in theme providers (default, Jewel, Material 2, Material 3) and docs
- The API was never wired into button rendering — custom painters were silently ignored
- Icon customization is not feasible: macOS traffic lights and JBR buttons are system-controlled, and proper support on Windows/Linux would require hover/pressed/inactive state variants

Closes #173

## Test plan

- [x] Verify decorated window builds and renders correctly on Windows
- [x] Verify no compilation errors in all `decorated-window-*` modules
- [x] Confirm `reformatAll` passes cleanly