### PR TITLE
fix(decorated-window-jni): apply DPI scaling to window min/max size on Windows

### DIFF
--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
@@ -270,6 +270,8 @@ private fun SyncMinMaxSizeToNative(window: java.awt.Window) {
             window.addPropertyChangeListener(propertyListener)
             onDispose {
                 window.removePropertyChangeListener(propertyListener)
+                JniWindowsDecorationBridge.nativeSetMinimumSize(hwnd, 0, 0)
+                JniWindowsDecorationBridge.nativeSetMaximumSize(hwnd, 0, 0)
             }
         } else {
             onDispose { }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
@@ -99,6 +99,9 @@ private fun DecoratedWindowScope.NativeWindowsTitleBar(
         }
     }
 
+    // Fix DPI scaling for min/max size on non-JBR JVMs (issue #102)
+    SyncMinMaxSizeToNative(window)
+
     val useNewFullscreenControls = modifier.hasNewFullscreenControls()
 
     // ── Fullscreen with newFullscreenControls: sliding overlay ──
@@ -236,5 +239,40 @@ private fun DecoratedWindowScope.FallbackWindowsTitleBar(
     ) { currentState ->
         WindowsWindowControlArea(window, currentState, style)
         content(currentState)
+    }
+}
+
+/**
+ * Syncs [java.awt.Window.minimumSize] and [java.awt.Window.maximumSize] to the native
+ * WM_GETMINMAXINFO handler so that DPI scaling is applied correctly on non-JBR JVMs.
+ */
+@Suppress("FunctionNaming")
+@Composable
+private fun SyncMinMaxSizeToNative(window: java.awt.Window) {
+    DisposableEffect(window) {
+        val hwnd = JniWindowsWindowUtil.getHwnd(window)
+        if (hwnd != 0L) {
+            val syncSizes = {
+                val min = window.minimumSize
+                JniWindowsDecorationBridge.nativeSetMinimumSize(hwnd, min.width, min.height)
+                val max = window.maximumSize
+                val maxW = if (max.width < Short.MAX_VALUE) max.width else 0
+                val maxH = if (max.height < Short.MAX_VALUE) max.height else 0
+                JniWindowsDecorationBridge.nativeSetMaximumSize(hwnd, maxW, maxH)
+            }
+            syncSizes()
+            val propertyListener =
+                java.beans.PropertyChangeListener { evt ->
+                    if (evt.propertyName == "minimumSize" || evt.propertyName == "maximumSize") {
+                        syncSizes()
+                    }
+                }
+            window.addPropertyChangeListener(propertyListener)
+            onDispose {
+                window.removePropertyChangeListener(propertyListener)
+            }
+        } else {
+            onDispose { }
+        }
     }
 }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/windows/JniWindowsDecorationBridge.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/windows/JniWindowsDecorationBridge.kt
@@ -73,6 +73,26 @@ internal object JniWindowsDecorationBridge {
         argb: Int,
     )
 
+    // Sets the minimum window size in logical pixels. The native
+    // WM_GETMINMAXINFO handler applies DPI scaling automatically.
+    // Pass (0, 0) to disable the override and fall back to AWT default.
+    @JvmStatic
+    external fun nativeSetMinimumSize(
+        hwnd: Long,
+        widthPx: Int,
+        heightPx: Int,
+    )
+
+    // Sets the maximum window size in logical pixels. The native
+    // WM_GETMINMAXINFO handler applies DPI scaling automatically.
+    // Pass (0, 0) to disable the override and fall back to AWT default.
+    @JvmStatic
+    external fun nativeSetMaximumSize(
+        hwnd: Long,
+        widthPx: Int,
+        heightPx: Int,
+    )
+
     // Returns debug counters as a string (temporary).
     @JvmStatic
     external fun nativeGetDebugInfo(hwnd: Long): String

