### PR TITLE
fix(decorated-window): allow focus within title bar content

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -101,7 +100,6 @@ fun GenericTitleBarImpl(
         modifier =
             modifier
                 .background(backgroundBrush)
-                .focusProperties { canFocus = false }
                 .layoutId(TITLE_BAR_LAYOUT_ID)
                 .height(style.metrics.height)
                 .onSizeChanged { with(density) { applyTitleBar(it.height.toDp(), state) } }


### PR DESCRIPTION
## Summary
- Remove `focusProperties { canFocus = false }` from the title bar `Box` in `GenericTitleBarImpl`.
- The property propagated to every descendant through the Compose focus chain, so any focusable composable placed inside the title bar (TextField, TextArea, etc.) silently failed to become the effective focus owner and never received keyboard events.
- Applies to all backends (JBR and JNI on every OS) since the fix is in `decorated-window-core`.

## Behavior change
- Gained: focusable widgets now work correctly inside the title bar on every backend.
- Trade-off: Tab navigation from the main content can now enter the title bar area. For apps with only icon buttons in the title bar this is an accessibility improvement; if the old behavior is desired for a specific button, `Modifier.focusProperties { canFocus = false }` can still be applied per-widget.

Closes #206.

## Test plan
- [x] Reproduce on macOS with JNI backend: `TextField` in `JewelTitleBar` receives keyboard input after the fix.
- [ ] Verify on macOS with JBR backend.
- [ ] Verify on Windows (JNI).
- [ ] Verify on Linux (JNI).
- [x] Confirm Tab navigation from main content reaches title bar widgets as expected.
- [x] Confirm window drag, double-click maximize and traffic-light buttons still behave normally.