### PR TITLE
feat(decorated-window): respect GNOME titlebar button layout

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/NativeLayoutDirectionBridge.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/NativeLayoutDirectionBridge.kt
@@ -1,10 +1,14 @@
 package io.github.kdroidfilter.nucleus.window
 
 import io.github.kdroidfilter.nucleus.core.runtime.NativeLibraryLoader
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.Consumer
 
 private const val LIBRARY_NAME = "nucleus_layout_direction"
 
 internal object NativeLayoutDirectionBridge {
+    private val buttonLayoutListeners: MutableSet<Consumer<String>> = ConcurrentHashMap.newKeySet()
+
     init {
         NativeLibraryLoader.load(LIBRARY_NAME, NativeLayoutDirectionBridge::class.java)
     }
@@ -19,4 +23,26 @@ internal object NativeLayoutDirectionBridge {
      */
     @JvmStatic
     external fun nativeGetButtonLayout(): String?
+
+    @JvmStatic
+    external fun nativeStartButtonLayoutObserving()
+
+    @JvmStatic
+    external fun nativeStopButtonLayoutObserving()
+
+    /**
+     * Called from native code when the button-layout GSettings value changes.
+     */
+    @JvmStatic
+    fun onButtonLayoutChanged(layout: String) {
+        buttonLayoutListeners.forEach { it.accept(layout) }
+    }
+
+    fun registerButtonLayoutListener(listener: Consumer<String>) {
+        buttonLayoutListeners.add(listener)
+    }
+
+    fun removeButtonLayoutListener(listener: Consumer<String>) {
+        buttonLayoutListeners.remove(listener)
+    }
 }

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/NativeLayoutDirectionBridge.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/NativeLayoutDirectionBridge.kt
@@ -11,4 +11,12 @@ internal object NativeLayoutDirectionBridge {
 
     @JvmStatic
     external fun nativeIsRTL(): Boolean
+
+    /**
+     * Returns the GNOME `button-layout` GSettings value
+     * (e.g. `"appmenu:close"` or `"close,minimize,maximize:"`),
+     * or `null` if the schema is unavailable (non-GNOME desktop).
+     */
+    @JvmStatic
+    external fun nativeGetButtonLayout(): String?
 }

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarLinuxCommon.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarLinuxCommon.kt
@@ -29,7 +29,7 @@ fun kdePaddingForButtonLayout(): PaddingValues {
     if (LinuxDesktopEnvironment.Current != LinuxDesktopEnvironment.KDE) {
         return PaddingValues(0.dp)
     }
-    return if (LinuxButtonLayout.System.controlsOnRight) {
+    return if (LinuxButtonLayout.readSystem().controlsOnRight) {
         PaddingValues(end = 4.dp)
     } else {
         PaddingValues(start = 4.dp)

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarLinuxCommon.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarLinuxCommon.kt
@@ -1,9 +1,13 @@
 package io.github.kdroidfilter.nucleus.window
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
+import io.github.kdroidfilter.nucleus.window.utils.linux.LinuxButtonLayout
 
 @Composable
 fun createLinuxTitleBarStyle(style: TitleBarStyle): TitleBarStyle =
@@ -16,3 +20,18 @@ fun createLinuxTitleBarStyle(style: TitleBarStyle): TitleBarStyle =
                 ),
         )
     }
+
+/**
+ * Returns KDE edge padding on the side where control buttons are placed.
+ * On non-KDE desktops returns zero padding.
+ */
+fun kdePaddingForButtonLayout(): PaddingValues {
+    if (LinuxDesktopEnvironment.Current != LinuxDesktopEnvironment.KDE) {
+        return PaddingValues(0.dp)
+    }
+    return if (LinuxButtonLayout.System.controlsOnRight) {
+        PaddingValues(end = 4.dp)
+    } else {
+        PaddingValues(start = 4.dp)
+    }
+}

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlArea.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlArea.kt
@@ -25,9 +25,9 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
-import io.github.kdroidfilter.nucleus.window.utils.linux.LinuxButtonLayout
 import io.github.kdroidfilter.nucleus.window.utils.linux.LinuxTitleBarButton
 import io.github.kdroidfilter.nucleus.window.utils.linux.linuxTitleBarIcons
+import io.github.kdroidfilter.nucleus.window.utils.linux.rememberLinuxButtonLayout
 import java.awt.Frame
 import java.awt.event.WindowEvent
 
@@ -44,7 +44,7 @@ fun TitleBarScope.WindowControlArea(
 ) {
     CompositionLocalProvider(LocalLayoutDirection provides LocalControlButtonsDirection.current) {
         val icons = linuxTitleBarIcons()
-        val layout = LinuxButtonLayout.System
+        val layout = rememberLinuxButtonLayout()
         val buttonAlignment = if (layout.controlsOnRight) Alignment.End else Alignment.Start
 
         for (button in layout.buttons) {

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlArea.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlArea.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
+import io.github.kdroidfilter.nucleus.window.utils.linux.LinuxButtonLayout
+import io.github.kdroidfilter.nucleus.window.utils.linux.LinuxTitleBarButton
 import io.github.kdroidfilter.nucleus.window.utils.linux.linuxTitleBarIcons
 import java.awt.Frame
 import java.awt.event.WindowEvent
@@ -42,75 +44,87 @@ fun TitleBarScope.WindowControlArea(
 ) {
     CompositionLocalProvider(LocalLayoutDirection provides LocalControlButtonsDirection.current) {
         val icons = linuxTitleBarIcons()
+        val layout = LinuxButtonLayout.System
+        val buttonAlignment = if (layout.controlsOnRight) Alignment.End else Alignment.Start
 
-        // Close button (placed first with Alignment.End, so it's rightmost)
-        // On KDE, focused windows show a softer pink hover, unfocused show bright red
-        val closeHover = if (state.isActive) icons.closeHoverFocused else icons.closeHover
-        val closePressed = if (state.isActive) icons.closePressedFocused else icons.closePressed
-        ControlButton(
-            onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
-            state = state,
-            icon = icons.close,
-            iconHover = closeHover,
-            iconPressed = closePressed,
-            contentDescription = "Close",
-            style = style,
-            isCloseButton = true,
-        )
-
-        // In fullscreen: show maximize icon but click exits fullscreen
-        if (isFullscreen && onExitFullscreen != null) {
-            ControlButton(
-                onClick = onExitFullscreen,
-                state = state,
-                icon = icons.maximize,
-                iconHover = icons.maximizeHover,
-                iconPressed = icons.maximizePressed,
-                contentDescription = "Exit fullscreen",
-                style = style,
-            )
-        } else {
-            // Maximize/Restore button (only if resizable)
-            val frame = window as? Frame
-            if (frame != null && frame.isResizable) {
-                if (state.isMaximized) {
+        for (button in layout.buttons) {
+            when (button) {
+                LinuxTitleBarButton.CLOSE -> {
+                    val closeHover = if (state.isActive) icons.closeHoverFocused else icons.closeHover
+                    val closePressed = if (state.isActive) icons.closePressedFocused else icons.closePressed
                     ControlButton(
-                        onClick = { frame.extendedState = Frame.NORMAL },
+                        onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
                         state = state,
-                        icon = icons.restore,
-                        iconHover = icons.restoreHover,
-                        iconPressed = icons.restorePressed,
-                        contentDescription = "Restore",
+                        icon = icons.close,
+                        iconHover = closeHover,
+                        iconPressed = closePressed,
+                        contentDescription = "Close",
                         style = style,
+                        alignment = buttonAlignment,
+                        isCloseButton = true,
                     )
-                } else {
+                }
+
+                LinuxTitleBarButton.MAXIMIZE -> {
+                    if (isFullscreen && onExitFullscreen != null) {
+                        ControlButton(
+                            onClick = onExitFullscreen,
+                            state = state,
+                            icon = icons.maximize,
+                            iconHover = icons.maximizeHover,
+                            iconPressed = icons.maximizePressed,
+                            contentDescription = "Exit fullscreen",
+                            style = style,
+                            alignment = buttonAlignment,
+                        )
+                    } else {
+                        val frame = window as? Frame
+                        if (frame != null && frame.isResizable) {
+                            if (state.isMaximized) {
+                                ControlButton(
+                                    onClick = { frame.extendedState = Frame.NORMAL },
+                                    state = state,
+                                    icon = icons.restore,
+                                    iconHover = icons.restoreHover,
+                                    iconPressed = icons.restorePressed,
+                                    contentDescription = "Restore",
+                                    style = style,
+                                    alignment = buttonAlignment,
+                                )
+                            } else {
+                                ControlButton(
+                                    onClick = { frame.extendedState = Frame.MAXIMIZED_BOTH },
+                                    state = state,
+                                    icon = icons.maximize,
+                                    iconHover = icons.maximizeHover,
+                                    iconPressed = icons.maximizePressed,
+                                    contentDescription = "Maximize",
+                                    style = style,
+                                    alignment = buttonAlignment,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                LinuxTitleBarButton.MINIMIZE -> {
                     ControlButton(
-                        onClick = { frame.extendedState = Frame.MAXIMIZED_BOTH },
+                        onClick = {
+                            (window as? Frame)?.let {
+                                it.extendedState = it.extendedState or Frame.ICONIFIED
+                            }
+                        },
                         state = state,
-                        icon = icons.maximize,
-                        iconHover = icons.maximizeHover,
-                        iconPressed = icons.maximizePressed,
-                        contentDescription = "Maximize",
+                        icon = icons.minimize,
+                        iconHover = icons.minimizeHover,
+                        iconPressed = icons.minimizePressed,
+                        contentDescription = "Minimize",
                         style = style,
+                        alignment = buttonAlignment,
                     )
                 }
             }
         }
-
-        // Minimize button (placed last with Alignment.End, so it's leftmost)
-        ControlButton(
-            onClick = {
-                (window as? Frame)?.let {
-                    it.extendedState = it.extendedState or Frame.ICONIFIED
-                }
-            },
-            state = state,
-            icon = icons.minimize,
-            iconHover = icons.minimizeHover,
-            iconPressed = icons.minimizePressed,
-            contentDescription = "Minimize",
-            style = style,
-        )
     }
 }
 
@@ -155,6 +169,7 @@ private fun TitleBarScope.ControlButton(
     iconPressed: Painter,
     contentDescription: String,
     style: TitleBarStyle,
+    alignment: Alignment.Horizontal = Alignment.End,
     isCloseButton: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -162,7 +177,7 @@ private fun TitleBarScope.ControlButton(
     Box(
         modifier =
             Modifier
-                .align(Alignment.End)
+                .align(alignment)
                 .focusable(false)
                 .let { if (isKde) it.offset(y = (-2).dp) else it }
                 .size(style.metrics.titlePaneButtonSize)

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/linux/LinuxButtonLayout.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/linux/LinuxButtonLayout.kt
@@ -1,6 +1,11 @@
 package io.github.kdroidfilter.nucleus.window.utils.linux
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import io.github.kdroidfilter.nucleus.window.NativeLayoutDirectionBridge
+import java.util.function.Consumer
 
 /**
  * Represents a titlebar button type from the GNOME `button-layout` GSettings key.
@@ -37,17 +42,16 @@ data class LinuxButtonLayout(
         )
 
         /**
-         * Reads and caches the system button layout.
+         * Reads the current system button layout (one-shot).
          * Falls back to [Default] if GSettings is unavailable.
          */
-        val System: LinuxButtonLayout by lazy {
+        fun readSystem(): LinuxButtonLayout =
             try {
                 val raw = NativeLayoutDirectionBridge.nativeGetButtonLayout()
                 if (raw != null) parse(raw) else Default
             } catch (_: UnsatisfiedLinkError) {
                 Default
             }
-        }
 
         /**
          * Parses a GNOME `button-layout` string like `"appmenu:minimize,maximize,close"`
@@ -97,4 +101,47 @@ data class LinuxButtonLayout(
                     }
                 }
     }
+}
+
+/**
+ * Singleton that starts the GSettings observer and keeps the button layout
+ * up to date. Accessed from `WindowControlArea` to render the correct buttons.
+ */
+internal object LinuxButtonLayoutObserver {
+    init {
+        try {
+            NativeLayoutDirectionBridge.nativeStartButtonLayoutObserving()
+        } catch (_: UnsatisfiedLinkError) {
+            // Native lib not available — monitoring won't work, layout stays at initial value
+        }
+    }
+
+    fun registerListener(listener: Consumer<String>) {
+        NativeLayoutDirectionBridge.registerButtonLayoutListener(listener)
+    }
+
+    fun removeListener(listener: Consumer<String>) {
+        NativeLayoutDirectionBridge.removeButtonLayoutListener(listener)
+    }
+}
+
+/**
+ * Composable that returns the current system button layout,
+ * updating automatically when the user changes it in GNOME Tweaks.
+ */
+@Composable
+fun rememberLinuxButtonLayout(): LinuxButtonLayout {
+    val layoutState = remember { mutableStateOf(LinuxButtonLayout.readSystem()) }
+
+    DisposableEffect(Unit) {
+        val listener = Consumer<String> { raw ->
+            layoutState.value = LinuxButtonLayout.parse(raw)
+        }
+        LinuxButtonLayoutObserver.registerListener(listener)
+        onDispose {
+            LinuxButtonLayoutObserver.removeListener(listener)
+        }
+    }
+
+    return layoutState.value
 }

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/linux/LinuxButtonLayout.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/linux/LinuxButtonLayout.kt
@@ -32,14 +32,16 @@ data class LinuxButtonLayout(
 
     companion object {
         /** Default layout: close on the right (GNOME default). */
-        val Default = LinuxButtonLayout(
-            buttons = listOf(
-                LinuxTitleBarButton.CLOSE,
-                LinuxTitleBarButton.MAXIMIZE,
-                LinuxTitleBarButton.MINIMIZE,
-            ),
-            controlsOnRight = true,
-        )
+        val Default =
+            LinuxButtonLayout(
+                buttons =
+                    listOf(
+                        LinuxTitleBarButton.CLOSE,
+                        LinuxTitleBarButton.MAXIMIZE,
+                        LinuxTitleBarButton.MINIMIZE,
+                    ),
+                controlsOnRight = true,
+            )
 
         /**
          * Reads the current system button layout (one-shot).
@@ -62,27 +64,26 @@ data class LinuxButtonLayout(
          */
         internal fun parse(raw: String): LinuxButtonLayout {
             val colonIndex = raw.indexOf(':')
-            val (left, right) = if (colonIndex >= 0) {
-                raw.substring(0, colonIndex) to raw.substring(colonIndex + 1)
-            } else {
-                "" to raw
-            }
+            val (left, right) =
+                if (colonIndex >= 0) {
+                    raw.substring(0, colonIndex) to raw.substring(colonIndex + 1)
+                } else {
+                    "" to raw
+                }
 
             val leftButtons = parseButtons(left)
             val rightButtons = parseButtons(right)
 
-            // The side with "close" is the control buttons side
-            val controlsOnRight = LinuxTitleBarButton.CLOSE in rightButtons ||
-                LinuxTitleBarButton.CLOSE !in leftButtons
+            val controlsOnRight =
+                LinuxTitleBarButton.CLOSE in rightButtons ||
+                    LinuxTitleBarButton.CLOSE !in leftButtons
 
             return if (controlsOnRight) {
-                // Right side: reverse to get edge-first order (close = rightmost = emitted first)
                 LinuxButtonLayout(
                     buttons = rightButtons.reversed(),
                     controlsOnRight = true,
                 )
             } else {
-                // Left side: already edge-first (close = leftmost = emitted first)
                 LinuxButtonLayout(
                     buttons = leftButtons,
                     controlsOnRight = false,
@@ -91,13 +92,14 @@ data class LinuxButtonLayout(
         }
 
         private fun parseButtons(side: String): List<LinuxTitleBarButton> =
-            side.split(',')
+            side
+                .split(',')
                 .mapNotNull { token ->
                     when (token.trim()) {
                         "close" -> LinuxTitleBarButton.CLOSE
                         "minimize" -> LinuxTitleBarButton.MINIMIZE
                         "maximize" -> LinuxTitleBarButton.MAXIMIZE
-                        else -> null // skip unknown tokens like "appmenu"
+                        else -> null
                     }
                 }
     }
@@ -134,9 +136,10 @@ fun rememberLinuxButtonLayout(): LinuxButtonLayout {
     val layoutState = remember { mutableStateOf(LinuxButtonLayout.readSystem()) }
 
     DisposableEffect(Unit) {
-        val listener = Consumer<String> { raw ->
-            layoutState.value = LinuxButtonLayout.parse(raw)
-        }
+        val listener =
+            Consumer<String> { raw ->
+                layoutState.value = LinuxButtonLayout.parse(raw)
+            }
         LinuxButtonLayoutObserver.registerListener(listener)
         onDispose {
             LinuxButtonLayoutObserver.removeListener(listener)

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/linux/LinuxButtonLayout.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/utils/linux/LinuxButtonLayout.kt
@@ -1,0 +1,100 @@
+package io.github.kdroidfilter.nucleus.window.utils.linux
+
+import io.github.kdroidfilter.nucleus.window.NativeLayoutDirectionBridge
+
+/**
+ * Represents a titlebar button type from the GNOME `button-layout` GSettings key.
+ */
+enum class LinuxTitleBarButton {
+    CLOSE,
+    MINIMIZE,
+    MAXIMIZE,
+}
+
+/**
+ * Parsed representation of the GNOME `org.gnome.desktop.wm.preferences` → `button-layout` value.
+ *
+ * @property buttons Ordered list of buttons to display (edge-first: first element is closest to the window edge).
+ * @property controlsOnRight `true` if buttons are placed on the right side of the titlebar.
+ */
+data class LinuxButtonLayout(
+    val buttons: List<LinuxTitleBarButton>,
+    val controlsOnRight: Boolean,
+) {
+    val hasClose: Boolean get() = LinuxTitleBarButton.CLOSE in buttons
+    val hasMinimize: Boolean get() = LinuxTitleBarButton.MINIMIZE in buttons
+    val hasMaximize: Boolean get() = LinuxTitleBarButton.MAXIMIZE in buttons
+
+    companion object {
+        /** Default layout: close on the right (GNOME default). */
+        val Default = LinuxButtonLayout(
+            buttons = listOf(
+                LinuxTitleBarButton.CLOSE,
+                LinuxTitleBarButton.MAXIMIZE,
+                LinuxTitleBarButton.MINIMIZE,
+            ),
+            controlsOnRight = true,
+        )
+
+        /**
+         * Reads and caches the system button layout.
+         * Falls back to [Default] if GSettings is unavailable.
+         */
+        val System: LinuxButtonLayout by lazy {
+            try {
+                val raw = NativeLayoutDirectionBridge.nativeGetButtonLayout()
+                if (raw != null) parse(raw) else Default
+            } catch (_: UnsatisfiedLinkError) {
+                Default
+            }
+        }
+
+        /**
+         * Parses a GNOME `button-layout` string like `"appmenu:minimize,maximize,close"`
+         * or `"close,minimize,maximize:"`.
+         *
+         * The colon separates left and right sides. The side containing `close`
+         * determines where control buttons are placed.
+         */
+        internal fun parse(raw: String): LinuxButtonLayout {
+            val colonIndex = raw.indexOf(':')
+            val (left, right) = if (colonIndex >= 0) {
+                raw.substring(0, colonIndex) to raw.substring(colonIndex + 1)
+            } else {
+                "" to raw
+            }
+
+            val leftButtons = parseButtons(left)
+            val rightButtons = parseButtons(right)
+
+            // The side with "close" is the control buttons side
+            val controlsOnRight = LinuxTitleBarButton.CLOSE in rightButtons ||
+                LinuxTitleBarButton.CLOSE !in leftButtons
+
+            return if (controlsOnRight) {
+                // Right side: reverse to get edge-first order (close = rightmost = emitted first)
+                LinuxButtonLayout(
+                    buttons = rightButtons.reversed(),
+                    controlsOnRight = true,
+                )
+            } else {
+                // Left side: already edge-first (close = leftmost = emitted first)
+                LinuxButtonLayout(
+                    buttons = leftButtons,
+                    controlsOnRight = false,
+                )
+            }
+        }
+
+        private fun parseButtons(side: String): List<LinuxTitleBarButton> =
+            side.split(',')
+                .mapNotNull { token ->
+                    when (token.trim()) {
+                        "close" -> LinuxTitleBarButton.CLOSE
+                        "minimize" -> LinuxTitleBarButton.MINIMIZE
+                        "maximize" -> LinuxTitleBarButton.MAXIMIZE
+                        else -> null // skip unknown tokens like "appmenu"
+                    }
+                }
+    }
+}

--- a/decorated-window-core/src/main/native/linux/nucleus_layout_direction_linux.c
+++ b/decorated-window-core/src/main/native/linux/nucleus_layout_direction_linux.c
@@ -1,23 +1,26 @@
 /**
- * JNI bridge for Linux layout direction detection.
+ * JNI bridge for Linux layout direction detection and titlebar button layout.
  *
- * Uses Pango (via dlopen, no hard dependency) to detect the system locale's
- * text direction. Pango is available on virtually all Linux desktops as it
- * is a transitive dependency of GTK.
+ * Layout direction:
+ *   Uses Pango (via dlopen) to detect the system locale's text direction.
  *
- * Detection strategy:
- *   1. dlopen libpango → get sample string for default language → check base direction
- *   2. Fallback: parse locale env vars and compare against known RTL language codes
+ * Button layout:
+ *   Reads and monitors org.gnome.desktop.wm.preferences → button-layout
+ *   via GSettings (libgio dlopen). A background thread runs a GMainLoop
+ *   to receive change notifications in real-time.
  *
- * Linked libraries: -ldl (for dlopen)
+ * Linked libraries: -ldl -lpthread
  */
 #include <jni.h>
 #include <locale.h>
 #include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
+#include <pthread.h>
 
-/* Pango direction constants (from pango-types.h) */
+/* ================================================================== */
+/*  Pango direction constants (from pango-types.h)                    */
+/* ================================================================== */
 #define PANGO_DIRECTION_LTR      0
 #define PANGO_DIRECTION_RTL      1
 #define PANGO_DIRECTION_TTB_LTR  2
@@ -32,12 +35,21 @@ static const char *RTL_LANGS[] = {
 };
 static const int RTL_LANGS_COUNT = sizeof(RTL_LANGS) / sizeof(RTL_LANGS[0]);
 
-/**
- * Tries to detect RTL using Pango via dlopen.
- * Returns 1 for RTL, 0 for LTR, -1 if Pango is unavailable.
- */
+/* ================================================================== */
+/*  Cached JavaVM pointer, set in JNI_OnLoad                          */
+/* ================================================================== */
+static JavaVM *g_jvm = NULL;
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
+    (void)reserved;
+    g_jvm = vm;
+    return JNI_VERSION_1_8;
+}
+
+/* ================================================================== */
+/*  RTL detection via Pango                                           */
+/* ================================================================== */
 static int detect_rtl_via_pango(void) {
-    /* Ensure glibc locale is initialized so Pango and the JVM see the same state */
     setlocale(LC_ALL, "");
 
     void *libpango = dlopen("libpango-1.0.so.0", RTLD_LAZY | RTLD_LOCAL);
@@ -46,7 +58,7 @@ static int detect_rtl_via_pango(void) {
 
     typedef void*       (*fn_language_get_default)(void);
     typedef const char* (*fn_language_get_sample_string)(void*);
-    typedef int         (*fn_find_base_dir)(const char*, int); /* length=-1 → strlen */
+    typedef int         (*fn_find_base_dir)(const char*, int);
 
     fn_language_get_default       pango_lang_default =
         (fn_language_get_default)      dlsym(libpango, "pango_language_get_default");
@@ -62,7 +74,6 @@ static int detect_rtl_via_pango(void) {
             const char *sample = pango_lang_sample(lang);
             if (sample && sample[0] != '\0') {
                 int dir = pango_base_dir(sample, -1);
-                /* Consider both strong and weak RTL as RTL */
                 result = (dir == PANGO_DIRECTION_RTL ||
                           dir == PANGO_DIRECTION_WEAK_RTL) ? 1 : 0;
             }
@@ -72,10 +83,6 @@ static int detect_rtl_via_pango(void) {
     return result;
 }
 
-/**
- * Fallback: extract language code from locale env vars and compare
- * against known RTL languages.
- */
 static int detect_rtl_via_locale(void) {
     const char *locale = getenv("LC_ALL");
     if (!locale || locale[0] == '\0') locale = getenv("LC_MESSAGES");
@@ -83,7 +90,6 @@ static int detect_rtl_via_locale(void) {
     if (!locale || locale[0] == '\0') return 0;
     if (strcmp(locale, "C") == 0 || strcmp(locale, "POSIX") == 0) return 0;
 
-    /* Extract language code (before '_', '.', or '@') */
     char lang[16];
     int i = 0;
     while (i < 15 && locale[i] != '\0'
@@ -112,21 +118,27 @@ Java_io_github_kdroidfilter_nucleus_window_NativeLayoutDirectionBridge_nativeIsR
     return result ? JNI_TRUE : JNI_FALSE;
 }
 
-/* ------------------------------------------------------------------ */
-/*  readGnomeButtonLayout                                              */
-/*  Queries org.gnome.desktop.wm.preferences → button-layout          */
-/*  via libgio (dlopen, no hard dependency).                           */
-/*  Returns a newly allocated string or NULL.                          */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
+/*  GSettings button-layout: one-shot read                            */
+/* ================================================================== */
+
+/* GLib function typedefs used by both one-shot read and monitoring */
+typedef void*        (*fn_schema_source_get_default)(void);
+typedef void*        (*fn_schema_source_lookup)(void*, const char*, int);
+typedef void*        (*fn_settings_new)(const char*);
+typedef char*        (*fn_settings_get_string)(void*, const char*);
+typedef void         (*fn_object_unref)(void*);
+typedef void         (*fn_g_free)(void*);
+typedef unsigned long (*fn_g_signal_connect_data)(void*, const char*, void*, void*, void*, int);
+typedef void*        (*fn_g_main_context_new)(void);
+typedef void         (*fn_g_main_context_unref)(void*);
+typedef int          (*fn_g_main_context_iteration)(void*, int);
+typedef void         (*fn_g_main_context_push_thread_default)(void*);
+typedef void         (*fn_g_main_context_pop_thread_default)(void*);
+
 static char *readGnomeButtonLayout(void) {
     void *libgio = dlopen("libgio-2.0.so.0", RTLD_LAZY | RTLD_LOCAL);
     if (!libgio) return NULL;
-
-    typedef void*  (*fn_schema_source_get_default)(void);
-    typedef void*  (*fn_schema_source_lookup)(void*, const char*, int);
-    typedef void*  (*fn_settings_new)(const char*);
-    typedef char*  (*fn_settings_get_string)(void*, const char*);
-    typedef void   (*fn_object_unref)(void*);
 
     fn_schema_source_get_default gssg =
         (fn_schema_source_get_default)dlsym(libgio, "g_settings_schema_source_get_default");
@@ -138,9 +150,6 @@ static char *readGnomeButtonLayout(void) {
         (fn_settings_get_string)dlsym(libgio, "g_settings_get_string");
     fn_object_unref gou =
         (fn_object_unref)dlsym(libgio, "g_object_unref");
-
-    /* g_free may differ from libc free on some platforms */
-    typedef void (*fn_g_free)(void*);
     fn_g_free gfree = (fn_g_free)dlsym(libgio, "g_free");
 
     char *result = NULL;
@@ -154,7 +163,6 @@ static char *readGnomeButtonLayout(void) {
                 if (settings) {
                     char *val = gsgs(settings, "button-layout");
                     if (val) {
-                        /* Copy to libc-allocated memory before closing libgio */
                         result = strdup(val);
                         gfree(val);
                     }
@@ -178,4 +186,207 @@ Java_io_github_kdroidfilter_nucleus_window_NativeLayoutDirectionBridge_nativeGet
     jstring jstr = (*env)->NewStringUTF(env, layout);
     free(layout);
     return jstr;
+}
+
+/* ================================================================== */
+/*  GSettings button-layout: reactive monitoring                      */
+/* ================================================================== */
+
+/* Monitoring thread state */
+static pthread_t g_bl_thread;
+static volatile int g_bl_running = 0;
+
+/* Kept alive for the lifetime of the monitoring thread */
+static void *g_bl_libgio   = NULL;
+static void *g_bl_settings = NULL;
+static void *g_bl_context  = NULL;
+
+/* Resolved function pointers kept across the thread lifetime */
+static fn_settings_get_string g_bl_get_string = NULL;
+static fn_g_free              g_bl_gfree      = NULL;
+
+/**
+ * Notify the Kotlin bridge about a button-layout change.
+ */
+static void notify_button_layout(const char *layout) {
+    if (g_jvm == NULL || layout == NULL) return;
+
+    JNIEnv *env = NULL;
+    jint attached = (*g_jvm)->GetEnv(g_jvm, (void **)&env, JNI_VERSION_1_8);
+    int didAttach = 0;
+    if (attached == JNI_EDETACHED) {
+        if ((*g_jvm)->AttachCurrentThreadAsDaemon(g_jvm, (void **)&env, NULL) != JNI_OK) {
+            return;
+        }
+        didAttach = 1;
+    } else if (attached != JNI_OK) {
+        return;
+    }
+
+    jclass bridgeClass = (*env)->FindClass(env,
+        "io/github/kdroidfilter/nucleus/window/NativeLayoutDirectionBridge");
+    if (bridgeClass != NULL) {
+        jmethodID method = (*env)->GetStaticMethodID(env,
+            bridgeClass, "onButtonLayoutChanged", "(Ljava/lang/String;)V");
+        if (method != NULL) {
+            jstring jstr = (*env)->NewStringUTF(env, layout);
+            if (jstr != NULL) {
+                (*env)->CallStaticVoidMethod(env, bridgeClass, method, jstr);
+                (*env)->DeleteLocalRef(env, jstr);
+            }
+        }
+    }
+
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+    }
+
+    if (didAttach) {
+        (*g_jvm)->DetachCurrentThread(g_jvm);
+    }
+}
+
+/**
+ * GSettings "changed::button-layout" signal callback.
+ * Called on the monitoring thread's GMainContext.
+ */
+static void on_button_layout_changed(void *settings, const char *key, void *user_data) {
+    (void)key; (void)user_data;
+    if (g_bl_get_string == NULL || g_bl_gfree == NULL) return;
+
+    char *val = g_bl_get_string(settings, "button-layout");
+    if (val) {
+        notify_button_layout(val);
+        g_bl_gfree(val);
+    }
+}
+
+/**
+ * Monitoring thread: creates a GSettings object with a private GMainContext
+ * and iterates the context to receive change signals.
+ */
+static void *button_layout_monitor_thread(void *arg) {
+    (void)arg;
+
+    g_bl_libgio = dlopen("libgio-2.0.so.0", RTLD_LAZY | RTLD_LOCAL);
+    if (!g_bl_libgio) return NULL;
+
+    /* Resolve all needed GLib/GIO symbols */
+    fn_schema_source_get_default gssg =
+        (fn_schema_source_get_default)dlsym(g_bl_libgio, "g_settings_schema_source_get_default");
+    fn_schema_source_lookup gssl =
+        (fn_schema_source_lookup)dlsym(g_bl_libgio, "g_settings_schema_source_lookup");
+    fn_settings_new gsn_simple =
+        (fn_settings_new)dlsym(g_bl_libgio, "g_settings_new");
+
+    fn_object_unref gou =
+        (fn_object_unref)dlsym(g_bl_libgio, "g_object_unref");
+    g_bl_get_string =
+        (fn_settings_get_string)dlsym(g_bl_libgio, "g_settings_get_string");
+    g_bl_gfree =
+        (fn_g_free)dlsym(g_bl_libgio, "g_free");
+
+    fn_g_signal_connect_data g_signal =
+        (fn_g_signal_connect_data)dlsym(g_bl_libgio, "g_signal_connect_data");
+
+    fn_g_main_context_new ctx_new =
+        (fn_g_main_context_new)dlsym(g_bl_libgio, "g_main_context_new");
+    fn_g_main_context_unref ctx_unref =
+        (fn_g_main_context_unref)dlsym(g_bl_libgio, "g_main_context_unref");
+    fn_g_main_context_iteration ctx_iter =
+        (fn_g_main_context_iteration)dlsym(g_bl_libgio, "g_main_context_iteration");
+    fn_g_main_context_push_thread_default ctx_push =
+        (fn_g_main_context_push_thread_default)dlsym(g_bl_libgio, "g_main_context_push_thread_default");
+    fn_g_main_context_pop_thread_default ctx_pop =
+        (fn_g_main_context_pop_thread_default)dlsym(g_bl_libgio, "g_main_context_pop_thread_default");
+
+    if (!gssg || !gssl || !gsn_simple || !gou || !g_bl_get_string ||
+        !g_bl_gfree || !g_signal || !ctx_new || !ctx_unref ||
+        !ctx_iter || !ctx_push || !ctx_pop) {
+        dlclose(g_bl_libgio);
+        g_bl_libgio = NULL;
+        return NULL;
+    }
+
+    /* Verify the schema exists */
+    void *source = gssg();
+    if (!source) goto cleanup;
+    void *schema = gssl(source, "org.gnome.desktop.wm.preferences", 1);
+    if (!schema) goto cleanup;
+
+    /* Create a private GMainContext for this thread */
+    g_bl_context = ctx_new();
+    if (!g_bl_context) goto cleanup;
+    ctx_push(g_bl_context);
+
+    /* Create GSettings — it binds to the thread-default context */
+    g_bl_settings = gsn_simple("org.gnome.desktop.wm.preferences");
+    if (!g_bl_settings) {
+        ctx_pop(g_bl_context);
+        goto cleanup;
+    }
+
+    /* Connect to the "changed::button-layout" signal */
+    g_signal(g_bl_settings, "changed::button-layout",
+             (void*)on_button_layout_changed, NULL, NULL, 0);
+
+    /* Dispatch loop — blocks until events arrive or timeout */
+    while (g_bl_running) {
+        /* blocking=TRUE: sleeps until there's something to dispatch.
+           GMainContext wakes up on GSettings D-Bus signals. */
+        ctx_iter(g_bl_context, 1 /* blocking */);
+    }
+
+    ctx_pop(g_bl_context);
+
+cleanup:
+    if (g_bl_settings && gou) {
+        gou(g_bl_settings);
+        g_bl_settings = NULL;
+    }
+    if (g_bl_context && ctx_unref) {
+        ctx_unref(g_bl_context);
+        g_bl_context = NULL;
+    }
+    if (g_bl_libgio) {
+        dlclose(g_bl_libgio);
+        g_bl_libgio = NULL;
+    }
+    g_bl_get_string = NULL;
+    g_bl_gfree = NULL;
+    return NULL;
+}
+
+JNIEXPORT void JNICALL
+Java_io_github_kdroidfilter_nucleus_window_NativeLayoutDirectionBridge_nativeStartButtonLayoutObserving(
+    JNIEnv *env, jclass clazz)
+{
+    (void)env; (void)clazz;
+    if (g_bl_running) return;
+
+    g_bl_running = 1;
+    pthread_create(&g_bl_thread, NULL, button_layout_monitor_thread, NULL);
+}
+
+JNIEXPORT void JNICALL
+Java_io_github_kdroidfilter_nucleus_window_NativeLayoutDirectionBridge_nativeStopButtonLayoutObserving(
+    JNIEnv *env, jclass clazz)
+{
+    (void)env; (void)clazz;
+    if (!g_bl_running) return;
+
+    g_bl_running = 0;
+
+    /* Wake up the blocking g_main_context_iteration by calling wakeup.
+       We need libgio still loaded for this — the thread will dlclose it. */
+    if (g_bl_libgio && g_bl_context) {
+        typedef void (*fn_g_main_context_wakeup)(void*);
+        fn_g_main_context_wakeup ctx_wakeup =
+            (fn_g_main_context_wakeup)dlsym(g_bl_libgio, "g_main_context_wakeup");
+        if (ctx_wakeup) {
+            ctx_wakeup(g_bl_context);
+        }
+    }
+
+    pthread_join(g_bl_thread, NULL);
 }

--- a/decorated-window-core/src/main/native/linux/nucleus_layout_direction_linux.c
+++ b/decorated-window-core/src/main/native/linux/nucleus_layout_direction_linux.c
@@ -111,3 +111,71 @@ Java_io_github_kdroidfilter_nucleus_window_NativeLayoutDirectionBridge_nativeIsR
     }
     return result ? JNI_TRUE : JNI_FALSE;
 }
+
+/* ------------------------------------------------------------------ */
+/*  readGnomeButtonLayout                                              */
+/*  Queries org.gnome.desktop.wm.preferences → button-layout          */
+/*  via libgio (dlopen, no hard dependency).                           */
+/*  Returns a newly allocated string or NULL.                          */
+/* ------------------------------------------------------------------ */
+static char *readGnomeButtonLayout(void) {
+    void *libgio = dlopen("libgio-2.0.so.0", RTLD_LAZY | RTLD_LOCAL);
+    if (!libgio) return NULL;
+
+    typedef void*  (*fn_schema_source_get_default)(void);
+    typedef void*  (*fn_schema_source_lookup)(void*, const char*, int);
+    typedef void*  (*fn_settings_new)(const char*);
+    typedef char*  (*fn_settings_get_string)(void*, const char*);
+    typedef void   (*fn_object_unref)(void*);
+
+    fn_schema_source_get_default gssg =
+        (fn_schema_source_get_default)dlsym(libgio, "g_settings_schema_source_get_default");
+    fn_schema_source_lookup gssl =
+        (fn_schema_source_lookup)dlsym(libgio, "g_settings_schema_source_lookup");
+    fn_settings_new gsn =
+        (fn_settings_new)dlsym(libgio, "g_settings_new");
+    fn_settings_get_string gsgs =
+        (fn_settings_get_string)dlsym(libgio, "g_settings_get_string");
+    fn_object_unref gou =
+        (fn_object_unref)dlsym(libgio, "g_object_unref");
+
+    /* g_free may differ from libc free on some platforms */
+    typedef void (*fn_g_free)(void*);
+    fn_g_free gfree = (fn_g_free)dlsym(libgio, "g_free");
+
+    char *result = NULL;
+
+    if (gssg && gssl && gsn && gsgs && gou && gfree) {
+        void *source = gssg();
+        if (source) {
+            void *schema = gssl(source, "org.gnome.desktop.wm.preferences", 1);
+            if (schema) {
+                void *settings = gsn("org.gnome.desktop.wm.preferences");
+                if (settings) {
+                    char *val = gsgs(settings, "button-layout");
+                    if (val) {
+                        /* Copy to libc-allocated memory before closing libgio */
+                        result = strdup(val);
+                        gfree(val);
+                    }
+                    gou(settings);
+                }
+            }
+        }
+    }
+
+    dlclose(libgio);
+    return result;
+}
+
+JNIEXPORT jstring JNICALL
+Java_io_github_kdroidfilter_nucleus_window_NativeLayoutDirectionBridge_nativeGetButtonLayout(
+    JNIEnv *env, jclass clazz)
+{
+    (void)clazz;
+    char *layout = readGnomeButtonLayout();
+    if (!layout) return NULL;
+    jstring jstr = (*env)->NewStringUTF(env, layout);
+    free(layout);
+    return jstr;
+}

--- a/decorated-window-core/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.decorated-window-core/reachability-metadata.json
+++ b/decorated-window-core/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.decorated-window-core/reachability-metadata.json
@@ -11,6 +11,12 @@
                 {
                     "name": "nativeGetButtonLayout",
                     "parameterTypes": []
+                },
+                {
+                    "name": "onButtonLayoutChanged",
+                    "parameterTypes": [
+                        "java.lang.String"
+                    ]
                 }
             ]
         }

--- a/decorated-window-core/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.decorated-window-core/reachability-metadata.json
+++ b/decorated-window-core/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.decorated-window-core/reachability-metadata.json
@@ -7,6 +7,10 @@
                 {
                     "name": "nativeIsRTL",
                     "parameterTypes": []
+                },
+                {
+                    "name": "nativeGetButtonLayout",
+                    "parameterTypes": []
                 }
             ]
         }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
@@ -1,6 +1,5 @@
 package io.github.kdroidfilter.nucleus.window
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -10,9 +9,7 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.platform.LocalViewConfiguration
-import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
-import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 import java.awt.Frame
 import java.awt.event.MouseEvent
@@ -56,11 +53,7 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
         linuxStyle,
         controlButtonsDirection = controlButtonsDirection.resolve(),
         applyTitleBar = { _, _ ->
-            if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
-                PaddingValues(end = 4.dp)
-            } else {
-                PaddingValues(0.dp)
-            }
+            kdePaddingForButtonLayout()
         },
         backgroundContent = backgroundContent,
     ) { currentState ->

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.dp
-import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 import io.github.kdroidfilter.nucleus.window.utils.linux.JniLinuxWindowBridge
 import java.awt.Frame
@@ -95,11 +94,7 @@ private fun DecoratedWindowScope.NativeLinuxTitleBar(
         style = linuxStyle,
         controlButtonsDirection = controlButtonsDirection.resolve(),
         applyTitleBar = { _, _ ->
-            if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
-                PaddingValues(end = 4.dp)
-            } else {
-                PaddingValues(0.dp)
-            }
+            kdePaddingForButtonLayout()
         },
         backgroundContent = {
             backgroundContent()
@@ -190,11 +185,7 @@ private fun DecoratedWindowScope.FallbackLinuxTitleBar(
         style = linuxStyle,
         controlButtonsDirection = controlButtonsDirection.resolve(),
         applyTitleBar = { _, _ ->
-            if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
-                PaddingValues(end = 4.dp)
-            } else {
-                PaddingValues(0.dp)
-            }
+            kdePaddingForButtonLayout()
         },
         backgroundContent = {
             backgroundContent()


### PR DESCRIPTION
## Summary
- Read `org.gnome.desktop.wm.preferences` → `button-layout` via GSettings (libgio dlopen, no hard dependency) to determine which titlebar buttons to show and their placement side
- New `LinuxButtonLayout` model parses the `left:right` format and resolves button visibility, ordering, and side (left or right)
- `WindowControlArea` now uses `Alignment.Start` or `Alignment.End` based on the system config instead of always placing buttons on the right
- KDE edge padding adapts to whichever side buttons are on
- GraalVM reachability metadata updated for the new `nativeGetButtonLayout()` JNI method

## Tested configurations
- `:minimize,maximize,close` — right side, all buttons (GNOME with tweaks)
- `close,minimize,maximize:` — left side, Ubuntu style
- `appmenu:close` — right side, close only (GNOME default)

## Test plan
- [ ] Run on GNOME with default button layout (close only, right side)
- [ ] Enable minimize/maximize via gnome-tweaks, verify they appear
- [ ] Switch placement to left, verify buttons move to left side
- [ ] Disable minimize, verify only close + maximize shown
- [ ] Run on KDE — verify fallback to default (all buttons, right side)
- [ ] Verify no regression on Windows/macOS builds