### PR TITLE
fix(system-color): return null accent color on macOS multicolor mode

### DIFF
--- a/docs/runtime/system-color.md
+++ b/docs/runtime/system-color.md
@@ -24,6 +24,7 @@ fun App() {
             // Build a dynamic color scheme from the system accent
             darkColorScheme(primary = accentColor)
         } else {
+            // null = unsupported platform or macOS multicolor mode
             darkColorScheme()
         }
     ) {
@@ -31,6 +32,9 @@ fun App() {
     }
 }
 ```
+
+!!! note "macOS Multicolor Mode"
+    On macOS, when the user selects **Multicolor** in System Settings → Appearance → Accent color, each app is expected to use its own default color. In this case, `systemAccentColor()` returns `null` so your app can fall back to its own brand color or a default palette.
 
 ### Check Support
 
@@ -98,7 +102,7 @@ The Nucleus example app uses this exact approach — you can test it by running:
 
 | Function | Returns | Description |
 |----------|---------|-------------|
-| `systemAccentColor()` | `Color?` | Composable. Returns the current system accent color, or `null` if unsupported. Recomposes on change. |
+| `systemAccentColor()` | `Color?` | Composable. Returns the current system accent color, or `null` if unsupported or if the OS is in multicolor mode (macOS). Recomposes on change. |
 | `isSystemInHighContrast()` | `Boolean` | Composable. Returns `true` if the OS is in high contrast / increased contrast mode. Recomposes on change. |
 | `isSystemAccentColorSupported()` | `Boolean` | Non-composable. Returns whether the current platform supports accent color detection. |
 
@@ -106,7 +110,7 @@ The Nucleus example app uses this exact approach — you can test it by running:
 
 | Platform | Accent Color | High Contrast | Reactive |
 |----------|-------------|---------------|----------|
-| **macOS** | `NSColor.controlAccentColor` (macOS 10.14+) | `accessibilityDisplayShouldIncreaseContrast` | Yes — `NSSystemColorsDidChangeNotification` / `NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification` |
+| **macOS** | `NSColor.controlAccentColor` (macOS 10.14+). Returns `null` in **multicolor mode** (detected via `AppleAccentColor` user default). | `accessibilityDisplayShouldIncreaseContrast` | Yes — `NSSystemColorsDidChangeNotification` / `NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification` |
 | **Windows** | `HKCU\SOFTWARE\Microsoft\Windows\DWM\AccentColor` registry key (AABBGGRR) | `SystemParametersInfoW(SPI_GETHIGHCONTRAST)` | Yes — `RegNotifyChangeKeyValue` on background thread |
 | **Linux** | XDG Desktop Portal `org.freedesktop.appearance` / `accent-color` — RGB tuple (0.0–1.0) | XDG Desktop Portal `org.freedesktop.appearance` / `contrast` — uint32 (1 = high) | Yes — D-Bus `SettingChanged` signal listener |
 
@@ -142,6 +146,7 @@ When ProGuard is enabled, the native bridge classes must be preserved. The Nucle
 -keep class io.github.kdroidfilter.nucleus.systemcolor.mac.NativeMacSystemColorBridge {
     native <methods>;
     static void onAccentColorChanged(float, float, float);
+    static void onAccentColorCleared();
     static void onContrastChanged(boolean);
 }
 

--- a/example/src/main/kotlin/com/example/demo/Main.kt
+++ b/example/src/main/kotlin/com/example/demo/Main.kt
@@ -155,7 +155,7 @@ fun main(args: Array<String>) {
                     ThemeMode.Light -> false
                 }
             val accentColor = systemAccentColor()
-            val seedColor = accentColor ?: Color(0xFF6750A4)
+            val seedColor = accentColor ?: Color.Yellow
 
             var isRtl by remember { mutableStateOf(false) }
 

--- a/jewel-sample/proguard-rules.pro
+++ b/jewel-sample/proguard-rules.pro
@@ -278,6 +278,7 @@
 -keep class io.github.kdroidfilter.nucleus.systemcolor.mac.NativeMacSystemColorBridge {
     native <methods>;
     static void onAccentColorChanged(float, float, float);
+    static void onAccentColorCleared();
     static void onContrastChanged(boolean);
 }
 

--- a/plugin-build/plugin/src/main/resources/default-compose-desktop-rules.pro
+++ b/plugin-build/plugin/src/main/resources/default-compose-desktop-rules.pro
@@ -181,6 +181,7 @@
 -keep class io.github.kdroidfilter.nucleus.systemcolor.mac.NativeMacSystemColorBridge {
     native <methods>;
     static void onAccentColorChanged(float, float, float);
+    static void onAccentColorCleared();
     static void onContrastChanged(boolean);
 }
 

--- a/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/mac/MacSystemColor.kt
+++ b/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/mac/MacSystemColor.kt
@@ -22,11 +22,11 @@ internal object MacSystemColorDetector {
 
     fun isHighContrast(): Boolean = NativeMacSystemColorBridge.nativeIsHighContrast()
 
-    fun registerAccentListener(listener: Consumer<Color>) {
+    fun registerAccentListener(listener: Consumer<Color?>) {
         NativeMacSystemColorBridge.registerAccentListener(listener)
     }
 
-    fun removeAccentListener(listener: Consumer<Color>) {
+    fun removeAccentListener(listener: Consumer<Color?>) {
         NativeMacSystemColorBridge.removeAccentListener(listener)
     }
 
@@ -44,7 +44,7 @@ internal fun macOsAccentColor(): Color? {
     val colorState = remember { mutableStateOf(MacSystemColorDetector.getAccentColor()) }
     DisposableEffect(Unit) {
         val listener =
-            Consumer<Color> { newColor ->
+            Consumer<Color?> { newColor ->
                 colorState.value = newColor
             }
         MacSystemColorDetector.registerAccentListener(listener)

--- a/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/mac/NativeMacSystemColorBridge.kt
+++ b/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/mac/NativeMacSystemColorBridge.kt
@@ -12,7 +12,7 @@ private const val LIBRARY_NAME = "nucleus_systemcolor"
 
 @Suppress("TooManyFunctions")
 internal object NativeMacSystemColorBridge {
-    private val accentListeners: MutableSet<Consumer<Color>> = ConcurrentHashMap.newKeySet()
+    private val accentListeners: MutableSet<Consumer<Color?>> = ConcurrentHashMap.newKeySet()
     private val contrastListeners: MutableSet<Consumer<Boolean>> = ConcurrentHashMap.newKeySet()
     private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeMacSystemColorBridge::class.java)
 
@@ -60,16 +60,22 @@ internal object NativeMacSystemColorBridge {
     }
 
     @JvmStatic
+    fun onAccentColorCleared() {
+        debugln(TAG) { "Accent color cleared (multicolor mode)" }
+        accentListeners.forEach { it.accept(null) }
+    }
+
+    @JvmStatic
     fun onContrastChanged(isHigh: Boolean) {
         debugln(TAG) { "Contrast mode changed: high=$isHigh" }
         contrastListeners.forEach { it.accept(isHigh) }
     }
 
-    fun registerAccentListener(listener: Consumer<Color>) {
+    fun registerAccentListener(listener: Consumer<Color?>) {
         accentListeners.add(listener)
     }
 
-    fun removeAccentListener(listener: Consumer<Color>) {
+    fun removeAccentListener(listener: Consumer<Color?>) {
         accentListeners.remove(listener)
     }
 

--- a/system-color/src/main/native/macos/NucleusSystemColorBridge.m
+++ b/system-color/src/main/native/macos/NucleusSystemColorBridge.m
@@ -10,7 +10,12 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
     return JNI_VERSION_1_8;
 }
 
-// Helper: call back into Kotlin with accent color RGB floats
+// Returns YES if the user has chosen a specific accent color, NO if multicolor mode is active.
+static BOOL isAccentColorSet(void) {
+    return [[NSUserDefaults standardUserDefaults] objectForKey:@"AppleAccentColor"] != nil;
+}
+
+// Helper: call back into Kotlin with accent color RGB floats (or null if multicolor)
 static void notifyAccentColorChanged(void) {
     if (g_jvm == NULL) return;
 
@@ -24,17 +29,24 @@ static void notifyAccentColorChanged(void) {
         return;
     }
 
-    if (@available(macOS 10.14, *)) {
-        NSColor *color = [[NSColor controlAccentColor]
-            colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
-        if (color != nil) {
-            jfloat r = (jfloat)[color redComponent];
-            jfloat g = (jfloat)[color greenComponent];
-            jfloat b = (jfloat)[color blueComponent];
+    jclass bridgeClass = (*env)->FindClass(env,
+        "io/github/kdroidfilter/nucleus/systemcolor/mac/NativeMacSystemColorBridge");
+    if (bridgeClass != NULL) {
+        if (!isAccentColorSet()) {
+            // Multicolor mode: notify with null
+            jmethodID method = (*env)->GetStaticMethodID(env,
+                bridgeClass, "onAccentColorCleared", "()V");
+            if (method != NULL) {
+                (*env)->CallStaticVoidMethod(env, bridgeClass, method);
+            }
+        } else if (@available(macOS 10.14, *)) {
+            NSColor *color = [[NSColor controlAccentColor]
+                colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+            if (color != nil) {
+                jfloat r = (jfloat)[color redComponent];
+                jfloat g = (jfloat)[color greenComponent];
+                jfloat b = (jfloat)[color blueComponent];
 
-            jclass bridgeClass = (*env)->FindClass(env,
-                "io/github/kdroidfilter/nucleus/systemcolor/mac/NativeMacSystemColorBridge");
-            if (bridgeClass != NULL) {
                 jmethodID method = (*env)->GetStaticMethodID(env,
                     bridgeClass, "onAccentColorChanged", "(FFF)V");
                 if (method != NULL) {
@@ -93,6 +105,10 @@ JNIEXPORT jboolean JNICALL
 Java_io_github_kdroidfilter_nucleus_systemcolor_mac_NativeMacSystemColorBridge_nativeGetAccentColor(
     JNIEnv *env, jclass clazz, jfloatArray out) {
     @autoreleasepool {
+        // In multicolor mode, AppleAccentColor is absent — return false so Kotlin gets null
+        if (!isAccentColorSet()) {
+            return JNI_FALSE;
+        }
         if (@available(macOS 10.14, *)) {
             NSColor *color = [[NSColor controlAccentColor]
                 colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];

--- a/system-color/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.system-color/reachability-metadata.json
+++ b/system-color/src/main/resources/META-INF/native-image/io.github.kdroidfilter/nucleus.system-color/reachability-metadata.json
@@ -25,6 +25,10 @@
                         "float",
                         "float"
                     ]
+                },
+                {
+                    "name": "onAccentColorCleared",
+                    "parameterTypes": []
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- Check `AppleAccentColor` in `NSUserDefaults` to detect macOS multicolor mode
- Return `null` instead of default blue when no user-chosen accent color is set
- Add `onAccentColorCleared()` JNI callback for reactive multicolor→specific color transitions
- Update listeners to `Consumer<Color?>` to propagate null through the chain
- Update ProGuard rules and GraalVM reachability metadata for the new method
- Use `Color.Yellow` as default fallback in example app

## Test plan
- [x] Set macOS to multicolor mode → verify `systemAccentColor()` returns `null`
- [x] Set macOS to a specific accent color → verify the correct color is returned
- [x] Switch between multicolor and a specific color → verify reactive updates work
- [x] Verify example app shows yellow theme in multicolor mode