--- a/decorated-window-jni/src/main/native/windows/nucleus_windows_decoration.c
+++ b/decorated-window-jni/src/main/native/windows/nucleus_windows_decoration.c
@@ -434,17 +434,15 @@ static LRESULT CALLBACK decorationWndProc(
         LPMINMAXINFO lpmmi = (LPMINMAXINFO)lParam;
         UINT dpi = getDpi(hwnd);
 
-        /* Override with DPI-scaled values if set */
-        if (state->minSizePx.x > 0 || state->minSizePx.y > 0) {
+        /* Override with DPI-scaled values if set (per-axis) */
+        if (state->minSizePx.x > 0)
             lpmmi->ptMinTrackSize.x = MulDiv(state->minSizePx.x, dpi, 96);
+        if (state->minSizePx.y > 0)
             lpmmi->ptMinTrackSize.y = MulDiv(state->minSizePx.y, dpi, 96);
-        }
-        if (state->maxSizePx.x > 0 || state->maxSizePx.y > 0) {
-            if (state->maxSizePx.x > 0)
-                lpmmi->ptMaxTrackSize.x = MulDiv(state->maxSizePx.x, dpi, 96);
-            if (state->maxSizePx.y > 0)
-                lpmmi->ptMaxTrackSize.y = MulDiv(state->maxSizePx.y, dpi, 96);
-        }
+        if (state->maxSizePx.x > 0)
+            lpmmi->ptMaxTrackSize.x = MulDiv(state->maxSizePx.x, dpi, 96);
+        if (state->maxSizePx.y > 0)
+            lpmmi->ptMaxTrackSize.y = MulDiv(state->maxSizePx.y, dpi, 96);
         return result;
     }
 

--- a/decorated-window-jni/src/main/native/windows/nucleus_windows_decoration.c
+++ b/decorated-window-jni/src/main/native/windows/nucleus_windows_decoration.c
@@ -93,6 +93,9 @@ typedef struct {
     LONG    savedStyle;
     LONG    savedExStyle;
     WINDOWPLACEMENT savedPlacement;
+    /* Min/max size override (logical pixels, 0 = not set) */
+    POINT   minSizePx;
+    POINT   maxSizePx;
     /* Debug counters */
     int     hitTestCount;
     int     hitTestCaption;
@@ -416,6 +419,33 @@ static LRESULT CALLBACK decorationWndProc(
         ScreenToClient(hwnd, &pt);
         PostMessageW(hwnd, WM_MOUSEMOVE, 0, MAKELPARAM(pt.x, pt.y));
         break;  /* also let original handle it */
+    }
+
+    /* -------------------------------------------------------------- */
+    /*  WM_GETMINMAXINFO: fix DPI scaling for min/max size.            */
+    /*  Standard OpenJDK stores logical pixels in ptMinTrackSize but  */
+    /*  Windows expects physical pixels. JBR applies ScaleUpX/Y;      */
+    /*  we replicate that fix here so it works on all JVMs.            */
+    /* -------------------------------------------------------------- */
+    case WM_GETMINMAXINFO: {
+        /* Let AWT process first (sets unscaled values) */
+        LRESULT result = CallWindowProcW(state->originalWndProc,
+                                          hwnd, msg, wParam, lParam);
+        LPMINMAXINFO lpmmi = (LPMINMAXINFO)lParam;
+        UINT dpi = getDpi(hwnd);
+
+        /* Override with DPI-scaled values if set */
+        if (state->minSizePx.x > 0 || state->minSizePx.y > 0) {
+            lpmmi->ptMinTrackSize.x = MulDiv(state->minSizePx.x, dpi, 96);
+            lpmmi->ptMinTrackSize.y = MulDiv(state->minSizePx.y, dpi, 96);
+        }
+        if (state->maxSizePx.x > 0 || state->maxSizePx.y > 0) {
+            if (state->maxSizePx.x > 0)
+                lpmmi->ptMaxTrackSize.x = MulDiv(state->maxSizePx.x, dpi, 96);
+            if (state->maxSizePx.y > 0)
+                lpmmi->ptMaxTrackSize.y = MulDiv(state->maxSizePx.y, dpi, 96);
+        }
+        return result;
     }
 
     /* -------------------------------------------------------------- */
@@ -1031,4 +1061,44 @@ Java_io_github_kdroidfilter_nucleus_window_utils_windows_JniWindowsDecorationBri
             (int)state->forceHitTestClient);
     }
     return (*env)->NewStringUTF(env, buf);
