### PR TITLE
fix: generate latest.yml for MSI and other non-NSIS formats

### DIFF
--- a/.github/workflows/release-graalvm.yaml
+++ b/.github/workflows/release-graalvm.yaml
@@ -237,7 +237,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets
-          find artifacts -type f \( -name '*.deb' -o -name '*.dmg' -o -name '*.exe' \) -exec cp {} release-assets/ \;
+          find artifacts -type f \( -name '*.deb' -o -name '*.dmg' -o -name '*.exe' -o -name 'latest*.yml' -o -name 'beta*.yml' -o -name 'alpha*.yml' \) -exec cp {} release-assets/ \;
           echo "==> Release assets:"
           ls -lh release-assets/
 

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/PublishMode.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/PublishMode.kt
@@ -9,7 +9,7 @@ package io.github.kdroidfilter.nucleus.desktop.application.dsl
 enum class PublishMode(
     internal val id: String,
 ) {
-    /** Disable auto-update publishing (no latest-*.yml generated). */
+    /** Disable auto-update publishing. latest-*.yml metadata is still generated locally for all updatable formats. */
     Never("never"),
 
     /** Publish to GitHub/S3 if configured (detects git tag). */

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/TargetFormat.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/TargetFormat.kt
@@ -51,9 +51,13 @@ enum class TargetFormat(
     val isStoreFormat: Boolean
         get() = this in setOf(Pkg, AppX, Flatpak)
 
-    /** Whether this format supports auto-update metadata (latest-*.yml). */
-    val isAutoUpdateSupported: Boolean
-        get() = this !in setOf(RawAppImage, AppX, Pkg, Flatpak, Snap, Zip, Tar, SevenZ)
+    /**
+     * Whether this format supports auto-update but electron-builder does not generate latest-*.yml for it.
+     * electron-builder natively generates yml for: NSIS, NSIS-Web, DMG, AppImage, DEB, RPM.
+     * This property is true only for formats that need the plugin to generate it: MSI and Portable.
+     */
+    val needsPluginUpdateYml: Boolean
+        get() = this == Msi || this == Portable
 
     /** Returns the auto-update YML filename for this format and channel. */
     fun updateYmlFilename(channel: ReleaseChannel): String {

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/TargetFormat.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/TargetFormat.kt
@@ -51,6 +51,21 @@ enum class TargetFormat(
     val isStoreFormat: Boolean
         get() = this in setOf(Pkg, AppX, Flatpak)
 
+    /** Whether this format supports auto-update metadata (latest-*.yml). */
+    val isAutoUpdateSupported: Boolean
+        get() = this !in setOf(RawAppImage, AppX, Pkg, Flatpak, Snap, Zip, Tar, SevenZ)
+
+    /** Returns the auto-update YML filename for this format and channel. */
+    fun updateYmlFilename(channel: ReleaseChannel): String {
+        val prefix = channel.id
+        val suffix = when (targetOS) {
+            OS.Windows -> ""
+            OS.MacOS -> "-mac"
+            OS.Linux -> "-linux"
+        }
+        return "$prefix$suffix.yml"
+    }
+
     internal fun isCompatibleWith(os: OS): Boolean = os == targetOS
 
     val outputDirName: String

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/UpdateYmlGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/UpdateYmlGenerator.kt
@@ -48,7 +48,9 @@ internal object UpdateYmlGenerator {
             return
         }
 
-        val releaseDate = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
+        val releaseDate = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            .withZone(java.time.ZoneOffset.UTC)
+            .format(Instant.now())
 
         val filesEntries = buildString {
             for (file in installerFiles) {

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/UpdateYmlGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/UpdateYmlGenerator.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package io.github.kdroidfilter.nucleus.desktop.application.internal
+
+import org.gradle.api.logging.Logger
+import java.io.File
+import java.security.MessageDigest
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.Base64
+
+/**
+ * Generates electron-builder-compatible auto-update metadata (latest-*.yml)
+ * for target formats where electron-builder does not produce them natively
+ * (e.g. MSI, Portable, AppImage, DEB, RPM, DMG).
+ */
+internal object UpdateYmlGenerator {
+    private const val BUFFER_SIZE = 8192
+    private val SKIP_EXTENSIONS = setOf("yml", "yaml", "blockmap", "json")
+
+    /**
+     * Generates the auto-update YML file if it does not already exist.
+     * When electron-builder natively generates the file (e.g. for NSIS), this is a no-op.
+     */
+    fun generateIfMissing(
+        outputDir: File,
+        ymlFilename: String,
+        version: String,
+        logger: Logger,
+    ) {
+        val ymlFile = File(outputDir, ymlFilename)
+        if (ymlFile.exists()) {
+            logger.info("Auto-update metadata already exists: ${ymlFile.name}, skipping generation")
+            return
+        }
+
+        val installerFiles = outputDir.listFiles { f ->
+            f.isFile &&
+                !f.name.startsWith(".") &&
+                f.extension.lowercase() !in SKIP_EXTENSIONS
+        }?.sortedBy { it.name } ?: emptyList()
+
+        if (installerFiles.isEmpty()) {
+            logger.warn("No installer files found in ${outputDir.absolutePath}, skipping update YML generation")
+            return
+        }
+
+        val releaseDate = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
+
+        val filesEntries = buildString {
+            for (file in installerFiles) {
+                val hash = sha512Base64(file)
+                appendLine("  - url: ${file.name}")
+                appendLine("    sha512: $hash")
+                appendLine("    size: ${file.length()}")
+                val blockmap = File(outputDir, "${file.name}.blockmap")
+                if (blockmap.exists()) {
+                    appendLine("    blockMapSize: ${blockmap.length()}")
+                }
+            }
+        }
+
+        val firstFile = installerFiles.first()
+        val firstHash = sha512Base64(firstFile)
+
+        val content = buildString {
+            appendLine("version: $version")
+            appendLine("files:")
+            append(filesEntries)
+            appendLine("path: ${firstFile.name}")
+            appendLine("sha512: $firstHash")
+            appendLine("releaseDate: '$releaseDate'")
+        }
+
+        ymlFile.writeText(content)
+        logger.lifecycle("Generated auto-update metadata: ${ymlFile.name}")
+    }
+
+    private fun sha512Base64(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-512")
+        file.inputStream().buffered().use { input ->
+            val buffer = ByteArray(BUFFER_SIZE)
+            var read = input.read(buffer)
+            while (read != -1) {
+                digest.update(buffer, 0, read)
+                read = input.read(buffer)
+            }
+        }
+        return Base64.getEncoder().encodeToString(digest.digest())
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -306,7 +306,7 @@ abstract class AbstractElectronBuilderPackageTask
             outputDir: File,
             dist: JvmApplicationDistributions,
         ) {
-            if (!targetFormat.isAutoUpdateSupported) return
+            if (!targetFormat.needsPluginUpdateYml) return
             val channel = resolveUpdateChannel(dist)
             val ymlFilename = targetFormat.updateYmlFilename(channel)
             val version = packageVersion.orNull ?: "0.0.0"

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -8,7 +8,9 @@ package io.github.kdroidfilter.nucleus.desktop.application.tasks
 import io.github.kdroidfilter.nucleus.desktop.application.dsl.CompressionLevel
 import io.github.kdroidfilter.nucleus.desktop.application.dsl.JvmApplicationDistributions
 import io.github.kdroidfilter.nucleus.desktop.application.dsl.MacOSSigningSettings
+import io.github.kdroidfilter.nucleus.desktop.application.dsl.ReleaseChannel
 import io.github.kdroidfilter.nucleus.desktop.application.dsl.TargetFormat
+import io.github.kdroidfilter.nucleus.desktop.application.internal.UpdateYmlGenerator
 import io.github.kdroidfilter.nucleus.desktop.application.internal.MacSigner
 import io.github.kdroidfilter.nucleus.desktop.application.internal.MacSignerImpl
 import io.github.kdroidfilter.nucleus.desktop.application.internal.NoCertificateSigner
@@ -296,7 +298,28 @@ abstract class AbstractElectronBuilderPackageTask
             cleanupBuildTemporaries(outputDir)
             configFile.delete()
             exportPackagingMetadata(outputDir, dist)
+            generateUpdateYmlIfNeeded(outputDir, dist)
             logger.lifecycle("nucleus builder package written to ${outputDir.canonicalPath}")
+        }
+
+        private fun generateUpdateYmlIfNeeded(
+            outputDir: File,
+            dist: JvmApplicationDistributions,
+        ) {
+            if (!targetFormat.isAutoUpdateSupported) return
+            val channel = resolveUpdateChannel(dist)
+            val ymlFilename = targetFormat.updateYmlFilename(channel)
+            val version = packageVersion.orNull ?: "0.0.0"
+            UpdateYmlGenerator.generateIfMissing(outputDir, ymlFilename, version, logger)
+        }
+
+        private fun resolveUpdateChannel(dist: JvmApplicationDistributions): ReleaseChannel {
+            val publish = dist.publish
+            return when {
+                publish.github.enabled -> publish.github.channel
+                publish.generic.enabled -> publish.generic.channel
+                else -> ReleaseChannel.Latest
+            }
         }
 
         private fun resolvePublishFlag(): String {


### PR DESCRIPTION
## Summary

- Generate `latest.yml` in the plugin for MSI and Portable formats, where electron-builder hardcodes `isWriteUpdateInfo: false` and never produces it
- Skip generation when electron-builder already created the file (NSIS, NSIS-Web, DMG, AppImage, DEB, RPM)
- Use millisecond-precision timestamps to match electron-builder format
- Collect generated yml files in `release-graalvm.yaml` publish job

## Context

electron-builder hardcodes `isWriteUpdateInfo: false` for MSI (`MsiTarget.ts:110`) and `isSuitableWindowsTarget()` only allows NSIS/NSIS-Web (`PublishManager.ts:514-519`). This has been the case since the MSI target was first introduced. Plugin users building MSI in their own CI never get a `latest.yml`, breaking auto-update.

Other formats (DMG, AppImage, DEB, RPM) generate yml natively via electron-builder and don't need this fix.

## Test plan

- [x] `packageMsi` produces `latest.yml` with correct SHA-512 (verified via openssl)
- [x] `packageGraalvmMsi` produces `latest.yml` with correct SHA-512
- [x] `packageExe` (NSIS) still uses electron-builder's native `latest.yml` — no overwrite
- [x] `packageGraalvmNsis` still uses electron-builder's native `latest.yml` — no overwrite
- [x] Plugin compiles cleanly
- [x] `release-graalvm.yaml` find command collects `latest*.yml` files

Closes #189