### PR TITLE
feat(runtime): preload() opt-in to warm JNI libs off the main thread

### DIFF
--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/IsSystemInDarkMode.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/IsSystemInDarkMode.kt
@@ -4,9 +4,28 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
+import io.github.kdroidfilter.nucleus.darkmodedetector.linux.LinuxPortalThemeDetector
 import io.github.kdroidfilter.nucleus.darkmodedetector.linux.isLinuxInDarkMode
+import io.github.kdroidfilter.nucleus.darkmodedetector.mac.MacOSThemeDetector
 import io.github.kdroidfilter.nucleus.darkmodedetector.mac.isMacOsInDarkMode
+import io.github.kdroidfilter.nucleus.darkmodedetector.windows.WindowsThemeDetector
 import io.github.kdroidfilter.nucleus.darkmodedetector.windows.isWindowsInDarkMode
+
+/**
+ * Eagerly triggers the JNI library load on the calling thread.
+ *
+ * On macOS the first `dlopen` can take 100–300 ms (AMFI code-signature
+ * validation). Call this from a background daemon thread during `main()` to
+ * keep the UI thread responsive on first dark-mode query.
+ */
+fun preloadDarkModeDetector() {
+    when (Platform.Current) {
+        Platform.MacOS -> MacOSThemeDetector.isDark()
+        Platform.Windows -> WindowsThemeDetector.isDark()
+        Platform.Linux -> LinuxPortalThemeDetector.isDark()
+        else -> Unit
+    }
+}
 
 /**
  * Composable function that returns whether the system is in dark mode.

--- a/docs/runtime/native-warmup.md
+++ b/docs/runtime/native-warmup.md
@@ -1,0 +1,81 @@
+# Native library warmup
+
+Nucleus modules that rely on JNI load their shared library on first access via
+`NativeLibraryLoader` (lazy, cached). On **macOS** the first `dlopen` of a
+given dylib pays a one-time cost — typically 100–300 ms — due to AMFI
+code-signature validation on the freshly extracted file. Subsequent loads (and
+all loads on Windows/Linux) are effectively free.
+
+If the first access happens on the AWT event dispatch thread — for example
+inside a Composable that opens a new screen — that cost turns into a visible
+frame stutter when the user navigates to the feature for the first time.
+
+## The fix
+
+Each JNI-backed façade exposes a `preload()` function whose only job is to
+trigger class-loading of the internal bridge object, which in turn runs
+`System.load()` on the **calling** thread. Call it from a background daemon
+thread early in `main()`:
+
+```kotlin
+fun main(args: Array<String>) {
+    GraalVmInitializer.initialize()
+
+    Thread({
+        AutoLaunch.preload()
+        EnergyManager.preload()
+        GlobalHotKeyManager.preload()
+        MediaControlService.preload()
+        NotificationCenter.preload()
+        TaskbarProgress.preload()
+        preloadDarkModeDetector()
+        preloadSystemColor()
+        if (Platform.Current == Platform.MacOS) {
+            MacOsDockMenu.preload()
+            preloadNativeMenuBar()
+        }
+    }, "nucleus-native-warmup").apply { isDaemon = true; start() }
+
+    application { /* ... */ }
+}
+```
+
+Only list the modules your app actually uses. `preload()` is idempotent, safe
+on every platform (no-op when the native lib isn't available) and does no
+significant work beyond the initial `System.load()`.
+
+## Available preload entry points
+
+| Module                  | Call                              |
+|-------------------------|-----------------------------------|
+| `autolaunch`            | `AutoLaunch.preload()`            |
+| `darkmode-detector`     | `preloadDarkModeDetector()`       |
+| `energy-manager`        | `EnergyManager.preload()`         |
+| `global-hotkey`         | `GlobalHotKeyManager.preload()`   |
+| `launcher-macos`        | `MacOsDockMenu.preload()`         |
+| `media-control`         | `MediaControlService.preload()`   |
+| `menu-macos`            | `preloadNativeMenuBar()`          |
+| `notification-macos`    | `NotificationCenter.preload()`    |
+| `system-color`          | `preloadSystemColor()`            |
+| `taskbar-progress`      | `TaskbarProgress.preload()`       |
+
+## Do I need this on Windows or Linux?
+
+Usually no. `LoadLibrary` on Windows and `dlopen` on Linux don't carry the
+code-signature validation overhead AMFI imposes on macOS. Calling `preload()`
+from a background thread is still harmless on those platforms — the warmup
+block above is portable and just returns fast.
+
+## Why not do it automatically?
+
+Auto-warming would need to either:
+
+- hook into an unrelated lifecycle (e.g. `GraalVmInitializer.initialize()`),
+  which couples modules that have nothing to do with each other, or
+- discover preloaders via `ServiceLoader`, adding a registration surface per
+  module and GraalVM reachability-metadata to match.
+
+Neither matches the pattern used by the wider JVM ecosystem — sqlite-jdbc,
+JNA, Netty-native, JavaCPP all load on first class access and let the
+application decide when that first access happens. Nucleus follows the same
+convention: `preload()` is the explicit, opt-in hook.

--- a/energy-manager/src/main/kotlin/io/github/kdroidfilter/nucleus/energymanager/EnergyManager.kt
+++ b/energy-manager/src/main/kotlin/io/github/kdroidfilter/nucleus/energymanager/EnergyManager.kt
@@ -46,6 +46,17 @@ object EnergyManager {
     fun isAvailable(): Boolean = delegate?.isAvailable() ?: false
 
     /**
+     * Eagerly triggers the JNI library load on the calling thread.
+     *
+     * On macOS the first `dlopen` can take 100–300 ms (AMFI code-signature
+     * validation). Call [preload] from a background daemon thread during
+     * `main()` to keep the UI thread responsive on first use.
+     */
+    fun preload() {
+        delegate?.isAvailable()
+    }
+
+    /**
      * Enables efficiency mode for the current process.
      */
     fun enableEfficiencyMode(): Result = delegate?.enableEfficiencyMode() ?: unsupported

--- a/example/src/main/kotlin/com/example/demo/Main.kt
+++ b/example/src/main/kotlin/com/example/demo/Main.kt
@@ -69,11 +69,19 @@ import io.github.kdroidfilter.nucleus.core.runtime.NucleusApp
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
 import io.github.kdroidfilter.nucleus.core.runtime.SingleInstanceManager
 import io.github.kdroidfilter.nucleus.darkmodedetector.isSystemInDarkMode
+import io.github.kdroidfilter.nucleus.darkmodedetector.preloadDarkModeDetector
 import io.github.kdroidfilter.nucleus.energymanager.EnergyManager
+import io.github.kdroidfilter.nucleus.globalhotkey.GlobalHotKeyManager
 import io.github.kdroidfilter.nucleus.graalvm.GraalVmInitializer
+import io.github.kdroidfilter.nucleus.launcher.macos.MacOsDockMenu
 import io.github.kdroidfilter.nucleus.launcher.windows.WindowsJumpListManager
+import io.github.kdroidfilter.nucleus.media.control.MediaControlService
+import io.github.kdroidfilter.nucleus.menu.macos.preloadNativeMenuBar
 import io.github.kdroidfilter.nucleus.nativehttp.NativeHttpClient
+import io.github.kdroidfilter.nucleus.notification.NotificationCenter
+import io.github.kdroidfilter.nucleus.systemcolor.preloadSystemColor
 import io.github.kdroidfilter.nucleus.systemcolor.systemAccentColor
+import io.github.kdroidfilter.nucleus.taskbarprogress.TaskbarProgress
 import io.github.kdroidfilter.nucleus.updater.NucleusUpdater
 import io.github.kdroidfilter.nucleus.updater.UpdateEvent
 import io.github.kdroidfilter.nucleus.updater.UpdateLevel
@@ -98,6 +106,23 @@ private val deepLinkUri = mutableStateOf<URI?>(null)
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 fun main(args: Array<String>) {
     GraalVmInitializer.initialize()
+
+    // Warm native JNI libraries off the main thread. First `dlopen` on macOS
+    // can take 100–300 ms (AMFI code-signature validation); without this the
+    // cost lands on the EDT when a tab is opened for the first time.
+    Thread({
+        EnergyManager.preload()
+        GlobalHotKeyManager.preload()
+        MediaControlService.preload()
+        NotificationCenter.preload()
+        TaskbarProgress.preload()
+        preloadDarkModeDetector()
+        preloadSystemColor()
+        if (Platform.Current == Platform.MacOS) {
+            MacOsDockMenu.preload()
+            preloadNativeMenuBar()
+        }
+    }, "nucleus-native-warmup").apply { isDaemon = true; start() }
 
     // Set AUMID before any window is created (required for jump lists in non-APPX mode)
     if (Platform.Current == Platform.Windows) {

--- a/global-hotkey/src/main/kotlin/io/github/kdroidfilter/nucleus/globalhotkey/GlobalHotKeyManager.kt
+++ b/global-hotkey/src/main/kotlin/io/github/kdroidfilter/nucleus/globalhotkey/GlobalHotKeyManager.kt
@@ -60,6 +60,17 @@ object GlobalHotKeyManager {
             }
 
     /**
+     * Eagerly triggers the JNI library load on the calling thread.
+     *
+     * On macOS the first `dlopen` can take 100–300 ms (AMFI code-signature
+     * validation). Call [preload] from a background daemon thread during
+     * `main()` to keep the UI thread responsive on first tab open.
+     */
+    fun preload() {
+        isAvailable
+    }
+
+    /**
      * Initialize the global hotkey subsystem.
      * Starts the native message loop thread (Windows).
      *

--- a/launcher-macos/src/main/kotlin/io/github/kdroidfilter/nucleus/launcher/macos/MacOsDockMenu.kt
+++ b/launcher-macos/src/main/kotlin/io/github/kdroidfilter/nucleus/launcher/macos/MacOsDockMenu.kt
@@ -14,6 +14,17 @@ object MacOsDockMenu {
     val isAvailable: Boolean
         get() = NativeMacOsDockMenuBridge.isLoaded
 
+    /**
+     * Eagerly triggers the JNI library load on the calling thread.
+     *
+     * On macOS the first `dlopen` can take 100–300 ms (AMFI code-signature
+     * validation). Call [preload] from a background daemon thread during
+     * `main()` to keep the UI thread responsive on first tab open.
+     */
+    fun preload() {
+        NativeMacOsDockMenuBridge.isLoaded
+    }
+
     /** Listener for dock menu item clicks. Callbacks are dispatched on the Swing EDT. */
     var listener: DockMenuListener? = null
 

--- a/media-control/src/main/kotlin/io/github/kdroidfilter/nucleus/media/control/MediaControlService.kt
+++ b/media-control/src/main/kotlin/io/github/kdroidfilter/nucleus/media/control/MediaControlService.kt
@@ -38,6 +38,17 @@ object MediaControlService {
     fun isAvailable(): Boolean = backend !== NoopBackend
 
     /**
+     * Eagerly triggers the JNI library load on the calling thread.
+     *
+     * On macOS the first `dlopen` can take 100–300 ms (AMFI code-signature
+     * validation). Call [preload] from a background daemon thread during
+     * `main()` to keep the UI thread responsive on first tab open.
+     */
+    fun preload() {
+        backend
+    }
+
+    /**
      * Configure the media player identity.
      *
      * On Linux, registers the MPRIS D-Bus name (format `org.mpris.MediaPlayer2.<name>`).

--- a/menu-macos/src/main/kotlin/io/github/kdroidfilter/nucleus/menu/macos/NativeMenuBar.kt
+++ b/menu-macos/src/main/kotlin/io/github/kdroidfilter/nucleus/menu/macos/NativeMenuBar.kt
@@ -8,6 +8,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 
+/**
+ * Eagerly triggers the JNI library load on the calling thread.
+ *
+ * On macOS the first `dlopen` can take 100–300 ms (AMFI code-signature
+ * validation). Call this from a background daemon thread during `main()` to
+ * keep the UI thread responsive when the native menu bar is first rendered.
+ */
+fun preloadNativeMenuBar() {
+    NativeNsMenuBridge.isLoaded
+}
+
 // ─── Public composable ───────────────────────────────────────────────────────
 
 /**

--- a/notification-macos/src/main/kotlin/io/github/kdroidfilter/nucleus/notification/NotificationCenter.kt
+++ b/notification-macos/src/main/kotlin/io/github/kdroidfilter/nucleus/notification/NotificationCenter.kt
@@ -36,6 +36,17 @@ object NotificationCenter {
         execPath != null && execPath.contains(".app/Contents/")
     }
 
+    /**
+     * Eagerly triggers the JNI library load on the calling thread.
+     *
+     * On macOS the first `dlopen` can take 100–300 ms (AMFI code-signature
+     * validation). Call [preload] from a background daemon thread during
+     * `main()` to keep the UI thread responsive on first tab open.
+     */
+    fun preload() {
+        NativeMacNotificationBridge.isLoaded
+    }
+
     /** Whether notifications are functional (native lib loaded AND inside an app bundle) */
     val isAvailable: Boolean by lazy {
         when {

--- a/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/SystemColor.kt
+++ b/system-color/src/main/kotlin/io/github/kdroidfilter/nucleus/systemcolor/SystemColor.kt
@@ -14,6 +14,17 @@ import io.github.kdroidfilter.nucleus.systemcolor.windows.windowsAccentColor
 import io.github.kdroidfilter.nucleus.systemcolor.windows.windowsHighContrast
 
 /**
+ * Eagerly triggers the JNI library load on the calling thread.
+ *
+ * On macOS the first `dlopen` can take 100–300 ms (AMFI code-signature
+ * validation). Call this from a background daemon thread during `main()` to
+ * keep the UI thread responsive on first accent-color query.
+ */
+fun preloadSystemColor() {
+    isSystemAccentColorSupported()
+}
+
+/**
  * Returns whether the current platform supports system accent color detection.
  */
 fun isSystemAccentColorSupported(): Boolean =

--- a/taskbar-progress/src/main/kotlin/io/github/kdroidfilter/nucleus/taskbarprogress/TaskbarProgress.kt
+++ b/taskbar-progress/src/main/kotlin/io/github/kdroidfilter/nucleus/taskbarprogress/TaskbarProgress.kt
@@ -22,6 +22,22 @@ object TaskbarProgress {
     private var macOsAttentionRequestId: Int = -1
 
     /**
+     * Eagerly triggers the JNI library load on the calling thread.
+     *
+     * On macOS the first `dlopen` can take 100–300 ms (AMFI code-signature
+     * validation). Call [preload] from a background daemon thread during
+     * `main()` to keep the UI thread responsive on first use.
+     */
+    fun preload() {
+        when (Platform.Current) {
+            Platform.Windows -> NativeWindowsTaskbarBridge.isLoaded
+            Platform.MacOS -> NativeMacOsTaskbarBridge.isLoaded
+            Platform.Linux -> NativeLinuxTaskbarBridge.isLoaded
+            else -> Unit
+        }
+    }
+
+    /**
      * Explicit override for the `.desktop` filename on Linux.
      *
      * When set, bypasses all auto-detection. Must match the installed `.desktop` file


### PR DESCRIPTION
## Summary

On macOS the first \`dlopen\` of a freshly extracted dylib pays a one-time
~100–300 ms AMFI code-signature validation. When that first access lands on
the AWT EDT (e.g. inside a Composable opening a tab for the first time), it
shows up as a visible frame stutter. Windows and Linux don't carry this
overhead.

This PR adds an explicit, opt-in \`preload()\` per JNI-backed facade. Its only
job is to trigger class-loading of the internal bridge object, which in turn
runs \`System.load()\` on the **calling** thread. Users invoke them from a
background daemon thread early in \`main()\` so the warmup runs while Compose
mounts.

## Pattern

Matches the wider JVM ecosystem (sqlite-jdbc, JNA, Netty-native, JavaCPP):
explicit opt-in, no \`ServiceLoader\` SPI, no central registry, no coupling
between unrelated modules.

\`\`\`kotlin
fun main(args: Array<String>) {
    GraalVmInitializer.initialize()
    Thread({
        EnergyManager.preload()
        GlobalHotKeyManager.preload()
        MediaControlService.preload()
        NotificationCenter.preload()
        TaskbarProgress.preload()
        preloadDarkModeDetector()
        preloadSystemColor()
        if (Platform.Current == Platform.MacOS) {
            MacOsDockMenu.preload()
            preloadNativeMenuBar()
        }
    }, "nucleus-native-warmup").apply { isDaemon = true; start() }
    // ...
}
\`\`\`

## Modules touched

| Module                  | Entry point                       |
|-------------------------|-----------------------------------|
| \`darkmode-detector\`     | \`preloadDarkModeDetector()\`       |
| \`energy-manager\`        | \`EnergyManager.preload()\`         |
| \`global-hotkey\`         | \`GlobalHotKeyManager.preload()\`   |
| \`launcher-macos\`        | \`MacOsDockMenu.preload()\`         |
| \`media-control\`         | \`MediaControlService.preload()\`   |
| \`menu-macos\`            | \`preloadNativeMenuBar()\`          |
| \`notification-macos\`    | \`NotificationCenter.preload()\`    |
| \`system-color\`          | \`preloadSystemColor()\`            |
| \`taskbar-progress\`      | \`TaskbarProgress.preload()\`       |

Plus the warmup wiring in \`example/Main.kt\` and a new doc page at
\`docs/runtime/native-warmup.md\`.

## Test plan

- [ ] \`./gradlew run\` on macOS, click Launcher / Notifications / Hotkeys /
      Menu / Media Control tabs in turn — first-open stutter should be gone.
- [ ] \`./gradlew run\` on Windows — no behavioural change.
- [ ] \`./gradlew preMerge\` passes.