+}
+
+/* -------------------------------------------------------------- */
+/*  nativeSetMinimumSize(long hwnd, int widthPx, int heightPx)     */
+/*  Stores the minimum window size in logical pixels. The          */
+/*  WM_GETMINMAXINFO handler applies DPI scaling automatically.    */
+/*  Pass (0, 0) to disable the override and fall back to AWT.      */
+/* -------------------------------------------------------------- */
+JNIEXPORT void JNICALL
+Java_io_github_kdroidfilter_nucleus_window_utils_windows_JniWindowsDecorationBridge_nativeSetMinimumSize(
+    JNIEnv *env, jclass clazz, jlong hwndLong, jint widthPx, jint heightPx)
+{
+    HWND hwnd = (HWND)(uintptr_t)hwndLong;
+    if (!hwnd) return;
+
+    DecoState *state = getState(hwnd);
+    if (!state) return;
+
+    state->minSizePx.x = (LONG)widthPx;
+    state->minSizePx.y = (LONG)heightPx;
+}
+
+/* -------------------------------------------------------------- */
+/*  nativeSetMaximumSize(long hwnd, int widthPx, int heightPx)     */
+/*  Stores the maximum window size in logical pixels. The          */
+/*  WM_GETMINMAXINFO handler applies DPI scaling automatically.    */
+/*  Pass (0, 0) to disable the override and fall back to AWT.      */
+/* -------------------------------------------------------------- */
+JNIEXPORT void JNICALL
+Java_io_github_kdroidfilter_nucleus_window_utils_windows_JniWindowsDecorationBridge_nativeSetMaximumSize(
+    JNIEnv *env, jclass clazz, jlong hwndLong, jint widthPx, jint heightPx)
+{
+    HWND hwnd = (HWND)(uintptr_t)hwndLong;
+    if (!hwnd) return;
+
+    DecoState *state = getState(hwnd);
+    if (!state) return;
+
+    state->maxSizePx.x = (LONG)widthPx;
+    state->maxSizePx.y = (LONG)heightPx;
 }

