### PR TITLE
fix(decorated-window): provide LocalContentColor in title bars for dark theme

### DIFF
--- a/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDecoratedWindow.kt
@@ -12,6 +12,8 @@ import io.github.kdroidfilter.nucleus.window.NucleusDecoratedWindowTheme
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 
+private const val LUMINANCE_THRESHOLD = 0.5f
+
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
 fun JewelDecoratedWindow(
@@ -33,7 +35,7 @@ fun JewelDecoratedWindow(
     val windowStyle = rememberJewelWindowStyle()
     val jewelTitleBarStyle = rememberJewelTitleBarStyle()
 
-    val titleBarIsDark = jewelTitleBarStyle.colors.background.luminance() < 0.5f
+    val titleBarIsDark = jewelTitleBarStyle.colors.background.luminance() < LUMINANCE_THRESHOLD
 
     NucleusDecoratedWindowTheme(
         isDark = titleBarIsDark,

--- a/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDecoratedWindow.kt
@@ -1,6 +1,7 @@
 package io.github.kdroidfilter.nucleus.window.jewel
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.window.WindowState
@@ -28,11 +29,14 @@ fun JewelDecoratedWindow(
     titleBarStyle: TitleBarStyle? = null,
     content: @Composable DecoratedWindowScope.() -> Unit,
 ) {
+    val colorScheme = JewelTheme.globalColors
     val windowStyle = rememberJewelWindowStyle()
     val jewelTitleBarStyle = rememberJewelTitleBarStyle()
 
+    val titleBarIsDark = jewelTitleBarStyle.colors.background.luminance() < 0.5f
+
     NucleusDecoratedWindowTheme(
-        isDark = JewelTheme.isDark,
+        isDark = titleBarIsDark,
         windowStyle = windowStyle,
         titleBarStyle = titleBarStyle ?: jewelTitleBarStyle,
     ) {

--- a/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDialogTitleBar.kt
+++ b/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDialogTitleBar.kt
@@ -1,6 +1,7 @@
 package io.github.kdroidfilter.nucleus.window.jewel
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
@@ -10,6 +11,7 @@ import io.github.kdroidfilter.nucleus.window.DialogTitleBar
 import io.github.kdroidfilter.nucleus.window.TitleBarScope
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
+import org.jetbrains.jewel.foundation.theme.LocalContentColor
 
 @Suppress("FunctionNaming")
 @Composable
@@ -25,6 +27,9 @@ fun DecoratedDialogScope.JewelDialogTitleBar(
         gradientStartColor = gradientStartColor,
         style = style,
         controlButtonsDirection = controlButtonsDirection,
-        content = content,
-    )
+    ) { state ->
+        CompositionLocalProvider(LocalContentColor provides style.colors.content) {
+            content(state)
+        }
+    }
 }

--- a/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelTitleBar.kt
+++ b/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelTitleBar.kt
@@ -1,6 +1,7 @@
 package io.github.kdroidfilter.nucleus.window.jewel
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
@@ -10,6 +11,7 @@ import io.github.kdroidfilter.nucleus.window.TitleBar
 import io.github.kdroidfilter.nucleus.window.TitleBarScope
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
+import org.jetbrains.jewel.foundation.theme.LocalContentColor
 
 @Suppress("FunctionNaming")
 @Composable
@@ -27,6 +29,9 @@ fun DecoratedWindowScope.JewelTitleBar(
         style = style,
         controlButtonsDirection = controlButtonsDirection,
         backgroundContent = backgroundContent,
-        content = content,
-    )
+    ) { state ->
+        CompositionLocalProvider(LocalContentColor provides style.colors.content) {
+            content(state)
+        }
+    }
 }

--- a/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialDialogTitleBar.kt
+++ b/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialDialogTitleBar.kt
@@ -1,6 +1,8 @@
 package io.github.kdroidfilter.nucleus.window.material2
 
+import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
@@ -25,6 +27,9 @@ fun DecoratedDialogScope.MaterialDialogTitleBar(
         gradientStartColor = gradientStartColor,
         style = style,
         controlButtonsDirection = controlButtonsDirection,
-        content = content,
-    )
+    ) { state ->
+        CompositionLocalProvider(LocalContentColor provides style.colors.content) {
+            content(state)
+        }
+    }
 }

