### PR TITLE
fix(decorated-window): center macOS windows correctly with minimum size

### DIFF
--- a/autolaunch/src/main/kotlin/io/github/kdroidfilter/nucleus/autolaunch/AutoLaunch.kt
+++ b/autolaunch/src/main/kotlin/io/github/kdroidfilter/nucleus/autolaunch/AutoLaunch.kt
@@ -145,6 +145,10 @@ public object AutoLaunch {
      */
     @JvmStatic
     public fun wasStartedAtLogin(args: Array<String>): Boolean {
+        // In development runs (Gradle :run, IDE), backends rely on env vars or
+        // AppleEvents inherited from the parent shell, which produces false
+        // positives (e.g. macOS LaunchInstanceID is inherited from the Terminal).
+        if (ExecutableRuntime.isDev()) return false
         if (startedAtLoginSticky) return true
         val result = backend.wasStartedAtLogin(args)
         if (result) startedAtLoginSticky = true

--- a/autolaunch/src/main/kotlin/io/github/kdroidfilter/nucleus/autolaunch/AutoLaunch.kt
+++ b/autolaunch/src/main/kotlin/io/github/kdroidfilter/nucleus/autolaunch/AutoLaunch.kt
@@ -4,6 +4,7 @@ import io.github.kdroidfilter.nucleus.autolaunch.linux.LinuxAutoLaunch
 import io.github.kdroidfilter.nucleus.autolaunch.windows.NativeAutoLaunchBridge
 import io.github.kdroidfilter.nucleus.autolaunch.windows.WindowsAutoLaunch
 import io.github.kdroidfilter.nucleus.core.runtime.ExecutableRuntime
+import io.github.kdroidfilter.nucleus.core.runtime.ExecutableType
 
 private const val MAC_SMAPPSERVICE_BACKEND_CLASS =
     "io.github.kdroidfilter.nucleus.autolaunch.macos.MacSMAppServiceBackend"
@@ -141,13 +142,20 @@ public object AutoLaunch {
      * caches positive results, so it is safe to poll it from a `LaunchedEffect`
      * or `remember` block to learn the actual value.
      *
+     * **Dev-mode short-circuit**: when [ExecutableRuntime.isDev] is `true`
+     * (Gradle `:run`, IDE launches), this method returns `false` unconditionally.
+     * Backends rely on env vars or AppleEvents inherited from the parent shell
+     * (notably macOS's `LaunchInstanceID`, which is inherited from Terminal),
+     * which would otherwise produce false positives. **Production builds must
+     * configure either the `nucleus.executable.type` system property or the
+     * `.nucleus-executable-type` marker file** — otherwise [ExecutableRuntime]
+     * defaults to [ExecutableType.DEV] and this method will always return
+     * `false`, masking real login launches.
+     *
      * @param args the application's `main(args: Array<String>)` arguments
      */
     @JvmStatic
     public fun wasStartedAtLogin(args: Array<String>): Boolean {
-        // In development runs (Gradle :run, IDE), backends rely on env vars or
-        // AppleEvents inherited from the parent shell, which produces false
-        // positives (e.g. macOS LaunchInstanceID is inherited from the Terminal).
         if (ExecutableRuntime.isDev()) return false
         if (startedAtLoginSticky) return true
         val result = backend.wasStartedAtLogin(args)

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/internal/MinimumSizeSupport.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/internal/MinimumSizeSupport.kt
@@ -1,0 +1,72 @@
+package io.github.kdroidfilter.nucleus.window.internal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.WindowState
+import kotlinx.coroutines.yield
+
+private const val MAX_FRAME_WAIT_ITERATIONS = 8
+
+/**
+ * Inflates [WindowState.size] up-front so Compose centers the window at the
+ * already-final dimensions. Without this, applying [java.awt.Window.minimumSize]
+ * after Compose has centered the window would re-anchor the frame at its
+ * bottom-left corner and visibly shift it (most visible on macOS).
+ *
+ * We mutate state during composition — normally an anti-pattern — but
+ * `SideEffect {}` runs after Window has already read state.size, which is
+ * too late to influence the initial centering. The mutation is idempotent
+ * (guarded by a size compare) and only re-runs when [state] or [minimumSize]
+ * changes, so it never loops.
+ *
+ * Pair this with [InstallMinimumSizeAfterCentering] inside the Window content
+ * to enforce the constraint at the AWT level.
+ */
+@Composable
+public fun WindowState.inflateToMinimumSize(minimumSize: DpSize?) {
+    remember(this, minimumSize) {
+        if (minimumSize != null) {
+            val w = size.width
+            val h = size.height
+            if (w < minimumSize.width || h < minimumSize.height) {
+                size = DpSize(maxOf(w, minimumSize.width), maxOf(h, minimumSize.height))
+            }
+        }
+    }
+}
+
+/**
+ * Installs [java.awt.Window.minimumSize] after Compose Desktop has applied
+ * [WindowState.size] / position to the AWT frame.
+ *
+ * We poll for the frame to reach the target dimensions instead of relying on
+ * a single `yield()`. The yield-once approach worked on Compose Desktop 1.10
+ * because the internal `update` block committed `state.size` synchronously
+ * before the next coroutine resume — but that ordering is an implementation
+ * detail and could break on a future version. Polling makes the fix robust:
+ * we wait until AWT actually has the size we expect, with a small cap so we
+ * never loop forever in pathological cases.
+ *
+ * AWT bounds are in logical pixels (= Dp). Do NOT convert via
+ * [androidx.compose.ui.unit.Density.roundToPx] — that applies the screen
+ * scale factor and would double the size on Retina/HiDPI displays.
+ */
+@Composable
+public fun FrameWindowScope.InstallMinimumSizeAfterCentering(minimumSize: DpSize?) {
+    if (minimumSize == null) return
+    LaunchedEffect(window, minimumSize) {
+        val targetW = minimumSize.width.value.toInt()
+        val targetH = minimumSize.height.value.toInt()
+        var attempts = 0
+        while ((window.width < targetW || window.height < targetH) &&
+            attempts < MAX_FRAME_WAIT_ITERATIONS
+        ) {
+            yield()
+            attempts++
+        }
+        window.minimumSize = java.awt.Dimension(targetW, targetH)
+    }
+}

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
@@ -1,7 +1,6 @@
 package io.github.kdroidfilter.nucleus.window
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
@@ -11,6 +10,8 @@ import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import com.jetbrains.JBR
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
+import io.github.kdroidfilter.nucleus.window.internal.InstallMinimumSizeAfterCentering
+import io.github.kdroidfilter.nucleus.window.internal.inflateToMinimumSize
 
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
@@ -36,21 +37,7 @@ fun DecoratedWindow(
         }
     }
 
-    // Inflate state.size to at least minimumSize BEFORE Compose centers the
-    // window; applying window.minimumSize afterwards would re-anchor the
-    // frame at its bottom-left corner and visibly shift the window.
-    remember(state, minimumSize) {
-        if (minimumSize != null) {
-            val current = state.size
-            if (current.width < minimumSize.width || current.height < minimumSize.height) {
-                state.size =
-                    DpSize(
-                        maxOf(current.width, minimumSize.width),
-                        maxOf(current.height, minimumSize.height),
-                    )
-            }
-        }
-    }
+    state.inflateToMinimumSize(minimumSize)
 
     val undecorated = Platform.Linux == Platform.Current
 
@@ -69,20 +56,7 @@ fun DecoratedWindow(
         onPreviewKeyEvent,
         onKeyEvent,
     ) {
-        if (minimumSize != null) {
-            LaunchedEffect(window, minimumSize) {
-                // Yield so Compose Desktop's internal `update` block commits
-                // state.size/position first — otherwise setMinimumSize runs on
-                // the unsized AWT frame and AWT re-anchors it at (0, 0) when
-                // it later grows to state.size.
-                kotlinx.coroutines.yield()
-                // AWT window bounds are in logical pixels (= Dp). Do NOT convert
-                // via Density.roundToPx() — that applies the screen scale factor
-                // and would double the size on Retina/HiDPI displays.
-                window.minimumSize =
-                    java.awt.Dimension(minimumSize.width.value.toInt(), minimumSize.height.value.toInt())
-            }
-        }
+        InstallMinimumSizeAfterCentering(minimumSize)
 
         DecoratedWindowBody(
             title = title,

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
@@ -1,9 +1,11 @@
 package io.github.kdroidfilter.nucleus.window
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
@@ -22,6 +24,7 @@ fun DecoratedWindow(
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     content: @Composable DecoratedWindowScope.() -> Unit,
@@ -30,6 +33,22 @@ fun DecoratedWindow(
         check(JBR.isAvailable()) {
             "DecoratedWindow requires JetBrains Runtime (JBR). " +
                 "Please run your application on JBR."
+        }
+    }
+
+    // Inflate state.size to at least minimumSize BEFORE Compose centers the
+    // window; applying window.minimumSize afterwards would re-anchor the
+    // frame at its bottom-left corner and visibly shift the window.
+    remember(state, minimumSize) {
+        if (minimumSize != null) {
+            val current = state.size
+            if (current.width < minimumSize.width || current.height < minimumSize.height) {
+                state.size =
+                    DpSize(
+                        maxOf(current.width, minimumSize.width),
+                        maxOf(current.height, minimumSize.height),
+                    )
+            }
         }
     }
 
@@ -50,6 +69,21 @@ fun DecoratedWindow(
         onPreviewKeyEvent,
         onKeyEvent,
     ) {
+        if (minimumSize != null) {
+            LaunchedEffect(window, minimumSize) {
+                // Yield so Compose Desktop's internal `update` block commits
+                // state.size/position first — otherwise setMinimumSize runs on
+                // the unsized AWT frame and AWT re-anchors it at (0, 0) when
+                // it later grows to state.size.
+                kotlinx.coroutines.yield()
+                // AWT window bounds are in logical pixels (= Dp). Do NOT convert
+                // via Density.roundToPx() — that applies the screen scale factor
+                // and would double the size on Retina/HiDPI displays.
+                window.minimumSize =
+                    java.awt.Dimension(minimumSize.width.value.toInt(), minimumSize.height.value.toInt())
+            }
+        }
+
         DecoratedWindowBody(
             title = title,
             icon = icon,

--- a/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/io/github/kdroidfilter/nucleus/window/jewel/JewelDecoratedWindow.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import io.github.kdroidfilter.nucleus.window.DecoratedWindow
@@ -26,6 +27,7 @@ fun JewelDecoratedWindow(
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     titleBarStyle: TitleBarStyle? = null,
@@ -52,6 +54,7 @@ fun JewelDecoratedWindow(
             enabled = enabled,
             focusable = focusable,
             alwaysOnTop = alwaysOnTop,
+            minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,
             content = content,

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
@@ -81,6 +81,7 @@ fun DecoratedWindow(
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     content: @Composable DecoratedWindowScope.() -> Unit,
@@ -101,6 +102,25 @@ fun DecoratedWindow(
         } else {
             state
         }
+
+    // ── Minimum-size pre-centering fix ────────────────────────────────
+    // Setting window.minimumSize from a LaunchedEffect grows the frame
+    // AFTER Compose has centered it, which on macOS anchors the growth
+    // at the bottom-left and visibly shifts the window off center.
+    // Inflate state.size up-front so Compose centers the already-final
+    // size, then apply the native minimumSize (see LaunchedEffect below).
+    remember(state, minimumSize) {
+        if (minimumSize != null) {
+            val current = state.size
+            if (current.width < minimumSize.width || current.height < minimumSize.height) {
+                state.size =
+                    DpSize(
+                        maxOf(current.width, minimumSize.width),
+                        maxOf(current.height, minimumSize.height),
+                    )
+            }
+        }
+    }
 
     // ── First-frame maximized fix ──────────────────────────────────────
     // When starting with WindowPlacement.Maximized, Compose's Window
@@ -138,6 +158,21 @@ fun DecoratedWindow(
         onPreviewKeyEvent,
         onKeyEvent,
     ) {
+        if (minimumSize != null) {
+            LaunchedEffect(window, minimumSize) {
+                // Yield so Compose Desktop's internal `update` block commits
+                // state.size/position first — otherwise setMinimumSize runs on
+                // the unsized AWT frame and AWT re-anchors it at (0, 0) when
+                // it later grows to state.size.
+                kotlinx.coroutines.yield()
+                // AWT window bounds are in logical pixels (= Dp). Do NOT convert
+                // via Density.roundToPx() — that applies the screen scale factor
+                // and would double the size on Retina/HiDPI displays.
+                window.minimumSize =
+                    java.awt.Dimension(minimumSize.width.value.toInt(), minimumSize.height.value.toInt())
+            }
+        }
+
         if (useNativeFullscreen) {
             NativeFullscreenEffect(state, windowState)
             if (Platform.Current == Platform.Windows) {

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedWindow.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
+import io.github.kdroidfilter.nucleus.window.internal.InstallMinimumSizeAfterCentering
+import io.github.kdroidfilter.nucleus.window.internal.inflateToMinimumSize
 import io.github.kdroidfilter.nucleus.window.utils.linux.JniLinuxWindowBridge
 import io.github.kdroidfilter.nucleus.window.utils.windows.JniWindowsDecorationBridge
 import io.github.kdroidfilter.nucleus.window.utils.windows.JniWindowsWindowUtil
@@ -103,24 +105,7 @@ fun DecoratedWindow(
             state
         }
 
-    // ── Minimum-size pre-centering fix ────────────────────────────────
-    // Setting window.minimumSize from a LaunchedEffect grows the frame
-    // AFTER Compose has centered it, which on macOS anchors the growth
-    // at the bottom-left and visibly shifts the window off center.
-    // Inflate state.size up-front so Compose centers the already-final
-    // size, then apply the native minimumSize (see LaunchedEffect below).
-    remember(state, minimumSize) {
-        if (minimumSize != null) {
-            val current = state.size
-            if (current.width < minimumSize.width || current.height < minimumSize.height) {
-                state.size =
-                    DpSize(
-                        maxOf(current.width, minimumSize.width),
-                        maxOf(current.height, minimumSize.height),
-                    )
-            }
-        }
-    }
+    state.inflateToMinimumSize(minimumSize)
 
     // ── First-frame maximized fix ──────────────────────────────────────
     // When starting with WindowPlacement.Maximized, Compose's Window
@@ -158,20 +143,7 @@ fun DecoratedWindow(
         onPreviewKeyEvent,
         onKeyEvent,
     ) {
-        if (minimumSize != null) {
-            LaunchedEffect(window, minimumSize) {
-                // Yield so Compose Desktop's internal `update` block commits
-                // state.size/position first — otherwise setMinimumSize runs on
-                // the unsized AWT frame and AWT re-anchors it at (0, 0) when
-                // it later grows to state.size.
-                kotlinx.coroutines.yield()
-                // AWT window bounds are in logical pixels (= Dp). Do NOT convert
-                // via Density.roundToPx() — that applies the screen scale factor
-                // and would double the size on Retina/HiDPI displays.
-                window.minimumSize =
-                    java.awt.Dimension(minimumSize.width.value.toInt(), minimumSize.height.value.toInt())
-            }
-        }
+        InstallMinimumSizeAfterCentering(minimumSize)
 
         if (useNativeFullscreen) {
             NativeFullscreenEffect(state, windowState)

--- a/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
+++ b/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
@@ -1377,6 +1377,12 @@ Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nati
                 }
             } else if (w.toolbar) {
                 w.toolbar = nil;
+                // Symmetrically revert the style/appearance changes applied
+                // when the toolbar was installed, so toggling the modifier
+                // off at runtime restores the standard title bar instead of
+                // leaving a transparent / full-size-content-view residue.
+                [w setStyleMask:([w styleMask] & ~NSWindowStyleMaskFullSizeContentView)];
+                [w setTitlebarAppearsTransparent:NO];
             }
             // Re-apply constraints so button positions update for the new inset
             NSNumber *storedHeight = objc_getAssociatedObject(w, &kTitleBarHeightKey);

--- a/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
+++ b/decorated-window-jni/src/main/native/macos/JniMacTitleBar.m
@@ -1360,6 +1360,14 @@ Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nati
                                      OBJC_ASSOCIATION_RETAIN_NONATOMIC);
             if (flag) {
                 if (!w.toolbar) {
+                    // Enable full-size content view and transparent title bar BEFORE
+                    // adding the toolbar, so AppKit treats the toolbar as part of the
+                    // existing content area instead of growing the window frame to
+                    // accommodate it. Without this, assigning w.toolbar expands the
+                    // frame height by the toolbar chrome, which later causes Compose's
+                    // center alignment to be off by half that extra height.
+                    [w setStyleMask:([w styleMask] | NSWindowStyleMaskFullSizeContentView)];
+                    [w setTitlebarAppearsTransparent:YES];
                     NSToolbar *toolbar = [[NSToolbar alloc] initWithIdentifier:@"NucleusToolbar"];
                     toolbar.showsBaselineSeparator = NO;
                     // Keep toolbar.visible = YES (default) so macOS renders 26pt corners
@@ -1367,7 +1375,7 @@ Java_io_github_kdroidfilter_nucleus_window_utils_macos_JniMacTitleBarBridge_nati
                     // the empty toolbar is visually invisible.
                     w.toolbar = toolbar;
                 }
-            } else {
+            } else if (w.toolbar) {
                 w.toolbar = nil;
             }
             // Re-apply constraints so button positions update for the new inset

--- a/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialDecoratedWindow.kt
+++ b/decorated-window-material2/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material2/MaterialDecoratedWindow.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import io.github.kdroidfilter.nucleus.window.DecoratedWindow
@@ -23,6 +24,7 @@ fun MaterialDecoratedWindow(
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     titleBarStyle: TitleBarStyle? = null,
@@ -47,6 +49,7 @@ fun MaterialDecoratedWindow(
             enabled = enabled,
             focusable = focusable,
             alwaysOnTop = alwaysOnTop,
+            minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,
             content = content,

--- a/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialDecoratedWindow.kt
+++ b/decorated-window-material3/src/main/kotlin/io/github/kdroidfilter/nucleus/window/material/MaterialDecoratedWindow.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import io.github.kdroidfilter.nucleus.window.DecoratedWindow
@@ -23,6 +24,7 @@ fun MaterialDecoratedWindow(
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     titleBarStyle: TitleBarStyle? = null,
@@ -47,6 +49,7 @@ fun MaterialDecoratedWindow(
             enabled = enabled,
             focusable = focusable,
             alwaysOnTop = alwaysOnTop,
+            minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,
             content = content,

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5374,6 +5374,7 @@ DecoratedWindow(
     title = "My App",
     icon = null,
     resizable = true,
+    minimumSize = DpSize(1100.dp, 480.dp),
 ) {
     TitleBar { state -> /* title bar content */ }
     // window content
@@ -5384,6 +5385,9 @@ The `content` lambda receives a `DecoratedWindowScope` which exposes:
 
 - `window: ComposeWindow` — the underlying AWT window
 - `state: DecoratedWindowState` — current window state (`.isActive`, `.isFullscreen`, `.isMinimized`, `.isMaximized`)
+
+**`minimumSize` parameter — preferred over `window.minimumSize`:** Always pass `minimumSize: DpSize?` to `DecoratedWindow` instead of setting `window.minimumSize` from a `LaunchedEffect`. Setting it manually after composition causes the frame to grow **after** Compose has centered it, which on macOS anchors the growth at the bottom-left corner and visibly shifts the window off-center on first display.
+    Internally, `DecoratedWindow` inflates `state.size` up-front so Compose centers the already-final dimensions, then applies `window.minimumSize` once the AWT frame has reached the target size. The value is in logical pixels (Dp) — DPI scaling is handled correctly on Retina/HiDPI screens. The same parameter is available on `MaterialDecoratedWindow` (Material 2 / Material 3) and `JewelDecoratedWindow`.
 
 ### `DecoratedDialog`
 
@@ -5871,13 +5875,14 @@ JewelDecoratedWindow(
     onCloseRequest = ::exitApplication,
     state = rememberWindowState(),
     title = "My App",
+    minimumSize = DpSize(1100.dp, 480.dp),
 ) {
     JewelTitleBar { state -> /* ... */ }
     // content
 }
 ```
 
-The `isDark` flag for `NucleusDecoratedWindowTheme` is read directly from `JewelTheme.isDark`.
+The `isDark` flag for `NucleusDecoratedWindowTheme` is read directly from `JewelTheme.isDark`. The `minimumSize` parameter sets a DPI-correct minimum window size and avoids the off-center first-frame issue described in [DecoratedWindow](decorated-window.md#decoratedwindow).
 
 ### `JewelDecoratedDialog`
 
@@ -6028,13 +6033,14 @@ MaterialDecoratedWindow(
     onCloseRequest = ::exitApplication,
     state = rememberWindowState(),
     title = "My App",
+    minimumSize = DpSize(1100.dp, 480.dp),
 ) {
     MaterialTitleBar { state -> /* ... */ }
     // content
 }
 ```
 
-The `isDark` flag for `NucleusDecoratedWindowTheme` is inferred from `Colors.isLight`.
+The `isDark` flag for `NucleusDecoratedWindowTheme` is inferred from `Colors.isLight`. The `minimumSize` parameter sets a DPI-correct minimum window size and avoids the off-center first-frame issue described in [DecoratedWindow](decorated-window.md#decoratedwindow).
 
 ### `MaterialDecoratedDialog`
 
@@ -6172,13 +6178,14 @@ MaterialDecoratedWindow(
     onCloseRequest = ::exitApplication,
     state = rememberWindowState(),
     title = "My App",
+    minimumSize = DpSize(1100.dp, 480.dp),
 ) {
     MaterialTitleBar { state -> /* ... */ }
     // content
 }
 ```
 
-The `isDark` flag for `NucleusDecoratedWindowTheme` is inferred automatically from the luminance of `colorScheme.background`.
+The `isDark` flag for `NucleusDecoratedWindowTheme` is inferred automatically from the luminance of `colorScheme.background`. The `minimumSize` parameter sets a DPI-correct minimum window size and avoids the off-center first-frame issue described in [DecoratedWindow](decorated-window.md#decoratedwindow).
 
 ### `MaterialDecoratedDialog`
 
@@ -12905,6 +12912,9 @@ Detection is transparent across packaging types and uses the **signal that is de
 | Linux (Flatpak) | `true` when launched by the portal's autostart entry; `false` on a manual `flatpak run` |
 
 Note on macOS: `LaunchInstanceID` is undocumented — Apple provides no public API to detect an `SMAppService.mainApp` login launch (feedback FB10207829, unresolved since June 2022). Treat this signal as empirical but reliable in practice across current macOS releases.
+
+**Dev-mode short-circuit:** `wasStartedAtLogin()` returns `false` unconditionally when [`ExecutableRuntime.isDev()`](executable-type.md) is `true` (Gradle `:run`, IDE launches). Backends rely on env vars or AppleEvents inherited from the parent shell — notably macOS's `LaunchInstanceID` inherited from Terminal — which would otherwise produce false positives.
+    **Production builds must configure** either the `nucleus.executable.type` system property or the `.nucleus-executable-type` marker file. Otherwise `ExecutableRuntime` defaults to `DEV` and `wasStartedAtLogin()` will always return `false`, masking real login launches. The Nucleus Gradle plugin writes the marker automatically for packaged distributions — only custom packaging needs manual setup.
 
 ## Rules to respect
 

--- a/docs/runtime/autolaunch.md
+++ b/docs/runtime/autolaunch.md
@@ -219,6 +219,11 @@ Detection is transparent across packaging types and uses the **signal that is de
 
 Note on macOS: `LaunchInstanceID` is undocumented — Apple provides no public API to detect an `SMAppService.mainApp` login launch (feedback FB10207829, unresolved since June 2022). Treat this signal as empirical but reliable in practice across current macOS releases.
 
+!!! warning "Dev-mode short-circuit"
+    `wasStartedAtLogin()` returns `false` unconditionally when [`ExecutableRuntime.isDev()`](executable-type.md) is `true` (Gradle `:run`, IDE launches). Backends rely on env vars or AppleEvents inherited from the parent shell — notably macOS's `LaunchInstanceID` inherited from Terminal — which would otherwise produce false positives.
+
+    **Production builds must configure** either the `nucleus.executable.type` system property or the `.nucleus-executable-type` marker file. Otherwise `ExecutableRuntime` defaults to `DEV` and `wasStartedAtLogin()` will always return `false`, masking real login launches. The Nucleus Gradle plugin writes the marker automatically for packaged distributions — only custom packaging needs manual setup.
+
 ## Rules to respect
 
 Three invariants are enforced by the API — trying to work around them is counter-productive:

--- a/docs/runtime/decorated-window-jewel.md
+++ b/docs/runtime/decorated-window-jewel.md
@@ -45,13 +45,14 @@ JewelDecoratedWindow(
     onCloseRequest = ::exitApplication,
     state = rememberWindowState(),
     title = "My App",
+    minimumSize = DpSize(1100.dp, 480.dp),
 ) {
     JewelTitleBar { state -> /* ... */ }
     // content
 }
 ```
 
-The `isDark` flag for `NucleusDecoratedWindowTheme` is read directly from `JewelTheme.isDark`.
+The `isDark` flag for `NucleusDecoratedWindowTheme` is read directly from `JewelTheme.isDark`. The `minimumSize` parameter sets a DPI-correct minimum window size and avoids the off-center first-frame issue described in [DecoratedWindow](decorated-window.md#decoratedwindow).
 
 ### `JewelDecoratedDialog`
 

--- a/docs/runtime/decorated-window-material2.md
+++ b/docs/runtime/decorated-window-material2.md
@@ -51,13 +51,14 @@ MaterialDecoratedWindow(
     onCloseRequest = ::exitApplication,
     state = rememberWindowState(),
     title = "My App",
+    minimumSize = DpSize(1100.dp, 480.dp),
 ) {
     MaterialTitleBar { state -> /* ... */ }
     // content
 }
 ```
 
-The `isDark` flag for `NucleusDecoratedWindowTheme` is inferred from `Colors.isLight`.
+The `isDark` flag for `NucleusDecoratedWindowTheme` is inferred from `Colors.isLight`. The `minimumSize` parameter sets a DPI-correct minimum window size and avoids the off-center first-frame issue described in [DecoratedWindow](decorated-window.md#decoratedwindow).
 
 ### `MaterialDecoratedDialog`
 

--- a/docs/runtime/decorated-window-material3.md
+++ b/docs/runtime/decorated-window-material3.md
@@ -51,13 +51,14 @@ MaterialDecoratedWindow(
     onCloseRequest = ::exitApplication,
     state = rememberWindowState(),
     title = "My App",
+    minimumSize = DpSize(1100.dp, 480.dp),
 ) {
     MaterialTitleBar { state -> /* ... */ }
     // content
 }
 ```
 
-The `isDark` flag for `NucleusDecoratedWindowTheme` is inferred automatically from the luminance of `colorScheme.background`.
+The `isDark` flag for `NucleusDecoratedWindowTheme` is inferred automatically from the luminance of `colorScheme.background`. The `minimumSize` parameter sets a DPI-correct minimum window size and avoids the off-center first-frame issue described in [DecoratedWindow](decorated-window.md#decoratedwindow).
 
 ### `MaterialDecoratedDialog`
 

--- a/docs/runtime/decorated-window.md
+++ b/docs/runtime/decorated-window.md
@@ -252,6 +252,7 @@ DecoratedWindow(
     title = "My App",
     icon = null,
     resizable = true,
+    minimumSize = DpSize(1100.dp, 480.dp),
 ) {
     TitleBar { state -> /* title bar content */ }
     // window content
@@ -262,6 +263,11 @@ The `content` lambda receives a `DecoratedWindowScope` which exposes:
 
 - `window: ComposeWindow` — the underlying AWT window
 - `state: DecoratedWindowState` — current window state (`.isActive`, `.isFullscreen`, `.isMinimized`, `.isMaximized`)
+
+!!! note "`minimumSize` parameter — preferred over `window.minimumSize`"
+    Always pass `minimumSize: DpSize?` to `DecoratedWindow` instead of setting `window.minimumSize` from a `LaunchedEffect`. Setting it manually after composition causes the frame to grow **after** Compose has centered it, which on macOS anchors the growth at the bottom-left corner and visibly shifts the window off-center on first display.
+
+    Internally, `DecoratedWindow` inflates `state.size` up-front so Compose centers the already-final dimensions, then applies `window.minimumSize` once the AWT frame has reached the target size. The value is in logical pixels (Dp) — DPI scaling is handled correctly on Retina/HiDPI screens. The same parameter is available on `MaterialDecoratedWindow` (Material 2 / Material 3) and `JewelDecoratedWindow`.
 
 ### `DecoratedDialog`
 

--- a/example/src/main/kotlin/com/example/demo/Main.kt
+++ b/example/src/main/kotlin/com/example/demo/Main.kt
@@ -184,11 +184,8 @@ fun main(args: Array<String>) {
                     state = state,
                     onCloseRequest = ::exitApplication,
                     title = "Nucleus Demo",
+                    minimumSize = DpSize(1100.dp, 480.dp),
                 ) {
-                    // Set minimum window size (DPI-scaled automatically by JNI module)
-                    LaunchedEffect(Unit) {
-                        window.minimumSize = java.awt.Dimension(1100, 480)
-                    }
                     CompositionLocalProvider(
                         LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr,
                     ) {

--- a/example/src/main/kotlin/com/example/demo/Main.kt
+++ b/example/src/main/kotlin/com/example/demo/Main.kt
@@ -184,7 +184,7 @@ fun main(args: Array<String>) {
                     state = state,
                     onCloseRequest = ::exitApplication,
                     title = "Nucleus Demo",
-                    minimumSize = DpSize(1100.dp, 480.dp),
+                    minimumSize = DpSize(1200.dp, 480.dp),
                 ) {
                     CompositionLocalProvider(
                         LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr,


### PR DESCRIPTION
## Summary
- Add `minimumSize: DpSize?` parameter to `DecoratedWindow` (both JBR and JNI variants) and to the Material2/Material3/Jewel wrappers. The value inflates `state.size` up-front and installs `window.minimumSize` after `yield()` so Compose Desktop can size and center the frame before AWT enforces the minimum.
- Native macOS bridge (`JniMacTitleBar.m`) enables `NSWindowStyleMaskFullSizeContentView` and `titlebarAppearsTransparent` before assigning the invisible `NSToolbar` used for 26pt corner radius, so the frame does not grow when the toolbar is attached.
- `AutoLaunch.wasStartedAtLogin()` short-circuits to `false` when `ExecutableRuntime.isDev()` is true — running from Gradle/IDE inherits `LaunchInstanceID` from the parent shell and would otherwise report a false positive on macOS.
- Update the demo in `example/Main.kt` to pass `minimumSize` through the new parameter instead of a `LaunchedEffect`.

## Test plan
- [x] `./gradlew :decorated-window-jni:compileKotlin :decorated-window-jbr:compileKotlin :decorated-window-material2:compileKotlin :decorated-window-material3:compileKotlin :decorated-window-jewel:compileKotlin :autolaunch:compileKotlin`
- [x] `./gradlew :example:compileKotlin :jewel-sample:compileKotlin :system-info-demo:compileKotlin :scheduler-demo:compileKotlin :sample-cmp:compileKotlinDesktop`
- [x] `./gradlew :example:run` on macOS — window opens centered with the configured minimum size
- [x] Confirm `AutoLaunch.wasStartedAtLogin(args)` returns `false` when launched via `./gradlew :example:run`
- [ ] Verify Windows `:example:run` still opens centered and `wasStartedAtLogin` reports correctly
- [ ] Verify Linux `:example:run` still opens centered