### PR TITLE
fix(core-runtime): handle stale lock files in SingleInstanceManager

### DIFF
--- a/core-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/core/runtime/SingleInstanceManager.kt
+++ b/core-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/core/runtime/SingleInstanceManager.kt
@@ -22,6 +22,7 @@ import java.nio.file.StandardWatchEventKinds
  * This object ensures that only one instance of the application can run at a time,
  * and provides a mechanism to notify the running instance when another instance attempts to start.
  */
+@Suppress("TooManyFunctions")
 object SingleInstanceManager {
     private const val TAG = "SingleInstanceChecker"
 
@@ -73,25 +74,11 @@ object SingleInstanceManager {
             return true
         }
         val lockFile = createLockFile()
-        fileChannel = RandomAccessFile(lockFile, "rw").channel
         return try {
+            fileChannel = openLockChannel(lockFile)
             fileLock = fileChannel?.tryLock()
             if (fileLock != null) {
-                // We are the only instance
-                debugLog { "Lock acquired, starting to watch for restore requests" }
-                // Ensure that watching is started only once
-                if (!isWatching) {
-                    isWatching = true
-                    watchForRestoreRequests(onRestoreRequest)
-                }
-                Runtime.getRuntime().addShutdownHook(
-                    Thread {
-                        releaseLock()
-                        lockFile.delete()
-                        deleteRestoreRequestFile()
-                        debugLog { "Shutdown hook executed" }
-                    },
-                )
+                onLockAcquired(lockFile, onRestoreRequest)
                 true
             } else {
                 // Another instance is already running
@@ -104,8 +91,66 @@ object SingleInstanceManager {
             debugLog { "The lock is already held by this process (${e.message})" }
             return true
         } catch (e: IOException) {
-            errorLog { "Error in isSingleInstance: $e" }
-            false
+            // Stale lock file (read-only, corrupted, etc.) — delete and retry once
+            debugLog { "Lock failed ($e), deleting stale lock file and retrying" }
+            deleteStaleLockFile(lockFile)
+            return retryLock(lockFile, onRestoreFileCreated, onRestoreRequest)
+        }
+    }
+
+    private fun openLockChannel(lockFile: File): FileChannel = RandomAccessFile(lockFile, "rw").channel
+
+    private fun onLockAcquired(
+        lockFile: File,
+        onRestoreRequest: Path.() -> Unit,
+    ) {
+        debugLog { "Lock acquired, starting to watch for restore requests" }
+        deleteRestoreRequestFile()
+        if (!isWatching) {
+            isWatching = true
+            watchForRestoreRequests(onRestoreRequest)
+        }
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                releaseLock()
+                lockFile.delete()
+                deleteRestoreRequestFile()
+                debugLog { "Shutdown hook executed" }
+            },
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun retryLock(
+        lockFile: File,
+        onRestoreFileCreated: (Path.() -> Unit)?,
+        onRestoreRequest: Path.() -> Unit,
+    ): Boolean =
+        try {
+            fileChannel = openLockChannel(lockFile)
+            fileLock = fileChannel?.tryLock()
+            if (fileLock != null) {
+                onLockAcquired(lockFile, onRestoreRequest)
+                true
+            } else {
+                sendRestoreRequest(onRestoreFileCreated)
+                debugLog { "Restore request sent to the existing instance (retry)" }
+                false
+            }
+        } catch (e: Exception) {
+            // Cannot recover — fail-open to avoid silently blocking the user
+            errorLog { "Cannot acquire lock after retry: $e" }
+            true
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun deleteStaleLockFile(lockFile: File) {
+        try {
+            lockFile.setWritable(true)
+            lockFile.delete()
+            debugLog { "Stale lock file deleted: ${lockFile.absolutePath}" }
+        } catch (e: Exception) {
+            errorLog { "Failed to delete stale lock file: $e" }
         }
     }
 
@@ -156,6 +201,7 @@ object SingleInstanceManager {
                 tempRestoreFilePath.onRestoreFileCreated()
                 Files.move(tempRestoreFilePath, restoreRequestFilePath, StandardCopyOption.REPLACE_EXISTING)
             } else {
+                Files.deleteIfExists(restoreRequestFilePath)
                 Files.createFile(restoreRequestFilePath)
             }
             debugLog { "Restore request file created: $restoreRequestFilePath" }

--- a/core-runtime/src/test/kotlin/io/github/kdroidfilter/nucleus/core/runtime/SingleInstanceHolder.kt
+++ b/core-runtime/src/test/kotlin/io/github/kdroidfilter/nucleus/core/runtime/SingleInstanceHolder.kt
@@ -1,0 +1,68 @@
+package io.github.kdroidfilter.nucleus.core.runtime
+
+import java.nio.file.Paths
+
+/**
+ * Subprocess helper that exercises the real [SingleInstanceManager].
+ *
+ * Args: <lockDir> <lockIdentifier> [holdSeconds]
+ *
+ * Prints to stdout (one tag per line):
+ *   "SINGLE"          — isSingleInstance() returned true (primary)
+ *   "NOT_SINGLE"      — isSingleInstance() returned false (secondary)
+ *   "RESTORE_REQUEST" — primary received a restore request from another instance
+ *   "ERROR:<message>"  — exception was thrown
+ *
+ * When SINGLE:
+ *   - If holdSeconds is provided, holds the lock for that duration then exits with code 0
+ *   - Otherwise, sleeps forever (expects SIGKILL to simulate crash)
+ *
+ * Exit codes: 0 = primary, 1 = secondary, 2 = error
+ */
+fun main(args: Array<String>) {
+    if (args.size < 2) {
+        System.err.println("Usage: <lockDir> <lockId> [holdSeconds]")
+        System.exit(2)
+    }
+
+    val lockDir = Paths.get(args[0])
+    val lockId = args[1]
+    val holdSeconds = args.getOrNull(2)?.toLongOrNull()
+
+    SingleInstanceManager.configuration =
+        SingleInstanceManager.Configuration(
+            lockFilesDir = lockDir,
+            lockIdentifier = lockId,
+        )
+
+    val result =
+        try {
+            SingleInstanceManager.isSingleInstance(
+                onRestoreFileCreated = null,
+                onRestoreRequest = {
+                    println("RESTORE_REQUEST")
+                    System.out.flush()
+                },
+            )
+        } catch (e: Throwable) {
+            println("ERROR:${e.javaClass.simpleName}:${e.message}")
+            System.out.flush()
+            System.exit(2)
+            return
+        }
+
+    if (result) {
+        println("SINGLE")
+        System.out.flush()
+        if (holdSeconds != null) {
+            Thread.sleep(holdSeconds * 1000)
+        } else {
+            Thread.sleep(Long.MAX_VALUE)
+        }
+    } else {
+        println("NOT_SINGLE")
+        System.out.flush()
+    }
+
+    System.exit(if (result) 0 else 1)
+}

--- a/core-runtime/src/test/kotlin/io/github/kdroidfilter/nucleus/core/runtime/SingleInstanceManagerEndToEndTest.kt
+++ b/core-runtime/src/test/kotlin/io/github/kdroidfilter/nucleus/core/runtime/SingleInstanceManagerEndToEndTest.kt
@@ -1,0 +1,231 @@
+package io.github.kdroidfilter.nucleus.core.runtime
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.BufferedReader
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end tests for [SingleInstanceManager].
+ *
+ * Each test launches real subprocesses exercising [SingleInstanceManager]
+ * to avoid singleton state pollution between tests.
+ *
+ * Tests cover:
+ * - Normal behavior (single instance, rejection, clean relaunch, restore requests)
+ * - Issue #161: stale/read-only residual lock files must not block startup
+ */
+class SingleInstanceManagerEndToEndTest {
+    private lateinit var tempDir: Path
+    private val lockIdentifier = "e2e-test-instance"
+
+    private val javaBin = File(System.getProperty("java.home"), "bin/java").absolutePath
+    private val classpath = System.getProperty("java.class.path")
+    private val processes = mutableListOf<Process>()
+
+    @Before
+    fun setUp() {
+        tempDir = Files.createTempDirectory("single-instance-e2e")
+    }
+
+    @After
+    fun tearDown() {
+        processes.forEach { p ->
+            if (p.isAlive) p.destroyForcibly()
+        }
+        processes.forEach { p -> p.waitFor(5, TimeUnit.SECONDS) }
+        tempDir.toFile().deleteRecursively()
+    }
+
+    // ── Normal behavior ───────────────────────────────────────────────
+
+    @Test
+    fun `first instance acquires lock and reports SINGLE`() {
+        val process = startProcess()
+        assertEquals("SINGLE", readSignal(process))
+    }
+
+    @Test
+    fun `second instance is rejected while first holds the lock`() {
+        val primary = startProcess()
+        assertEquals("SINGLE", readSignal(primary))
+
+        val secondary = startProcess()
+        assertEquals("NOT_SINGLE", readSignal(secondary))
+    }
+
+    @Test
+    fun `relaunch succeeds after first instance exits cleanly`() {
+        val first = startProcess(holdSeconds = 1)
+        assertEquals("SINGLE", readSignal(first))
+
+        // Wait for first to exit via its shutdown hook
+        assertTrue("First process should exit cleanly", first.waitFor(10, TimeUnit.SECONDS))
+        assertEquals("First process should exit with code 0", 0, first.exitValue())
+
+        // Lock file should be cleaned up by the shutdown hook
+        val lockFile = tempDir.resolve("$lockIdentifier.lock").toFile()
+        assertFalse("Lock file should be deleted by shutdown hook", lockFile.exists())
+
+        // Second launch must succeed
+        val second = startProcess(holdSeconds = 1)
+        assertEquals("SINGLE", readSignal(second))
+        assertTrue(second.waitFor(10, TimeUnit.SECONDS))
+        assertEquals(0, second.exitValue())
+    }
+
+    @Test
+    fun `relaunch succeeds after first instance is killed (SIGKILL)`() {
+        val first = startProcess()
+        assertEquals("SINGLE", readSignal(first))
+
+        first.destroyForcibly()
+        assertTrue(first.waitFor(5, TimeUnit.SECONDS))
+
+        // Lock file remains (shutdown hook didn't run)
+        val lockFile = tempDir.resolve("$lockIdentifier.lock").toFile()
+        assertTrue("Lock file should remain after SIGKILL", lockFile.exists())
+
+        // Relaunch must still succeed
+        val second = startProcess(holdSeconds = 1)
+        assertEquals("SINGLE", readSignal(second))
+        assertTrue(second.waitFor(10, TimeUnit.SECONDS))
+        assertEquals(0, second.exitValue())
+    }
+
+    @Test
+    fun `secondary instance exits with code 1`() {
+        val primary = startProcess()
+        assertEquals("SINGLE", readSignal(primary))
+
+        val secondary = startProcess()
+        assertEquals("NOT_SINGLE", readSignal(secondary))
+        assertTrue(secondary.waitFor(5, TimeUnit.SECONDS))
+        assertEquals("Secondary should exit with code 1", 1, secondary.exitValue())
+    }
+
+    @Test
+    fun `primary receives restore request from secondary`() {
+        val primary = startProcess()
+        val primaryReader = primary.inputStream.bufferedReader()
+        assertEquals("SINGLE", primaryReader.readLine())
+
+        // Launch secondary — it creates a .restore_request file
+        val secondary = startProcess()
+        assertEquals("NOT_SINGLE", readSignal(secondary))
+        assertTrue(secondary.waitFor(5, TimeUnit.SECONDS))
+
+        // Primary's WatchService should detect it (macOS polling can be slow)
+        val restoreLine = waitForLine(primary, primaryReader, "RESTORE_REQUEST", timeoutMs = 15_000)
+        assertEquals("Primary should receive RESTORE_REQUEST", "RESTORE_REQUEST", restoreLine)
+    }
+
+    // ── Issue #161: stale residual files ───────────────────────────────
+
+    @Test
+    fun `stale lock file does not prevent new instance from starting`() {
+        createStaleLockFile()
+        val process = startProcess(holdSeconds = 1)
+        assertEquals("SINGLE", readSignal(process))
+        assertTrue(process.waitFor(10, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+    }
+
+    @Test
+    fun `stale lock AND restore_request files do not prevent new instance`() {
+        createStaleLockFile()
+        tempDir.resolve("$lockIdentifier.restore_request").toFile().createNewFile()
+
+        val process = startProcess(holdSeconds = 1)
+        assertEquals("SINGLE", readSignal(process))
+        assertTrue(process.waitFor(10, TimeUnit.SECONDS))
+        assertEquals(0, process.exitValue())
+    }
+
+    @Test
+    fun `read-only stale lock file does not prevent new instance from starting`() {
+        val staleLock = createStaleLockFile()
+        staleLock.setReadOnly()
+        assertTrue("Lock file must be read-only", !staleLock.canWrite())
+
+        val process = startProcess(holdSeconds = 1)
+        try {
+            assertEquals("SINGLE", readSignal(process))
+            assertTrue(process.waitFor(10, TimeUnit.SECONDS))
+            assertEquals(0, process.exitValue())
+        } finally {
+            staleLock.setWritable(true)
+        }
+    }
+
+    @Test
+    fun `read-only stale lock AND restore_request do not prevent new instance`() {
+        val staleLock = createStaleLockFile()
+        staleLock.setReadOnly()
+        tempDir.resolve("$lockIdentifier.restore_request").toFile().createNewFile()
+
+        val process = startProcess(holdSeconds = 1)
+        try {
+            assertEquals("SINGLE", readSignal(process))
+            assertTrue(process.waitFor(10, TimeUnit.SECONDS))
+            assertEquals(0, process.exitValue())
+        } finally {
+            staleLock.setWritable(true)
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private fun createStaleLockFile(): File {
+        val lockFile = tempDir.resolve("$lockIdentifier.lock").toFile()
+        lockFile.createNewFile()
+        assertTrue("Stale lock file must exist", lockFile.exists())
+        return lockFile
+    }
+
+    private fun startProcess(holdSeconds: Long? = null): Process {
+        val args =
+            mutableListOf(
+                javaBin,
+                "-cp",
+                classpath,
+                "io.github.kdroidfilter.nucleus.core.runtime.SingleInstanceHolderKt",
+                tempDir.toAbsolutePath().toString(),
+                lockIdentifier,
+            )
+        if (holdSeconds != null) args.add(holdSeconds.toString())
+
+        val process = ProcessBuilder(args).start()
+        processes.add(process)
+        return process
+    }
+
+    private fun readSignal(process: Process): String = process.inputStream.bufferedReader().readLine()
+
+    @Suppress("LoopWithTooManyJumpStatements")
+    private fun waitForLine(
+        process: Process,
+        reader: BufferedReader,
+        marker: String,
+        timeoutMs: Long,
+    ): String? {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (!process.isAlive && !reader.ready()) return null
+            if (reader.ready()) {
+                val line = reader.readLine() ?: return null
+                if (line.contains(marker)) return line
+            } else {
+                Thread.sleep(50)
+            }
+        }
+        return null
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #161

- Move `RandomAccessFile(lockFile, "rw")` inside the try-catch — previously an IOException here was uncaught and crashed the app
- On IOException (e.g. read-only residual lock file): `setWritable(true)` + `delete()` + retry once
- If retry also fails: fail-open (`return true`) instead of silently blocking the user
- Clean stale `.restore_request` files on primary startup
- `deleteIfExists` before `createFile` in `sendRestoreRequest` to avoid `FileAlreadyExistsException`

## Test plan

- [x] `first instance acquires lock and reports SINGLE`
- [x] `second instance is rejected while first holds the lock`
- [x] `relaunch succeeds after first instance exits cleanly`
- [x] `relaunch succeeds after first instance is killed (SIGKILL)`
- [x] `secondary instance exits with code 1`
- [x] `primary receives restore request from secondary`
- [x] `stale lock file does not prevent new instance from starting`
- [x] `stale lock AND restore_request files do not prevent new instance`
- [x] `read-only stale lock file does not prevent new instance from starting`
- [x] `read-only stale lock AND restore_request do not prevent new instance`