--- a/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialTitleBar.kt
+++ b/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialTitleBar.kt
@@ -1,6 +1,8 @@
 package io.github.kdroidfilter.nucleus.window.material2
 
+import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
@@ -35,6 +37,9 @@ fun DecoratedWindowScope.MaterialTitleBar(
         style = style,
         controlButtonsDirection = controlButtonsDirection,
         backgroundContent = backgroundContent,
-        content = content,
-    )
+    ) { state ->
+        CompositionLocalProvider(LocalContentColor provides style.colors.content) {
+            content(state)
+        }
+    }
 }

--- a/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialDialogTitleBar.kt
+++ b/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialDialogTitleBar.kt
@@ -1,6 +1,8 @@
 package io.github.kdroidfilter.nucleus.window.material
 
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
@@ -25,6 +27,9 @@ fun DecoratedDialogScope.MaterialDialogTitleBar(
         gradientStartColor = gradientStartColor,
         style = style,
         controlButtonsDirection = controlButtonsDirection,
-        content = content,
-    )
+    ) { state ->
+        CompositionLocalProvider(LocalContentColor provides style.colors.content) {
+            content(state)
+        }
+    }
 }

--- a/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialTitleBar.kt
+++ b/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialTitleBar.kt
@@ -1,6 +1,8 @@
 package io.github.kdroidfilter.nucleus.window.material
 
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import io.github.kdroidfilter.nucleus.window.ControlButtonsDirection
@@ -35,6 +37,9 @@ fun DecoratedWindowScope.MaterialTitleBar(
         style = style,
         controlButtonsDirection = controlButtonsDirection,
         backgroundContent = backgroundContent,
-        content = content,
-    )
+    ) { state ->
+        CompositionLocalProvider(LocalContentColor provides style.colors.content) {
+            content(state)
+        }
+    }
 }

--- a/jewel-sample/src/main/kotlin/jewelsample/Main.kt
+++ b/jewel-sample/src/main/kotlin/jewelsample/Main.kt
@@ -55,7 +55,7 @@ fun main() {
         val titleBarTheme = if (isTitleBarDark) darkTheme else lightTheme
 
         IntUiTheme(
-            theme = contentTheme,
+            theme = titleBarTheme,
             styling = ComponentStyling.default(),
             swingCompatMode = MainViewModel.swingCompat,
         ) {
@@ -71,19 +71,15 @@ fun main() {
                     processKeyShortcuts(keyEvent = keyEvent, onNavigateTo = MainViewModel::onNavigateTo)
                 },
                 content = {
-                    if (isTitleBarDark != isDark) {
-                        IntUiTheme(
-                            theme = titleBarTheme,
-                            styling = ComponentStyling.default(),
-                            swingCompatMode = MainViewModel.swingCompat,
-                        ) {
-                            TitleBarView()
-                        }
-                    } else {
-                        TitleBarView()
+                    TitleBarView()
+                    IntUiTheme(
+                        theme = contentTheme,
+                        styling = ComponentStyling.default(),
+                        swingCompatMode = MainViewModel.swingCompat,
+                    ) {
+                        @OptIn(ExperimentalJewelApi::class)
+                        ProvideMarkdownStyling { currentView.content() }
                     }
-                    @OptIn(ExperimentalJewelApi::class)
-                    ProvideMarkdownStyling { currentView.content() }
                 },
             )
         }


### PR DESCRIPTION
## Summary
- Text inside Material/Jewel title bars was invisible in dark theme because `LocalContentColor` was not provided
- Wrap title bar content with `CompositionLocalProvider` using `style.colors.content` for Material2, Material3, and Jewel
- Fix `JewelDecoratedWindow`: derive `isDark` from title bar background luminance instead of global `JewelTheme.isDark`, ensuring the title bar theme matches its own background

## Test plan
- [x] Run jewel-sample on dark theme — title bar text must be visible
- [x] Run jewel-sample on light theme — no regression
- [x] Run material-sample on dark theme — title bar text must be visible
- [x] Verify JewelDecoratedWindow title bar styling matches title bar background (not app-wide theme)

Fixes #198