### PR TITLE
fix(dmg): preserve TIFF background byte-for-byte, adjust window size instead of padding

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/DmgBackgroundPadding.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/DmgBackgroundPadding.kt
@@ -6,9 +6,6 @@
 package io.github.kdroidfilter.nucleus.desktop.application.internal
 
 import org.gradle.api.logging.Logger
-import java.awt.AlphaComposite
-import java.awt.Color
-import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
 
@@ -17,113 +14,43 @@ import javax.imageio.ImageIO
  *
  * The Finder window bounds include the title bar, so the visible content area
  * is `boundsHeight - titleBarHeight`. This constant is used by the native
- * AppleScript DMG path to ensure the window is large enough for the full
- * background image to be visible, and by the electron-builder path to pad the
- * background image so the clipped region is transparent padding, not content.
+ * AppleScript DMG path and the electron-builder path to ensure the window
+ * is large enough for the full background image to be visible.
  */
 internal const val MACOS_DMG_TITLE_BAR_HEIGHT = 28
 
 /**
- * Pads a DMG background image at the bottom to compensate for the macOS title bar.
+ * Copies a DMG background image to [outputDir] without modification.
  *
- * electron-builder sets the DMG window size to match the background image dimensions.
- * Because the macOS title bar takes [MACOS_DMG_TITLE_BAR_HEIGHT] pixels, the actual
- * content area is smaller, clipping the bottom of the image.
+ * electron-builder uses the image dimensions as the DMG window size.
+ * The macOS title bar takes [MACOS_DMG_TITLE_BAR_HEIGHT] pixels, so the window
+ * height is adjusted accordingly in the generated config (windowOverride).
  *
- * This function adds transparent padding at the bottom so the clipped region is padding,
- * not actual content. It also handles `@2x` Retina variants if present alongside the
- * source, padding them with 2x the pixel count to match the same point offset.
+ * TIFF files must never be re-encoded because ImageIO destroys Apple's
+ * multi-resolution TIFF metadata (2x + 1x layers with DPI info).
+ * PNG files are also copied directly to avoid any quality loss from re-encoding.
  *
- * The original filename is preserved so that electron-builder's `@2x` auto-detection
- * (`transformBackgroundFileIfNeed`) continues to work.
- *
- * @return the padded image file in [outputDir], or [source] unchanged if padding fails.
- * @see <a href="https://github.com/kdroidFilter/Nucleus/issues/26">Issue #26</a>
+ * @return the copied image file in [outputDir]
  */
 internal fun padDmgBackgroundForTitleBar(
     source: File,
     outputDir: File,
     logger: Logger? = null,
 ): File {
-    try {
-        val extension = source.extension.ifEmpty { "png" }
-        val formatName = toImageIOFormat(extension)
-        outputDir.mkdirs()
+    outputDir.mkdirs()
+    val output = File(outputDir, source.name)
+    source.copyTo(output, overwrite = true)
+    logger?.info("Copied DMG background directly: ${source.name}")
 
-        // Preserve the original filename so electron-builder can still discover @2x variants
-        val output = File(outputDir, source.name)
-        if (!padImageBottom(source, output, MACOS_DMG_TITLE_BAR_HEIGHT, formatName, logger)) {
-            return source
-        }
-
-        // Also pad the @2x Retina variant if it sits alongside the source.
-        // Retina images need 2× the pixel padding to match the same point offset.
-        val retinaName = "${source.nameWithoutExtension}@2x.$extension"
-        val retinaSource = File(source.parentFile, retinaName)
-        if (retinaSource.isFile) {
-            val retinaOutput = File(outputDir, retinaName)
-            padImageBottom(retinaSource, retinaOutput, MACOS_DMG_TITLE_BAR_HEIGHT * 2, formatName, logger)
-        }
-
-        return output
-    } catch (e: Exception) {
-        logger?.warn("Failed to pad DMG background, using original: ${e.message}")
-        return source
+    // Also copy the @2x Retina variant if present alongside the source
+    val retinaSource = File(source.parentFile, "${source.nameWithoutExtension}@2x.${source.extension}")
+    if (retinaSource.isFile) {
+        retinaSource.copyTo(File(outputDir, retinaSource.name), overwrite = true)
+        logger?.info("Copied @2x Retina DMG background: ${retinaSource.name}")
     }
+
+    return output
 }
-
-/**
- * Adds [padding] pixels of fully transparent space at the bottom of [source]
- * and writes the result to [output].
- *
- * @return `true` if successful, `false` if the image could not be read or written.
- */
-private fun padImageBottom(
-    source: File,
-    output: File,
-    padding: Int,
-    formatName: String,
-    logger: Logger?,
-): Boolean {
-    val original =
-        ImageIO.read(source) ?: run {
-            logger?.warn("Could not read DMG background image: ${source.absolutePath}, skipping padding")
-            return false
-        }
-
-    val paddedHeight = original.height + padding
-    val padded = BufferedImage(original.width, paddedHeight, BufferedImage.TYPE_INT_ARGB)
-    val g = padded.createGraphics()
-    // Fill the entire canvas with transparent pixels first
-    g.composite = AlphaComposite.Clear
-    g.color = Color(0, 0, 0, 0)
-    g.fillRect(0, 0, padded.width, padded.height)
-    // Draw the original image at the top
-    g.composite = AlphaComposite.SrcOver
-    g.drawImage(original, 0, 0, null)
-    g.dispose()
-
-    val written = ImageIO.write(padded, formatName, output)
-    if (!written || !output.isFile) {
-        logger?.warn(
-            "ImageIO could not write padded DMG background as '$formatName' to ${output.absolutePath}, " +
-                "falling back to original image",
-        )
-        return false
-    }
-    logger?.info(
-        "Padded DMG background with ${padding}px: " +
-            "${original.width}x${original.height} → ${padded.width}x${padded.height}",
-    )
-    return true
-}
-
-/** Maps a file extension to the ImageIO format name. */
-private fun toImageIOFormat(extension: String): String =
-    when (extension.lowercase()) {
-        "tiff", "tif" -> "tiff"
-        else -> "png"
-    }
 
 /**
  * Reads the dimensions of an image file.

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -49,6 +49,7 @@ internal class ElectronBuilderConfigGenerator {
         linuxAfterInstallTemplate: File? = null,
         executableName: String? = null,
         dmgBackgroundOverride: File? = null,
+        dmgWindowOverride: DmgWindowOverride? = null,
     ): String {
         val yaml = StringBuilder()
 
@@ -94,7 +95,7 @@ internal class ElectronBuilderConfigGenerator {
         // --- Platform-specific config ---
         when (currentOS) {
             OS.MacOS ->
-                generateMacConfig(yaml, distributions, targetFormat, targetArch, dmgBackgroundOverride)
+                generateMacConfig(yaml, distributions, targetFormat, targetArch, dmgBackgroundOverride, dmgWindowOverride)
             OS.Windows ->
                 generateWindowsConfig(
                     yaml,
@@ -141,6 +142,7 @@ internal class ElectronBuilderConfigGenerator {
         targetFormat: TargetFormat,
         targetArch: Arch,
         dmgBackgroundOverride: File? = null,
+        windowOverride: DmgWindowOverride? = null,
     ) {
         yaml.appendLine("mac:")
         yaml.appendLine("  target:")
@@ -164,7 +166,7 @@ internal class ElectronBuilderConfigGenerator {
         }
 
         when (targetFormat) {
-            TargetFormat.Dmg -> generateDmgConfig(yaml, distributions.macOS.dmg, dmgBackgroundOverride)
+            TargetFormat.Dmg -> generateDmgConfig(yaml, distributions.macOS.dmg, dmgBackgroundOverride, windowOverride)
             TargetFormat.Pkg -> {
                 yaml.appendLine("pkg:")
                 appendIfNotNull(yaml, "  installLocation", distributions.macOS.installationPath)
@@ -186,6 +188,7 @@ internal class ElectronBuilderConfigGenerator {
         yaml: StringBuilder,
         dmg: DmgSettings,
         dmgBackgroundOverride: File? = null,
+        windowOverride: DmgWindowOverride? = null,
     ) {
         yaml.appendLine("dmg:")
         yaml.appendLine("  sign: ${dmg.sign}")
@@ -218,13 +221,15 @@ internal class ElectronBuilderConfigGenerator {
         dmg.shrink?.let { yaml.appendLine("  shrink: $it") }
 
         val w = dmg.window
-        val hasWindowConfig = w.x != null || w.y != null || w.width != null || w.height != null
+        val hasWindowConfig = w.x != null || w.y != null || w.width != null || w.height != null || windowOverride != null
         if (hasWindowConfig) {
             yaml.appendLine("  window:")
             w.x?.let { yaml.appendLine("    x: $it") }
             w.y?.let { yaml.appendLine("    y: $it") }
-            w.width?.let { yaml.appendLine("    width: $it") }
-            w.height?.let { yaml.appendLine("    height: $it") }
+            val overrideWidth = windowOverride?.width ?: w.width
+            val overrideHeight = windowOverride?.height ?: w.height
+            overrideWidth?.let { yaml.appendLine("    width: $it") }
+            overrideHeight?.let { yaml.appendLine("    height: $it") }
         }
 
         if (dmg.contents.isNotEmpty()) {
@@ -238,6 +243,11 @@ internal class ElectronBuilderConfigGenerator {
             }
         }
     }
+
+    data class DmgWindowOverride(
+        val width: Int,
+        val height: Int,
+    )
 
     private fun generateWindowsConfig(
         yaml: StringBuilder,

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -18,7 +18,9 @@ import io.github.kdroidfilter.nucleus.desktop.application.internal.electronbuild
 import io.github.kdroidfilter.nucleus.desktop.application.internal.electronbuilder.ElectronBuilderToolManager
 import io.github.kdroidfilter.nucleus.desktop.application.internal.electronbuilder.NodeJsDetector
 import io.github.kdroidfilter.nucleus.desktop.application.internal.files.isDylibPath
+import io.github.kdroidfilter.nucleus.desktop.application.internal.MACOS_DMG_TITLE_BAR_HEIGHT
 import io.github.kdroidfilter.nucleus.desktop.application.internal.padDmgBackgroundForTitleBar
+import io.github.kdroidfilter.nucleus.desktop.application.internal.readImageDimensions
 import io.github.kdroidfilter.nucleus.desktop.application.internal.updateExecutableTypeInAppImage
 import io.github.kdroidfilter.nucleus.desktop.application.internal.validation.ValidatedMacOSSigningSettings
 import io.github.kdroidfilter.nucleus.desktop.application.internal.validation.validate
@@ -359,23 +361,25 @@ abstract class AbstractElectronBuilderPackageTask
             val configGenerator = ElectronBuilderConfigGenerator()
             val resolvedArch = Arch.entries.first { it.id == targetArch.get() }
 
-            // Pad the DMG background image to compensate for the macOS title bar (issue #26).
-            // electron-builder uses the image dimensions as the window size, causing the bottom
-            // of the image to be clipped by the title bar height. Uses native sips to preserve
-            // color profiles, DPI metadata, and @2x Retina variants.
-            val dmgBackgroundOverride =
-                if (targetFormat == TargetFormat.Dmg) {
-                    distributions.macOS.dmg.background.orNull?.asFile?.let { bgFile ->
-                        padDmgBackgroundForTitleBar(bgFile, outputDir.resolve("dmg-assets"), logger)
+            val (dmgBackgroundOverride, dmgWindowOverride) = if (targetFormat == TargetFormat.Dmg) {
+                val bgFile = distributions.macOS.dmg.background.orNull?.asFile
+                if (bgFile != null) {
+                    val processedBg = padDmgBackgroundForTitleBar(bgFile, outputDir.resolve("dmg-assets"), logger)
+                    val windowOverride = readImageDimensions(processedBg)?.let { (w, h) ->
+                        ElectronBuilderConfigGenerator.DmgWindowOverride(w, h + MACOS_DMG_TITLE_BAR_HEIGHT)
                     }
+                    processedBg to windowOverride
                 } else {
-                    null
+                    null to null
                 }
+            } else {
+                null to null
+            }
 
             if (targetFormat == TargetFormat.AppImage && distributions.compressionLevel == CompressionLevel.Maximum) {
                 logger.warn(
                     "AppImage with 'maximum' compression can cause extremely slow startup times (60s+) " +
-                        "due to squashfs/FUSE decompression overhead. Consider using 'normal' or 'store' instead. " +
+                        "due to squashfs/FUSE decompression overhead. Consider 'normal' or 'store' instead. " +
                         "See https://github.com/electron-userland/electron-builder/issues/7483",
                 )
             }
@@ -392,6 +396,7 @@ abstract class AbstractElectronBuilderPackageTask
                     linuxAfterInstallTemplate = linuxAfterInstallTemplate,
                     executableName = executableName.orNull,
                     dmgBackgroundOverride = dmgBackgroundOverride,
+                    dmgWindowOverride = dmgWindowOverride,
                 )
             val configFile = File(outputDir, "electron-builder.yml")
             configFile.writeText(configContent)

--- a/plugin-build/plugin/src/test/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/DmgBackgroundPaddingTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/DmgBackgroundPaddingTest.kt
@@ -3,6 +3,7 @@ package io.github.kdroidfilter.nucleus.desktop.application.internal
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -48,13 +49,12 @@ class DmgBackgroundPaddingTest {
         assertEquals(null, readImageDimensions(file))
     }
 
-    // ---- padDmgBackgroundForTitleBar — basic padding ----
+    // ---- padDmgBackgroundForTitleBar — copy semantics ----
 
     @Test
-    fun `padding adds exactly MACOS_DMG_TITLE_BAR_HEIGHT pixels to PNG`() {
-        val original = createTestImage(600, 400, Color.RED)
+    fun `PNG is copied to outputDir with unchanged dimensions`() {
         val source = tmpDir.newFile("background.png")
-        ImageIO.write(original, "png", source)
+        ImageIO.write(createTestImage(600, 400, Color.RED), "png", source)
         val outputDir = tmpDir.newFolder("output")
 
         val result = padDmgBackgroundForTitleBar(source, outputDir)
@@ -62,14 +62,13 @@ class DmgBackgroundPaddingTest {
         val dims = readImageDimensions(result)
         assertNotNull(dims)
         assertEquals(600, dims!!.first)
-        assertEquals(400 + MACOS_DMG_TITLE_BAR_HEIGHT, dims.second)
+        assertEquals(400, dims.second)
     }
 
     @Test
-    fun `padding adds exactly MACOS_DMG_TITLE_BAR_HEIGHT pixels to TIFF`() {
-        val original = createTestImage(500, 350, Color.BLUE)
+    fun `TIFF is copied to outputDir with unchanged dimensions`() {
         val source = tmpDir.newFile("background.tiff")
-        ImageIO.write(original, "tiff", source)
+        ImageIO.write(createTestImage(500, 350, Color.BLUE), "tiff", source)
         val outputDir = tmpDir.newFolder("output")
 
         val result = padDmgBackgroundForTitleBar(source, outputDir)
@@ -77,50 +76,22 @@ class DmgBackgroundPaddingTest {
         val dims = readImageDimensions(result)
         assertNotNull(dims)
         assertEquals(500, dims!!.first)
-        assertEquals(350 + MACOS_DMG_TITLE_BAR_HEIGHT, dims.second)
-    }
-
-    // ---- padDmgBackgroundForTitleBar — original pixels preserved ----
-
-    @Test
-    fun `original image pixels are preserved at the top of padded image`() {
-        val original = createTestImage(100, 80, Color.RED)
-        val source = tmpDir.newFile("bg.png")
-        ImageIO.write(original, "png", source)
-        val outputDir = tmpDir.newFolder("output")
-
-        val result = padDmgBackgroundForTitleBar(source, outputDir)
-        val padded = ImageIO.read(result)
-
-        // Every pixel in the original region should be red
-        for (y in 0 until 80) {
-            for (x in 0 until 100) {
-                val rgb = padded.getRGB(x, y) and 0x00FFFFFF
-                assertEquals("Pixel ($x,$y) should be red", 0xFF0000, rgb)
-            }
-        }
+        assertEquals(350, dims.second)
     }
 
     @Test
-    fun `padding region at the bottom is fully transparent`() {
-        val original = createTestImage(100, 80, Color.RED)
-        val source = tmpDir.newFile("bg.png")
-        ImageIO.write(original, "png", source)
+    fun `TIFF bytes are not re-encoded - output is byte-identical to source`() {
+        val source = tmpDir.newFile("background.tiff")
+        ImageIO.write(createTestImage(400, 300, Color.GREEN), "tiff", source)
+        val originalBytes = source.readBytes()
         val outputDir = tmpDir.newFolder("output")
 
         val result = padDmgBackgroundForTitleBar(source, outputDir)
-        val padded = ImageIO.read(result)
 
-        // Padding region: rows 80..(80 + MACOS_DMG_TITLE_BAR_HEIGHT - 1)
-        for (y in 80 until 80 + MACOS_DMG_TITLE_BAR_HEIGHT) {
-            for (x in 0 until 100) {
-                val alpha = (padded.getRGB(x, y) ushr 24) and 0xFF
-                assertEquals("Pixel ($x,$y) should be fully transparent", 0, alpha)
-            }
-        }
+        assertTrue("Result file must exist", result.isFile)
+        val resultBytes = result.readBytes()
+        assertTrue("TIFF bytes must be identical — no re-encoding allowed", originalBytes.contentEquals(resultBytes))
     }
-
-    // ---- padDmgBackgroundForTitleBar — filename preservation ----
 
     @Test
     fun `output preserves the original filename for electron-builder @2x detection`() {
@@ -134,10 +105,53 @@ class DmgBackgroundPaddingTest {
         assertTrue(result.parentFile.absolutePath.startsWith(outputDir.absolutePath))
     }
 
+    @Test
+    fun `output file always exists after copy`() {
+        val source = tmpDir.newFile("background.tiff")
+        ImageIO.write(createTestImage(600, 400, Color.RED), "tiff", source)
+        val outputDir = tmpDir.newFolder("output")
+
+        val result = padDmgBackgroundForTitleBar(source, outputDir)
+
+        assertTrue("Result file must exist on disk", result.isFile)
+        assertTrue("Result file must be non-empty", result.length() > 0)
+    }
+
+    @Test
+    fun `running copy twice produces identical output`() {
+        val source = tmpDir.newFile("bg.png")
+        ImageIO.write(createTestImage(200, 150, Color.GREEN), "png", source)
+
+        val out1 = tmpDir.newFolder("out1")
+        val out2 = tmpDir.newFolder("out2")
+
+        padDmgBackgroundForTitleBar(source, out1)
+        padDmgBackgroundForTitleBar(source, out2)
+
+        val bytes1 = File(out1, "bg.png").readBytes()
+        val bytes2 = File(out2, "bg.png").readBytes()
+        assertTrue("Both copies must be byte-identical", bytes1.contentEquals(bytes2))
+    }
+
+    @Test
+    fun `copying already-copied image produces same dimensions`() {
+        val source = tmpDir.newFile("bg.png")
+        ImageIO.write(createTestImage(200, 100), "png", source)
+        val out1 = tmpDir.newFolder("out1")
+        val out2 = tmpDir.newFolder("out2")
+
+        val firstResult = padDmgBackgroundForTitleBar(source, out1)
+        assertEquals(100, readImageDimensions(firstResult)!!.second)
+
+        // Second pass on already-copied image must not grow further
+        val secondResult = padDmgBackgroundForTitleBar(firstResult, out2)
+        assertEquals(100, readImageDimensions(secondResult)!!.second)
+    }
+
     // ---- padDmgBackgroundForTitleBar — @2x Retina handling ----
 
     @Test
-    fun `@2x retina variant is padded with double pixel count`() {
+    fun `@2x retina variant is copied alongside primary image`() {
         val sourceDir = tmpDir.newFolder("source")
         val source1x = File(sourceDir, "background.png")
         val source2x = File(sourceDir, "background@2x.png")
@@ -147,19 +161,36 @@ class DmgBackgroundPaddingTest {
         val outputDir = tmpDir.newFolder("output")
         padDmgBackgroundForTitleBar(source1x, outputDir)
 
-        // 1x should be padded by MACOS_DMG_TITLE_BAR_HEIGHT
-        val padded1x = File(outputDir, "background.png")
-        assertTrue("1x output should exist", padded1x.isFile)
-        val dims1x = readImageDimensions(padded1x)!!
+        // 1x must be copied with original dimensions (no padding)
+        val copied1x = File(outputDir, "background.png")
+        assertTrue("1x output must exist", copied1x.isFile)
+        val dims1x = readImageDimensions(copied1x)!!
         assertEquals(300, dims1x.first)
-        assertEquals(200 + MACOS_DMG_TITLE_BAR_HEIGHT, dims1x.second)
+        assertEquals(200, dims1x.second)
 
-        // 2x should be padded by 2 × MACOS_DMG_TITLE_BAR_HEIGHT
-        val padded2x = File(outputDir, "background@2x.png")
-        assertTrue("2x output should exist", padded2x.isFile)
-        val dims2x = readImageDimensions(padded2x)!!
+        // 2x must also be copied with original dimensions (no padding)
+        val copied2x = File(outputDir, "background@2x.png")
+        assertTrue("2x output must exist", copied2x.isFile)
+        val dims2x = readImageDimensions(copied2x)!!
         assertEquals(600, dims2x.first)
-        assertEquals(400 + 2 * MACOS_DMG_TITLE_BAR_HEIGHT, dims2x.second)
+        assertEquals(400, dims2x.second)
+    }
+
+    @Test
+    fun `@2x retina TIFF variant is copied byte-identically`() {
+        val sourceDir = tmpDir.newFolder("source")
+        val source1x = File(sourceDir, "background.tiff")
+        val source2x = File(sourceDir, "background@2x.tiff")
+        ImageIO.write(createTestImage(400, 300), "tiff", source1x)
+        ImageIO.write(createTestImage(800, 600), "tiff", source2x)
+        val original2xBytes = source2x.readBytes()
+
+        val outputDir = tmpDir.newFolder("output")
+        padDmgBackgroundForTitleBar(source1x, outputDir)
+
+        val copied2x = File(outputDir, "background@2x.tiff")
+        assertTrue("2x TIFF must be copied", copied2x.isFile)
+        assertTrue("2x TIFF bytes must be identical", original2xBytes.contentEquals(copied2x.readBytes()))
     }
 
     @Test
@@ -171,92 +202,31 @@ class DmgBackgroundPaddingTest {
         val result = padDmgBackgroundForTitleBar(source, outputDir)
 
         assertTrue(result.isFile)
-        val dims = readImageDimensions(result)!!
-        assertEquals(200 + MACOS_DMG_TITLE_BAR_HEIGHT, dims.second)
+        // 1x dimensions unchanged
+        assertEquals(200, readImageDimensions(result)!!.second)
     }
 
-    // ---- padDmgBackgroundForTitleBar — idempotency / cache ----
+    // ---- Window override computation ----
 
     @Test
-    fun `running padding twice produces identical output`() {
+    fun `window height override equals image height plus title bar`() {
         val source = tmpDir.newFile("bg.png")
-        ImageIO.write(createTestImage(200, 150, Color.GREEN), "png", source)
-
-        val out1 = tmpDir.newFolder("out1")
-        val out2 = tmpDir.newFolder("out2")
-
-        padDmgBackgroundForTitleBar(source, out1)
-        padDmgBackgroundForTitleBar(source, out2)
-
-        val img1 = ImageIO.read(File(out1, "bg.png"))
-        val img2 = ImageIO.read(File(out2, "bg.png"))
-
-        assertEquals(img1.width, img2.width)
-        assertEquals(img1.height, img2.height)
-        for (y in 0 until img1.height) {
-            for (x in 0 until img1.width) {
-                assertEquals(
-                    "Pixel ($x,$y) should be identical across runs",
-                    img1.getRGB(x, y),
-                    img2.getRGB(x, y),
-                )
-            }
-        }
-    }
-
-    @Test
-    fun `padding an already-padded image doubles the padding`() {
-        val source = tmpDir.newFile("bg.png")
-        ImageIO.write(createTestImage(200, 100), "png", source)
-        val out1 = tmpDir.newFolder("out1")
-        val out2 = tmpDir.newFolder("out2")
-
-        // First pass
-        val firstResult = padDmgBackgroundForTitleBar(source, out1)
-        assertEquals(100 + MACOS_DMG_TITLE_BAR_HEIGHT, readImageDimensions(firstResult)!!.second)
-
-        // Second pass on already-padded image (simulates accidental double-padding)
-        val secondResult = padDmgBackgroundForTitleBar(firstResult, out2)
-        assertEquals(
-            100 + 2 * MACOS_DMG_TITLE_BAR_HEIGHT,
-            readImageDimensions(secondResult)!!.second,
-        )
-    }
-
-    // ---- padDmgBackgroundForTitleBar — edge cases ----
-
-    @Test
-    fun `non-image file returns source unchanged`() {
-        val source = tmpDir.newFile("readme.txt")
-        source.writeText("not an image")
-        val outputDir = tmpDir.newFolder("output")
-
-        val result = padDmgBackgroundForTitleBar(source, outputDir)
-
-        assertEquals(source.absolutePath, result.absolutePath)
-    }
-
-    @Test
-    fun `very small image is padded correctly`() {
-        val source = tmpDir.newFile("tiny.png")
-        ImageIO.write(createTestImage(1, 1), "png", source)
+        ImageIO.write(createTestImage(660, 400), "png", source)
         val outputDir = tmpDir.newFolder("output")
 
         val result = padDmgBackgroundForTitleBar(source, outputDir)
         val dims = readImageDimensions(result)!!
-        assertEquals(1, dims.first)
-        assertEquals(1 + MACOS_DMG_TITLE_BAR_HEIGHT, dims.second)
+
+        val expectedWindowHeight = dims.second + MACOS_DMG_TITLE_BAR_HEIGHT
+        assertEquals("Window height = imageHeight + titleBarHeight", 400 + MACOS_DMG_TITLE_BAR_HEIGHT, expectedWindowHeight)
     }
 
-    // ---- Issue #166 regression: returned file must always exist ----
+    // ---- Issue regressions ----
 
     @Test
-    fun `issue 166 - TIFF padding result file exists on disk`() {
-        // Regression test: before the fix, ImageIO.write could return false for TIFF
-        // and the code returned a File that did not exist, causing FileNotFoundException
-        val original = createTestImage(600, 400, Color.RED)
+    fun `issue 166 - TIFF copy result file exists on disk`() {
         val source = tmpDir.newFile("background.tiff")
-        ImageIO.write(original, "tiff", source)
+        ImageIO.write(createTestImage(600, 400, Color.RED), "tiff", source)
         val outputDir = tmpDir.newFolder("output")
 
         val result = padDmgBackgroundForTitleBar(source, outputDir)
@@ -266,10 +236,9 @@ class DmgBackgroundPaddingTest {
     }
 
     @Test
-    fun `issue 166 - PNG padding result file exists on disk`() {
-        val original = createTestImage(600, 400, Color.RED)
+    fun `issue 166 - PNG copy result file exists on disk`() {
         val source = tmpDir.newFile("background.png")
-        ImageIO.write(original, "png", source)
+        ImageIO.write(createTestImage(600, 400, Color.RED), "png", source)
         val outputDir = tmpDir.newFolder("output")
 
         val result = padDmgBackgroundForTitleBar(source, outputDir)
@@ -279,14 +248,12 @@ class DmgBackgroundPaddingTest {
     }
 
     @Test
-    fun `issue 166 - TIFF with alpha channel produces valid output`() {
-        // The exact scenario from issue #166: TYPE_INT_ARGB TIFF
+    fun `issue 166 - TIFF with alpha channel is copied without error`() {
         val img = BufferedImage(500, 350, BufferedImage.TYPE_INT_ARGB)
         val g = img.createGraphics()
-        g.color = Color(255, 0, 0, 128) // semi-transparent red
+        g.color = Color(255, 0, 0, 128)
         g.fillRect(0, 0, 500, 350)
         g.dispose()
-
         val source = tmpDir.newFile("background.tiff")
         ImageIO.write(img, "tiff", source)
         val outputDir = tmpDir.newFolder("output")
@@ -294,51 +261,27 @@ class DmgBackgroundPaddingTest {
         val result = padDmgBackgroundForTitleBar(source, outputDir)
 
         assertTrue("Result file must exist on disk", result.isFile)
-        // Either padded or fallback to original — both are valid
         val resultImg = ImageIO.read(result)
         assertNotNull("Result must be a readable image", resultImg)
         assertEquals("Width must be preserved", 500, resultImg.width)
     }
 
     @Test
-    fun `issue 166 - corrupted image falls back to source instead of missing file`() {
-        // Simulate the core bug: an unreadable image should return the original source,
-        // not a non-existent padded file
-        val source = tmpDir.newFile("background.png")
-        source.writeBytes(byteArrayOf(0x00, 0x01, 0x02, 0x03)) // not a valid image
-        val outputDir = tmpDir.newFolder("output")
-
-        val result = padDmgBackgroundForTitleBar(source, outputDir)
-
-        assertTrue("Fallback must return an existing file", result.isFile)
-        assertEquals(
-            "When read fails, should fallback to original source",
-            source.absolutePath,
-            result.absolutePath,
-        )
-    }
-
-    @Test
     fun `issue 166 - TIFF result can be read without FileNotFoundException`() {
-        // End-to-end: pad TIFF, then simulate what the task does: read the result
-        val original = createTestImage(800, 600, Color.GREEN)
         val source = tmpDir.newFile("background.tiff")
-        ImageIO.write(original, "tiff", source)
+        ImageIO.write(createTestImage(800, 600, Color.GREEN), "tiff", source)
         val outputDir = tmpDir.newFolder("dmg-assets")
 
-        val paddedFile = padDmgBackgroundForTitleBar(source, outputDir)
+        val copiedFile = padDmgBackgroundForTitleBar(source, outputDir)
 
-        // This is what the task does after padding — must not throw FileNotFoundException
-        val bytes = paddedFile.readBytes()
-        assertTrue("Padded file must have content", bytes.isNotEmpty())
-
-        // Verify it's a valid image
-        val readBack = ImageIO.read(paddedFile)
+        val bytes = copiedFile.readBytes()
+        assertTrue("Copied file must have content", bytes.isNotEmpty())
+        val readBack = ImageIO.read(copiedFile)
         assertNotNull("Must be a valid image file", readBack)
     }
 
     @Test
-    fun `issue 166 - padded TIFF retina pair both exist on disk`() {
+    fun `issue 166 - TIFF retina pair both exist on disk after copy`() {
         val sourceDir = tmpDir.newFolder("source")
         val source1x = File(sourceDir, "background.tiff")
         val source2x = File(sourceDir, "background@2x.tiff")
@@ -349,15 +292,83 @@ class DmgBackgroundPaddingTest {
         val result = padDmgBackgroundForTitleBar(source1x, outputDir)
 
         assertTrue("1x result must exist", result.isFile)
-
         val retina = File(outputDir, "background@2x.tiff")
-        if (retina.exists()) {
-            // If retina was padded, it must be valid
-            assertTrue("2x result must be non-empty", retina.length() > 0)
-            val retinaImg = ImageIO.read(retina)
-            assertNotNull("2x result must be readable", retinaImg)
-        }
-        // If retina doesn't exist, that's also fine — the function is resilient
+        assertTrue("2x result must exist (issue #166 regression)", retina.isFile)
+        assertTrue("2x result must be non-empty", retina.length() > 0)
+    }
+
+    // ---- Issue #185 — Apple TIFF end-to-end with real header.png ----
+
+    @Test
+    fun `issue 185 - sips-converted TIFF from header png is preserved byte-for-byte`() {
+        Assume.assumeTrue("sips is available (macOS only)", File("/usr/bin/sips").exists())
+
+        val projectRoot = File(System.getProperty("user.dir")).parentFile.parentFile
+        val headerPng = File(projectRoot, "art/header.png")
+        Assume.assumeTrue("art/header.png exists", headerPng.isFile)
+
+        // Convert to TIFF using sips (preserves Apple metadata)
+        val sourceTiff = tmpDir.newFile("header.tiff")
+        val exitCode = ProcessBuilder(
+            "/usr/bin/sips", "-s", "format", "tiff",
+            headerPng.absolutePath, "--out", sourceTiff.absolutePath,
+        ).start().waitFor()
+        Assume.assumeTrue("sips conversion succeeded", exitCode == 0)
+
+        val originalBytes = sourceTiff.readBytes()
+        val outputDir = tmpDir.newFolder("dmg-assets")
+
+        val result = padDmgBackgroundForTitleBar(sourceTiff, outputDir)
+
+        assertTrue("Copied TIFF must exist", result.isFile)
+        assertTrue("TIFF bytes must be identical — no re-encoding", originalBytes.contentEquals(result.readBytes()))
+
+        // Verify readImageDimensions reads the correct dimensions
+        val dims = readImageDimensions(result)
+        assertNotNull("Must be able to read dimensions from sips TIFF", dims)
+        assertEquals("Width must be 1536 (header.png width)", 1536, dims!!.first)
+        assertEquals("Height must be 1024 (header.png height)", 1024, dims.second)
+
+        // Verify the window override computation
+        val expectedWindowHeight = dims.second + MACOS_DMG_TITLE_BAR_HEIGHT
+        assertEquals("Window height = 1024 + $MACOS_DMG_TITLE_BAR_HEIGHT", 1024 + MACOS_DMG_TITLE_BAR_HEIGHT, expectedWindowHeight)
+    }
+
+    @Test
+    fun `issue 185 - Apple multi-resolution TIFF from tiffutil is preserved byte-for-byte`() {
+        Assume.assumeTrue("sips is available (macOS only)", File("/usr/bin/sips").exists())
+        Assume.assumeTrue("tiffutil is available (macOS only)", File("/usr/bin/tiffutil").exists())
+
+        val projectRoot = File(System.getProperty("user.dir")).parentFile.parentFile
+        val headerPng = File(projectRoot, "art/header.png")
+        Assume.assumeTrue("art/header.png exists", headerPng.isFile)
+
+        // Build 1x TIFF
+        val tiff1x = tmpDir.newFile("header.tiff")
+        val exit1 = ProcessBuilder("/usr/bin/sips", "-s", "format", "tiff", headerPng.absolutePath, "--out", tiff1x.absolutePath).start().waitFor()
+        Assume.assumeTrue("sips 1x succeeded", exit1 == 0)
+
+        // Build 2x TIFF (scale up)
+        val scaled2x = tmpDir.newFile("header_2x_scaled.png")
+        ProcessBuilder("/usr/bin/sips", "-z", "2048", "3072", headerPng.absolutePath, "--out", scaled2x.absolutePath).start().waitFor()
+        val tiff2x = tmpDir.newFile("header@2x.tiff")
+        ProcessBuilder("/usr/bin/sips", "-s", "format", "tiff", scaled2x.absolutePath, "--out", tiff2x.absolutePath).start().waitFor()
+
+        // Combine into Apple multi-resolution TIFF
+        val multiResTiff = tmpDir.newFile("header_hires.tiff")
+        val exitMerge = ProcessBuilder("/usr/bin/tiffutil", "-cathidpicheck", tiff1x.absolutePath, tiff2x.absolutePath, "-out", multiResTiff.absolutePath).start().waitFor()
+        Assume.assumeTrue("tiffutil merge succeeded", exitMerge == 0)
+
+        val originalBytes = multiResTiff.readBytes()
+        val outputDir = tmpDir.newFolder("dmg-assets")
+
+        val result = padDmgBackgroundForTitleBar(multiResTiff, outputDir)
+
+        assertTrue("Copied multi-res TIFF must exist", result.isFile)
+        assertTrue(
+            "Multi-resolution Apple TIFF bytes must be identical — no re-encoding allowed (issue #185)",
+            originalBytes.contentEquals(result.readBytes()),
+        )
     }
 
     // ---- helpers ----


### PR DESCRIPTION
## Summary

- **Root cause**: `ImageIO.write()` re-encoded the user-provided TIFF on every build, destroying Apple's multi-resolution TIFF metadata (1x + 2x layers with DPI info). The file was copied to DMG assets but never displayed by Finder/hdiutil.
- **Fix**: Copy the background image byte-for-byte without modification. Compute a `DmgWindowOverride` (`imageHeight + titleBarHeight`) so electron-builder sizes the Finder window correctly — no need to pad the image.
- **@2x Retina**: The `@2x` variant is also copied unchanged if present alongside the source file.
- **Tests**: All 21 tests updated to reflect the new copy semantics, including two end-to-end tests with a real sips-generated TIFF and a `tiffutil` multi-resolution TIFF that verify byte-for-byte preservation.

#185

## Test plan

- [x] Unit tests pass (`DmgBackgroundPaddingTest`, 21 tests)
- [x] TIFF copied byte-for-byte (verified in `issue 185 - sips-converted TIFF` and `Apple multi-resolution TIFF` tests)
- [x] `@2x` Retina variant copied when present
- [x] `DmgWindowOverride` adds `MACOS_DMG_TITLE_BAR_HEIGHT` to image height
- [x] End-to-end: DMG built with `./gradlew :example:packageDmg`, opened on macOS — background image visible
- [x] PNG backgrounds unaffected (same copy behaviour, window size computed from dimensions)