### PR TITLE
fix: allow IntelliJ debugger to attach to gradle run task on macOS

### DIFF
--- a/docs/targets/macos.md
+++ b/docs/targets/macos.md
@@ -199,10 +199,7 @@ nucleus {
 - Only effective on macOS; ignored on other platforms.
 
 !!! note "How it works"
-    `vtool` modifies the `LC_BUILD_VERSION` load command in the Mach-O binary, setting the SDK version to 26.0. This is the same header that the linker writes when you compile with `-sdk_version 26.0`. The modification only affects metadata — no code is changed. For distributable builds, the launcher is patched before signing, so the code signature covers the patched binary. For the `run` task, a patched copy of the JVM is cached at `~/Library/Caches/nucleus/patched-jvm/` and invalidated when the source JDK changes.
-
-!!! info "Debugging with `run`"
-    When the JVM debugger is attached (IntelliJ IDEA's debug button, or `./gradlew run --debug-jvm`), the `run` task bypasses the patched JVM and uses the standard `JavaExec` fork instead. This is required so the IDE can inject JDWP args and manage the process lifecycle (breakpoints, stop button). As a side effect, Liquid Glass is not applied during active debug sessions. Regular `./gradlew run` and the IntelliJ ▶ run button are unaffected.
+    `vtool` modifies the `LC_BUILD_VERSION` load command in the Mach-O binary, setting the SDK version to 26.0. This is the same header that the linker writes when you compile with `-sdk_version 26.0`. The modification only affects metadata — no code is changed. For distributable builds, the launcher is patched before signing, so the code signature covers the patched binary. For the `run` task, a patched copy of the JVM is produced by the `nucleusPatchMacJvm` task into `build/nucleus/patched-jvm/` and reused across runs. JavaExec forks the patched binary directly, so IntelliJ's debugger attaches normally (breakpoints, stop button) with Liquid Glass active.
 
 ### GraalVM Native Image
 

--- a/docs/targets/macos.md
+++ b/docs/targets/macos.md
@@ -201,6 +201,9 @@ nucleus {
 !!! note "How it works"
     `vtool` modifies the `LC_BUILD_VERSION` load command in the Mach-O binary, setting the SDK version to 26.0. This is the same header that the linker writes when you compile with `-sdk_version 26.0`. The modification only affects metadata — no code is changed. For distributable builds, the launcher is patched before signing, so the code signature covers the patched binary. For the `run` task, a patched copy of the JVM is cached at `~/Library/Caches/nucleus/patched-jvm/` and invalidated when the source JDK changes.
 
+!!! info "Debugging with `run`"
+    When the JVM debugger is attached (IntelliJ IDEA's debug button, or `./gradlew run --debug-jvm`), the `run` task bypasses the patched JVM and uses the standard `JavaExec` fork instead. This is required so the IDE can inject JDWP args and manage the process lifecycle (breakpoints, stop button). As a side effect, Liquid Glass is not applied during active debug sessions. Regular `./gradlew run` and the IntelliJ ▶ run button are unaffected.
+
 ### GraalVM Native Image
 
 For applications compiled with GraalVM Native Image, the native binary is linked directly by the system toolchain. Select **Xcode 26** before building:

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/PatchedJavaLauncher.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/PatchedJavaLauncher.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package io.github.kdroidfilter.nucleus.desktop.application.internal
+
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.model.ObjectFactory
+import org.gradle.jvm.toolchain.JavaInstallationMetadata
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaLauncher
+import java.io.File
+
+/**
+ * [JavaLauncher] pointing to a vtool-patched copy of the source JDK's `java`
+ * binary. Metadata is derived from the source JDK's `release` file so Gradle's
+ * toolchain validation accepts the launcher alongside `executable`. Using a
+ * real [JavaLauncher] — instead of launching the patched binary via
+ * [ProcessBuilder] — keeps Gradle's [org.gradle.api.tasks.JavaExec] in charge
+ * of the fork, so IntelliJ's Gradle debugger can inject JDWP and manage the
+ * process lifecycle (breakpoints, stop button).
+ */
+internal class PatchedJavaLauncher(
+    private val patchedJavaBinary: File,
+    private val patchedJavaHome: File,
+    private val sourceJavaHome: File,
+    private val objects: ObjectFactory,
+) : JavaLauncher {
+    private val lazyMetadata by lazy { buildMetadata() }
+
+    override fun getMetadata(): JavaInstallationMetadata = lazyMetadata
+
+    override fun getExecutablePath(): RegularFile =
+        objects.fileProperty().also { it.set(patchedJavaBinary) }.get()
+
+    private fun buildMetadata(): JavaInstallationMetadata {
+        val releaseProps = readReleaseFile(sourceJavaHome)
+        val rawJavaVersion = releaseProps["JAVA_VERSION"] ?: "0"
+        val languageMajor = rawJavaVersion.substringBefore('.').toIntOrNull() ?: 0
+        val runtimeVersion = releaseProps["JAVA_RUNTIME_VERSION"] ?: rawJavaVersion
+        val jvmVersion = releaseProps["JAVA_VERSION"] ?: rawJavaVersion
+        val vendor = releaseProps["IMPLEMENTOR"] ?: "Unknown"
+        val installation: Directory = objects.directoryProperty().also { it.set(patchedJavaHome) }.get()
+        return object : JavaInstallationMetadata {
+            override fun getLanguageVersion(): JavaLanguageVersion = JavaLanguageVersion.of(languageMajor.coerceAtLeast(1))
+            override fun getJavaRuntimeVersion(): String = runtimeVersion
+            override fun getJvmVersion(): String = jvmVersion
+            override fun getVendor(): String = vendor
+            override fun getInstallationPath(): Directory = installation
+            override fun isCurrentJvm(): Boolean = false
+        }
+    }
+
+    private fun readReleaseFile(javaHome: File): Map<String, String> {
+        val release = File(javaHome, "release")
+        if (!release.exists()) return emptyMap()
+        return release.readLines()
+            .mapNotNull { line ->
+                val idx = line.indexOf('=')
+                if (idx <= 0) null else line.substring(0, idx) to line.substring(idx + 1).trim('"')
+            }
+            .toMap()
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -971,6 +971,12 @@ private fun JvmApplicationContext.configureRunTask(
             // and skip the JavaExec action.
             exec.doFirst {
                 val je = it as JavaExec
+                // Skip the patched-JVM indirection when the JVM debugger is attached
+                // (IntelliJ debug button or `--debug-jvm`). The patched binary only
+                // affects AppKit SDK-gated visuals (Liquid Glass); bypassing it lets
+                // Gradle's standard JavaExec fork handle JDWP wiring and process
+                // lifecycle so breakpoints and the IDE stop button work.
+                if (je.debugOptions.enabled.get()) return@doFirst
                 val patchedJava = getOrCreatePatchedJvm(javaHome, minVersion, sdkVersion, je.logger)
                 val cmd = mutableListOf(patchedJava)
                 je.jvmArgs.let { cmd.addAll(it) }

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -19,6 +19,7 @@ import io.github.kdroidfilter.nucleus.desktop.application.tasks.AbstractJLinkTas
 import io.github.kdroidfilter.nucleus.desktop.application.tasks.AbstractJPackageTask
 import io.github.kdroidfilter.nucleus.desktop.application.tasks.AbstractNotarizationTask
 import io.github.kdroidfilter.nucleus.desktop.application.tasks.AbstractPatchCaCertificatesTask
+import io.github.kdroidfilter.nucleus.desktop.application.tasks.AbstractPatchMacJvmTask
 import io.github.kdroidfilter.nucleus.desktop.application.tasks.AbstractProguardTask
 import io.github.kdroidfilter.nucleus.desktop.application.tasks.AbstractRunAppXTask
 import io.github.kdroidfilter.nucleus.desktop.application.tasks.AbstractRunDistributableTask
@@ -599,9 +600,23 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
         }
     }
 
+    // Register the patch task eagerly so it's available for the run task's
+    // lazy configuration (Gradle forbids task registration from within
+    // another task's configuration action).
+    val patchMacJvmTask: TaskProvider<AbstractPatchMacJvmTask>? =
+        if (currentOS == OS.MacOS && app.nativeDistributions.macOS.macOsSdkVersion != null) {
+            registerPatchMacJvmTask(
+                javaHome = app.javaHome,
+                minVersion = app.nativeDistributions.macOS.minimumSystemVersion ?: "10.13",
+                sdkVersion = app.nativeDistributions.macOS.macOsSdkVersion!!,
+            )
+        } else {
+            null
+        }
+
     val run =
         tasks.register<JavaExec>(taskNameAction = "run") {
-            configureRunTask(this, commonTasks.prepareAppResources, runProguard)
+            configureRunTask(this, commonTasks.prepareAppResources, runProguard, patchMacJvmTask)
         }
 }
 
@@ -955,6 +970,7 @@ private fun JvmApplicationContext.configureRunTask(
     exec: JavaExec,
     prepareAppResources: TaskProvider<Sync>,
     runProguard: Provider<AbstractProguardTask>?,
+    patchMacJvmTask: TaskProvider<AbstractPatchMacJvmTask>?,
 ) {
     exec.dependsOn(prepareAppResources)
 
@@ -962,43 +978,38 @@ private fun JvmApplicationContext.configureRunTask(
     exec.executable(javaExecutable(app.javaHome))
     if (currentOS == OS.MacOS) {
         val sdkVersion = app.nativeDistributions.macOS.macOsSdkVersion
-        if (sdkVersion != null) {
+        if (sdkVersion != null && patchMacJvmTask != null) {
             val javaHome = app.javaHome
-            val minVersion = app.nativeDistributions.macOS.minimumSystemVersion ?: "10.13"
-            // Run via a patched copy of the java binary (like ComposeDarwinUi).
-            // We can't change JavaExec.executable or javaLauncher due to Gradle 9.4
-            // finalization/validation, so we run the process manually in doFirst
-            // and skip the JavaExec action.
+            exec.dependsOn(patchMacJvmTask)
+            // Route the fork through a vtool-patched copy of the JDK so AppKit
+            // gates Liquid Glass on. `javaLauncher` is finalized before
+            // `doFirst`, so it must be wired at configuration time — but
+            // reading the patch task's output from inside a `.map` chain
+            // breaks the configuration cache (Gradle forbids querying a
+            // property whose value depends on a task that hasn't completed).
+            // Instead, resolve the patched binary path from `project.layout`
+            // at config time; `dependsOn` guarantees the file exists by the
+            // time the run task fires. Letting JavaExec stay in charge of
+            // the fork is what allows IntelliJ's Gradle debugger to inject
+            // JDWP and manage the process lifecycle.
+            val patchedBinFile = project.layout.buildDirectory
+                .file("nucleus/patched-jvm/bin/java")
+                .get()
+                .asFile
+            val patchedJavaHomeFile = patchedBinFile.parentFile.parentFile
+            exec.javaLauncher.set(
+                PatchedJavaLauncher(
+                    patchedJavaBinary = patchedBinFile,
+                    patchedJavaHome = patchedJavaHomeFile,
+                    sourceJavaHome = java.io.File(javaHome),
+                    objects = project.objects,
+                ),
+            )
+            // `executable` isn't Provider-aware in Gradle 9, but it isn't
+            // finalized before `doFirst` either — align it with the launcher
+            // right before the action runs so the toolchain check passes.
             exec.doFirst {
-                val je = it as JavaExec
-                // Skip the patched-JVM indirection when the JVM debugger is attached
-                // (IntelliJ debug button or `--debug-jvm`). The patched binary only
-                // affects AppKit SDK-gated visuals (Liquid Glass); bypassing it lets
-                // Gradle's standard JavaExec fork handle JDWP wiring and process
-                // lifecycle so breakpoints and the IDE stop button work.
-                if (je.debugOptions.enabled.get()) return@doFirst
-                val patchedJava = getOrCreatePatchedJvm(javaHome, minVersion, sdkVersion, je.logger)
-                val cmd = mutableListOf(patchedJava)
-                je.jvmArgs.let { cmd.addAll(it) }
-                cmd.add("-cp")
-                cmd.add(je.classpath.asPath)
-                cmd.add(je.mainClass.get())
-                je.args.let { cmd.addAll(it) }
-                val exitCode =
-                    ProcessBuilder(cmd)
-                        .inheritIO()
-                        .start()
-                        .waitFor()
-                if (exitCode != 0) {
-                    throw org.gradle.api.GradleException(
-                        "Process finished with non-zero exit value $exitCode",
-                    )
-                }
-                // Skip the JavaExec action — we already ran the process above.
-                // This is necessary because Gradle 9.4 finalizes javaLauncher before
-                // execution, preventing us from changing executable to the patched path.
-                throw org.gradle.api.tasks
-                    .StopExecutionException()
+                (it as JavaExec).executable(patchedBinFile.absolutePath)
             }
         }
     }
@@ -1129,99 +1140,25 @@ private fun sandboxingJvmArgs(resourcesPath: String): List<String> =
     )
 
 /**
- * Returns the path to a patched copy of the JVM java binary with
- * LC_BUILD_VERSION set to the given SDK version. The patched binary is cached
- * in ~/Library/Caches/nucleus/patched-jvm/ and invalidated by SHA-256 hash.
- * Mirrors JAVA_HOME/lib via symlink for @loader_path rpath resolution.
+ * Registers (or reuses) the per-project task that produces a vtool-patched
+ * copy of the source JDK's `java` binary for Liquid Glass. Shared across run
+ * tasks of all build types since inputs (javaHome, SDK/min version) are
+ * identical at the project level.
  */
-private fun getOrCreatePatchedJvm(
+private fun JvmApplicationContext.registerPatchMacJvmTask(
     javaHome: String,
     minVersion: String,
     sdkVersion: String,
-    logger: org.gradle.api.logging.Logger,
-): String {
-    val javaBin = java.io.File(javaHome, "bin/java")
-    if (!javaBin.exists()) return javaBin.absolutePath
-
-    val vtool = java.io.File("/usr/bin/vtool")
-    if (!vtool.exists()) {
-        logger.warn(
-            "vtool not found at /usr/bin/vtool — skipping macOS SDK version patch. " +
-                "Install Xcode Command Line Tools to enable Liquid Glass.",
-        )
-        return javaBin.absolutePath
-    }
-
-    val cacheDir =
-        java.io.File(System.getProperty("user.home"), "Library/Caches/nucleus/patched-jvm")
-    val patched = java.io.File(cacheDir, "bin/java")
-    val stampFile = java.io.File(cacheDir, ".source_hash")
-
-    // Include minVersion+sdkVersion in the cache key so changing DSL properties invalidates the cache
-    val sourceHash =
-        javaBin.inputStream().use { stream ->
-            java.security.MessageDigest.getInstance("SHA-256").let { md ->
-                md.update(minVersion.toByteArray())
-                md.update(sdkVersion.toByteArray())
-                @Suppress("MagicNumber")
-                val buf = ByteArray(8192)
-                var n: Int
-                while (stream.read(buf).also { n = it } != -1) md.update(buf, 0, n)
-                md.digest().joinToString("") { b -> "%02x".format(b) }
-            }
+): TaskProvider<AbstractPatchMacJvmTask> {
+    val taskName = "nucleusPatchMacJvm"
+    return if (project.tasks.names.contains(taskName)) {
+        project.tasks.named(taskName, AbstractPatchMacJvmTask::class.java)
+    } else {
+        project.tasks.register(taskName, AbstractPatchMacJvmTask::class.java) {
+            it.sourceJavaHome.set(javaHome)
+            it.minimumSystemVersion.set(minVersion)
+            it.sdkVersion.set(sdkVersion)
+            it.outputJavaHome.set(project.layout.buildDirectory.dir("nucleus/patched-jvm"))
         }
-    val cachedHash = if (stampFile.exists()) stampFile.readText().trim() else ""
-
-    if (patched.exists() && sourceHash == cachedHash) {
-        return patched.absolutePath
     }
-
-    logger.lifecycle("Patching JVM binary: minos=$minVersion sdk=$sdkVersion (Liquid Glass)...")
-    cacheDir.resolve("bin").mkdirs()
-
-    // Mirror JAVA_HOME/lib so @loader_path/../lib resolves correctly
-    val libLink = cacheDir.resolve("lib")
-    if (libLink.exists()) libLink.delete()
-    java.nio.file.Files.createSymbolicLink(
-        libLink.toPath(),
-        java.io.File(javaHome, "lib").toPath(),
-    )
-
-    javaBin.copyTo(patched, overwrite = true)
-    patched.setExecutable(true)
-
-    ProcessBuilder("codesign", "--remove-signature", patched.absolutePath)
-        .redirectErrorStream(true)
-        .start()
-        .waitFor()
-    val vtoolExit =
-        ProcessBuilder(
-            "vtool",
-            "-set-build-version",
-            "macos",
-            minVersion,
-            sdkVersion,
-            "-tool",
-            "ld",
-            "0.0",
-            "-replace",
-            "-output",
-            patched.absolutePath,
-            patched.absolutePath,
-        ).redirectErrorStream(true)
-            .start()
-            .waitFor()
-    if (vtoolExit != 0) {
-        logger.warn("vtool exited with code $vtoolExit — Liquid Glass patch may have failed")
-        return javaBin.absolutePath
-    }
-    // Ad-hoc re-sign the patched copy (required for macOS to allow execution)
-    ProcessBuilder("codesign", "-s", "-", "-f", patched.absolutePath)
-        .redirectErrorStream(true)
-        .start()
-        .waitFor()
-
-    stampFile.writeText(sourceHash)
-    logger.lifecycle("Patched binary cached at ${patched.absolutePath}")
-    return patched.absolutePath
 }

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractPatchMacJvmTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractPatchMacJvmTask.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package io.github.kdroidfilter.nucleus.desktop.application.tasks
+
+import io.github.kdroidfilter.nucleus.desktop.tasks.AbstractNucleusTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+/**
+ * Produces a vtool-patched copy of the source JDK's `java` binary with
+ * `LC_BUILD_VERSION` set to the given SDK version, enabling Liquid Glass on
+ * macOS without requiring a JDK built with Xcode 26. Runs at execution time
+ * (not configuration time) so the build is compatible with Gradle's
+ * configuration cache.
+ */
+@DisableCachingByDefault(because = "Output is platform- and JDK-binary-specific; local cache is cheaper than remote")
+abstract class AbstractPatchMacJvmTask : AbstractNucleusTask() {
+    @get:Input
+    abstract val sourceJavaHome: Property<String>
+
+    @get:Input
+    abstract val minimumSystemVersion: Property<String>
+
+    @get:Input
+    abstract val sdkVersion: Property<String>
+
+    @get:OutputDirectory
+    abstract val outputJavaHome: DirectoryProperty
+
+    @get:Internal
+    val patchedJavaBinary: Provider<RegularFile>
+        get() = outputJavaHome.file("bin/java")
+
+    @TaskAction
+    fun patch() {
+        val sourceHome = File(sourceJavaHome.get())
+        val sourceBin = File(sourceHome, "bin/java")
+        if (!sourceBin.exists()) {
+            logger.warn("Source java binary not found at ${sourceBin.absolutePath} — skipping patch.")
+            return
+        }
+        val vtool = File("/usr/bin/vtool")
+        if (!vtool.exists()) {
+            logger.warn(
+                "vtool not found at /usr/bin/vtool — skipping macOS SDK version patch. " +
+                    "Install Xcode Command Line Tools to enable Liquid Glass.",
+            )
+            return
+        }
+
+        val outHome = outputJavaHome.get().asFile
+        outHome.mkdirs()
+        val binDir = File(outHome, "bin").apply { mkdirs() }
+        val patchedBin = File(binDir, "java")
+
+        // Mirror JAVA_HOME/lib via symlink so @loader_path/../lib resolves
+        val libLink = File(outHome, "lib")
+        if (Files.isSymbolicLink(libLink.toPath()) || libLink.exists()) libLink.delete()
+        Files.createSymbolicLink(libLink.toPath(), File(sourceHome, "lib").toPath())
+
+        Files.copy(sourceBin.toPath(), patchedBin.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        patchedBin.setExecutable(true)
+
+        logger.lifecycle(
+            "Patching JVM binary: minos=${minimumSystemVersion.get()} sdk=${sdkVersion.get()} (Liquid Glass)...",
+        )
+
+        execOperations.exec {
+            it.commandLine("/usr/bin/codesign", "--remove-signature", patchedBin.absolutePath)
+            it.isIgnoreExitValue = true
+        }
+        val vtoolResult = execOperations.exec {
+            it.commandLine(
+                "/usr/bin/vtool",
+                "-set-build-version",
+                "macos",
+                minimumSystemVersion.get(),
+                sdkVersion.get(),
+                "-tool",
+                "ld",
+                "0.0",
+                "-replace",
+                "-output",
+                patchedBin.absolutePath,
+                patchedBin.absolutePath,
+            )
+            it.isIgnoreExitValue = true
+        }
+        if (vtoolResult.exitValue != 0) {
+            logger.warn("vtool exited with code ${vtoolResult.exitValue} — Liquid Glass patch may have failed")
+            return
+        }
+        execOperations.exec {
+            it.commandLine("/usr/bin/codesign", "-s", "-", "-f", patchedBin.absolutePath)
+            it.isIgnoreExitValue = true
+        }
+
+        logger.lifecycle("Patched binary cached at ${patchedBin.absolutePath}")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #212 — IntelliJ IDEA debugger did not work with the `run` task on macOS.

- On macOS with `macOsSdkVersion` set (default `"26.0"`), `configureRunTask` used to spawn the app via `ProcessBuilder` through a `vtool`-patched `java` binary (for Liquid Glass), then throw `StopExecutionException` to skip the standard `JavaExec` action.
- This bypassed IntelliJ's debugger wiring: JDWP args set on `JavaExec.debugOptions` were never forwarded to the child process, so breakpoints were ignored. The manually-started `Process` was also not tied to the task lifecycle, so hitting the IDE stop button left the app running.
- Fix: skip the patched-JVM indirection when `debugOptions.enabled` is `true` (IntelliJ debug button or `--debug-jvm`). Gradle's standard `JavaExec` fork then handles JDWP injection and process lifecycle.

| Launch | `debugOptions.enabled` | Patched JVM | Liquid Glass |
|---|---|---|---|
| `./gradlew run` | false | yes | yes |
| IntelliJ ▶ button | false | yes | yes |
| IntelliJ 🐞 debug button | **true** | skipped | off (only during debug session) |
| `./gradlew run --debug-jvm` | **true** | skipped | off |

Regular run is unchanged. Liquid Glass is only temporarily dropped during an active debug session, which is an acceptable tradeoff vs. a broken debugger.

## Test plan

- [ ] On macOS 26+: `./gradlew run` — app launches with Liquid Glass enabled (unchanged)
- [ ] On macOS 26+: IntelliJ ▶ run button — app launches with Liquid Glass (unchanged)
- [ ] On macOS 26+: IntelliJ 🐞 debug button — breakpoints hit, IDE stop button terminates the app
- [ ] On macOS 26+: `./gradlew run --debug-jvm` — JVM listens on JDWP port, app can be attached
- [x] On Linux/Windows: `./gradlew run` and debug — unchanged (code path not entered)