### PR TITLE
feat(graalvm): add FileKit Linux and dbus-java reachability metadata

### DIFF
--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/dbus-java.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/dbus-java.json
@@ -1,0 +1,66 @@
+{
+    "_meta": {
+        "description": "dbus-java D-Bus bindings for Linux desktop portal integration",
+        "matchPackages": [
+            "org.freedesktop.dbus"
+        ]
+    },
+    "reflection": [
+        {
+            "type": "org.freedesktop.dbus.connections.base.GlobalHandler"
+        },
+        {
+            "type": "org.freedesktop.dbus.connections.impl.DBusConnection",
+            "allPublicMethods": true
+        },
+        {
+            "type": "org.freedesktop.dbus.interfaces.DBus$NameAcquired",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        "java.lang.String",
+                        "java.lang.String"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "org.freedesktop.dbus.interfaces.Introspectable"
+        },
+        {
+            "type": "org.freedesktop.dbus.interfaces.Peer"
+        },
+        {
+            "type": "org.freedesktop.dbus.interfaces.Properties"
+        },
+        {
+            "type": {
+                "proxy": [
+                    "org.freedesktop.dbus.interfaces.DBus"
+                ]
+            }
+        },
+        {
+            "type": {
+                "proxy": [
+                    "org.freedesktop.dbus.interfaces.Introspectable"
+                ]
+            }
+        },
+        {
+            "type": {
+                "proxy": [
+                    "org.freedesktop.dbus.interfaces.Peer"
+                ]
+            }
+        },
+        {
+            "type": {
+                "proxy": [
+                    "org.freedesktop.dbus.interfaces.Properties"
+                ]
+            }
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/filekit.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/filekit.json
@@ -99,6 +99,24 @@
                     "io.github.vinceglb.filekit.dialogs.platform.windows.jna.Shell32"
                 ]
             }
+        },
+        {
+            "type": "io.github.vinceglb.filekit.dialogs.platform.xdg.Pair",
+            "fields": [
+                {
+                    "name": "a"
+                },
+                {
+                    "name": "b"
+                }
+            ]
+        },
+        {
+            "type": {
+                "proxy": [
+                    "io.github.vinceglb.filekit.dialogs.platform.xdg.FileChooserDbusInterface"
+                ]
+            }
         }
     ]
 }

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/index.txt
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/library-metadata/index.txt
@@ -4,6 +4,7 @@ compose-mediaplayer.json
 compose-ui.json
 compose-webview-wry.json
 composetray.json
+dbus-java.json
 filekit.json
 intellij-compat.json
 jdk-awt.json

--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/linux-reachability-metadata.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/linux-reachability-metadata.json
@@ -627,6 +627,24 @@
             ]
         },
         {
+            "type": "com.sun.security.auth.module.UnixSystem",
+            "jniAccessible": true,
+            "fields": [
+                {
+                    "name": "gid"
+                },
+                {
+                    "name": "groups"
+                },
+                {
+                    "name": "uid"
+                },
+                {
+                    "name": "username"
+                }
+            ]
+        },
+        {
             "type": "sun.security.provider.NativePRNG",
             "methods": [
                 {
@@ -636,6 +654,20 @@
                     ]
                 }
             ]
+        },
+        {
+            "type": "sun.security.provider.NativePRNG$NonBlocking",
+            "methods": [
+                {
+                    "name": "<init>",
+                    "parameterTypes": [
+                        "java.security.SecureRandomParameters"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "sun.text.resources.CollationData"
         },
         {
             "type": "sun.security.provider.SHA2$SHA256",


### PR DESCRIPTION
## Summary
- Add GraalVM reachability metadata for FileKit Linux XDG desktop portal file dialogs
- Create new conditional `dbus-java.json` library metadata (auto-included when `org.freedesktop.dbus` is on classpath)
- Add missing Linux JDK internals (`UnixSystem`, `NativePRNG$NonBlocking`, `CollationData`) to platform metadata

## Test plan
- [x] Build a GraalVM native image of an app using FileKit on Linux
- [x] Verify file open/save dialogs work without manual reachability entries
- [x] Confirm dbus-java metadata is only included when dbus-java is on classpath
- [x] Verify no regression on Windows/macOS builds