--- a/decorated-window-jni/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.decorated-window-jni/reachability-metadata.json
+++ b/decorated-window-jni/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.decorated-window-jni/reachability-metadata.json
@@ -12,6 +12,28 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "io.github.kdroidfilter.nucleus.window.utils.windows.JniWindowsDecorationBridge",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "nativeSetMinimumSize",
+                    "parameterTypes": [
+                        "long",
+                        "int",
+                        "int"
+                    ]
+                },
+                {
+                    "name": "nativeSetMaximumSize",
+                    "parameterTypes": [
+                        "long",
+                        "int",
+                        "int"
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/docs/runtime/decorated-window.md
+++ b/docs/runtime/decorated-window.md
@@ -58,6 +58,13 @@ This module does not depend on JBR, making it compatible with **any JVM** (OpenJ
 !!! info "macOS: Liquid Glass and Xcode 26 appearance"
     Nucleus automatically patches the application launcher's `LC_BUILD_VERSION` to macOS SDK 26.0 via `vtool`, enabling Liquid Glass window decorations (larger traffic lights, rounded corners). This works with **any JDK** — a JDK compiled with Xcode 26 is no longer required. See [macOS 26 Window Appearance](../targets/macos.md#macos-26-window-appearance-liquid-glass) for details and configuration options.
 
+!!! note "Windows: DPI-aware minimum and maximum window size"
+    On non-JBR JVMs (OpenJDK, GraalVM), `Window.minimumSize` and `Window.maximumSize` are stored in logical pixels but Windows expects physical pixels in `WM_GETMINMAXINFO`. This causes the enforced min/max size to be too small on HiDPI displays (e.g. a 640×480 minimum becomes 427×320 at 150% scaling). JBR fixes this internally with `ScaleUpX`/`ScaleUpY`.
+
+    The JNI module replicates this fix: it intercepts `WM_GETMINMAXINFO` after AWT and applies `MulDiv(value, dpi, 96)` scaling. Just set `window.minimumSize` or `window.maximumSize` as usual — the DPI correction is automatic.
+
+    This fix is **not present** in `decorated-window-jbr` (JBR handles it natively).
+
 !!! note "Windows: no white background flash during resize"
     On Windows, Skiko's rendering pipeline clears the DirectX canvas to white before each frame. When the window is resized larger, the newly exposed pixels remain white for one frame — producing a visible white flash. The JNI module eliminates this by adjusting Skiko's clear color to transparent for dark themes (rendered as opaque black on the DirectX surface), so the flash is invisible against a dark background. It also synchronizes the DWM caption and border colors (`DWMWA_CAPTION_COLOR`, `DWMWA_BORDER_COLOR`, `DWMWA_USE_IMMERSIVE_DARK_MODE`) with the title bar color for consistent Windows 11 window chrome styling.
 
@@ -175,6 +182,7 @@ The following tables compare a standard Compose `Window()`, the JBR module (`dec
 | True fullscreen | Broken (doesn't cover taskbar) | Broken (doesn't cover taskbar) | **Fixed** — native Win32 fullscreen (`newFullscreenControls()`) |
 | Fullscreen sliding title bar | No | No | Yes (`newFullscreenControls()`) |
 | DWM dark mode sync | No | No | Yes (`DWMWA_USE_IMMERSIVE_DARK_MODE`, caption/border color) |
+| DPI-aware min/max size | Broken on non-JBR | JBR handles it | **Fixed** — `WM_GETMINMAXINFO` DPI scaling |
 | RTL support | No custom title bar | Yes (no hot-swap, restart required) | Yes (live hot-swap) |
 | JDK requirement | Any | JBR only | Any |
 | Fallback (no native lib) | N/A | N/A | Compose `windowDragHandler()` (no WndProc subclass) |

--- a/example/src/main/kotlin/com/example/demo/Main.kt
+++ b/example/src/main/kotlin/com/example/demo/Main.kt
@@ -175,6 +175,10 @@ fun main(args: Array<String>) {
                     onCloseRequest = ::exitApplication,
                     title = "Nucleus Demo",
                 ) {
+                    // Set minimum window size (DPI-scaled automatically by JNI module)
+                    LaunchedEffect(Unit) {
+                        window.minimumSize = java.awt.Dimension(640, 480)
+                    }
                     CompositionLocalProvider(
                         LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr,
                     ) {


### PR DESCRIPTION
## Summary

- Intercept `WM_GETMINMAXINFO` in the native WndProc subclass and apply `MulDiv(value, dpi, 96)` scaling to `ptMinTrackSize` / `ptMaxTrackSize`
- Add `nativeSetMinimumSize` / `nativeSetMaximumSize` JNI functions to push min/max values from Kotlin to native
- Sync `window.minimumSize` / `window.maximumSize` via `PropertyChangeListener` in `SyncMinMaxSizeToNative` composable

Fixes `window.minimumSize` being ignored on non-JBR JVMs (Azul, Oracle OpenJDK) at HiDPI scaling levels. Standard OpenJDK sets `ptMinTrackSize` in logical pixels, but Windows expects physical pixels. JBR applies `ScaleUpX/Y`; we replicate that fix in our WndProc.

Closes #102

## Test plan

- [x] Build native DLL on Windows (`build.bat`)
- [x] Run example app with non-JBR JVM + `window.minimumSize = Dimension(800, 600)`
- [x] Verify window cannot be resized below 800×600 at 150% and 200% DPI
- [x] Verify no regression on JBR (both fixes coexist safely)
- [x] Verify maximized window still works correctly