### PR TITLE
feat(linux-hidpi): detect GNOME fractional scale via Mutter DBus

### DIFF
--- a/linux-hidpi/src/main/kotlin/io/github/kdroidfilter/nucleus/hidpi/LinuxHiDpi.kt
+++ b/linux-hidpi/src/main/kotlin/io/github/kdroidfilter/nucleus/hidpi/LinuxHiDpi.kt
@@ -7,9 +7,10 @@ package io.github.kdroidfilter.nucleus.hidpi
  * Sources consulted in priority order:
  *   1. `J2D_UISCALE`   — explicit JVM override (env var)
  *   2. GSettings       — GNOME `org.gnome.desktop.interface` → `scaling-factor`
- *   3. `GDK_SCALE`     — GTK / GNOME session variable
- *   4. `GDK_DPI_SCALE` — GTK fractional DPI multiplier
- *   5. `Xft.dpi`       — X Resource Manager (KDE, legacy GNOME, …)
+ *   3. Mutter DBus     — GNOME fractional scale via `org.gnome.Mutter.DisplayConfig`
+ *   4. `GDK_SCALE`     — GTK / GNOME session variable
+ *   5. `GDK_DPI_SCALE` — GTK fractional DPI multiplier
+ *   6. `Xft.dpi`       — X Resource Manager (KDE, legacy GNOME, …)
  *
  * @return A positive scale factor (e.g. `2.0` for a 200 % HiDPI display),
  *         or `0.0` when the scale cannot be determined (let the JVM decide).

--- a/linux-hidpi/src/main/native/linux/nucleus_hidpi_linux.c
+++ b/linux-hidpi/src/main/native/linux/nucleus_hidpi_linux.c
@@ -9,9 +9,10 @@
  * Detection order (same priority as JBR):
  *   1. J2D_UISCALE   — explicit JVM override (env var)
  *   2. GSettings     — GNOME integer scaling via libgio (dlopen, no hard dep)
- *   3. GDK_SCALE     — GTK environment variable
- *   4. GDK_DPI_SCALE — GTK fractional DPI multiplier
- *   5. Xft.dpi       — X Resource Manager via libX11 (dlopen, no hard dep)
+ *   3. Mutter DBus   — GNOME fractional scaling via libgio GDBus (dlopen)
+ *   4. GDK_SCALE     — GTK environment variable
+ *   5. GDK_DPI_SCALE — GTK fractional DPI multiplier
+ *   6. Xft.dpi       — X Resource Manager via libX11 (dlopen, no hard dep)
  *
  * All external libraries (libgio, libX11) are loaded at runtime via dlopen
  * so the .so itself has no hard link-time dependencies beyond libc/libdl.
@@ -98,6 +99,111 @@ static double readGnomeScaleFactor(void) {
 }
 
 /* ------------------------------------------------------------------ */
+/*  readGnomeMutterScale                                               */
+/*  Queries the active logical-monitor scale from                      */
+/*  org.gnome.Mutter.DisplayConfig via libgio's GDBus client           */
+/*  (dlopened, same pattern as readGnomeScaleFactor). This is the      */
+/*  only source of truth for GNOME fractional scaling (1.25, 1.5,      */
+/*  5/3, …); on such sessions GSettings scaling-factor stays at 0.     */
+/*                                                                     */
+/*  Returns the scale of the logical monitor flagged primary, or the   */
+/*  first non-zero scale if none is marked primary, or 0.0 on any      */
+/*  failure (service missing, not on GNOME, dbus denied, parse error). */
+/* ------------------------------------------------------------------ */
+static double readGnomeMutterScale(void) {
+    void *libgio = dlopen("libgio-2.0.so.0", RTLD_LAZY | RTLD_LOCAL);
+    if (!libgio) return 0.0;
+
+    /* GBusType enum: SESSION = 2 */
+    typedef void *(*fn_bus_get)(int bus_type, void *cancellable, void **error);
+    typedef void *(*fn_dbus_call)(void *conn, const char *bus_name,
+                                  const char *obj_path, const char *iface,
+                                  const char *method, void *params,
+                                  void *reply_type, int flags, int timeout,
+                                  void *cancellable, void **error);
+    typedef void *(*fn_var_child)(void *variant, size_t index);
+    typedef size_t (*fn_var_n)(void *variant);
+    typedef double (*fn_var_dbl)(void *variant);
+    typedef int (*fn_var_bool)(void *variant);
+    typedef void (*fn_unref)(void *ptr);
+    typedef void (*fn_error_free)(void *error);
+
+    fn_bus_get     gbgs = (fn_bus_get)     dlsym(libgio, "g_bus_get_sync");
+    fn_dbus_call   gcs  = (fn_dbus_call)   dlsym(libgio, "g_dbus_connection_call_sync");
+    fn_var_child   gvcv = (fn_var_child)   dlsym(libgio, "g_variant_get_child_value");
+    fn_var_n       gvnc = (fn_var_n)       dlsym(libgio, "g_variant_n_children");
+    fn_var_dbl     gvgd = (fn_var_dbl)     dlsym(libgio, "g_variant_get_double");
+    fn_var_bool    gvgb = (fn_var_bool)    dlsym(libgio, "g_variant_get_boolean");
+    fn_unref       gvu  = (fn_unref)       dlsym(libgio, "g_variant_unref");
+    fn_unref       gou  = (fn_unref)       dlsym(libgio, "g_object_unref");
+    fn_error_free  gef  = (fn_error_free)  dlsym(libgio, "g_error_free");
+
+    double scale = 0.0;
+
+    if (gbgs && gcs && gvcv && gvnc && gvgd && gvgb && gvu && gou) {
+        void *error = NULL;
+        void *conn = gbgs(2 /* G_BUS_TYPE_SESSION */, NULL, &error);
+        if (conn && !error) {
+            void *reply = gcs(
+                conn,
+                "org.gnome.Mutter.DisplayConfig",
+                "/org/gnome/Mutter/DisplayConfig",
+                "org.gnome.Mutter.DisplayConfig",
+                "GetCurrentState",
+                NULL /* parameters */,
+                NULL /* reply_type */,
+                0    /* G_DBUS_CALL_FLAGS_NONE */,
+                2000 /* 2 s timeout */,
+                NULL /* cancellable */,
+                &error);
+            if (reply && !error) {
+                /*
+                 * Reply is the 4-tuple
+                 *   (uint32 serial, monitors, logical_monitors, properties)
+                 * Logical-monitor entries have the shape
+                 *   (int32 x, int32 y, double scale,
+                 *    uint32 transform, bool primary,
+                 *    array<monitor_spec>, dict properties)
+                 * We want index 2 (scale) of whichever entry is primary.
+                 */
+                void *logical = gvcv(reply, 2);
+                if (logical) {
+                    size_t n = gvnc(logical);
+                    double first = 0.0;
+                    for (size_t i = 0; i < n; i++) {
+                        void *lm = gvcv(logical, i);
+                        if (!lm) continue;
+                        void *sc_v = gvcv(lm, 2);
+                        void *pr_v = gvcv(lm, 4);
+                        double s = sc_v ? gvgd(sc_v) : 0.0;
+                        int prim = pr_v ? gvgb(pr_v) : 0;
+                        if (sc_v) gvu(sc_v);
+                        if (pr_v) gvu(pr_v);
+                        gvu(lm);
+                        if (s > 0.0) {
+                            if (prim) { scale = s; break; }
+                            if (first == 0.0) first = s;
+                        }
+                    }
+                    if (scale <= 0.0) scale = first;
+                    gvu(logical);
+                }
+                gvu(reply);
+            } else if (error && gef) {
+                gef(error);
+                error = NULL;
+            }
+            gou(conn);
+        } else if (error && gef) {
+            gef(error);
+        }
+    }
+
+    dlclose(libgio);
+    return scale;
+}
+
+/* ------------------------------------------------------------------ */
 /*  readXftScale                                                       */
 /*  Reads Xft.dpi from the X11 Resource Manager via dlopen(libX11).  */
 /*  No hard link-time dependency on libX11.                            */
@@ -172,15 +278,21 @@ Java_io_github_kdroidfilter_nucleus_hidpi_HiDpiLinuxBridge_nativeGetScaleFactor(
     scale = readGnomeScaleFactor();
     if (scale > 0.0) return (jdouble)scale;
 
-    /* 3. GDK_SCALE — set by GNOME session / GTK apps */
+    /* 3. GNOME fractional scaling via Mutter DBus. This is the only
+     *    source on Wayland sessions that use scale-monitor-framebuffer,
+     *    where GSettings scaling-factor is 0 and the GDK_* vars are unset. */
+    scale = readGnomeMutterScale();
+    if (scale > 0.0) return (jdouble)scale;
+
+    /* 4. GDK_SCALE — set by GNOME session / GTK apps */
     scale = readEnvDouble("GDK_SCALE");
     if (scale > 0.0) return (jdouble)scale;
 
-    /* 4. GDK_DPI_SCALE — fractional DPI multiplier */
+    /* 5. GDK_DPI_SCALE — fractional DPI multiplier */
     scale = readEnvDouble("GDK_DPI_SCALE");
     if (scale > 0.0) return (jdouble)scale;
 
-    /* 5. Xft.dpi from X Resource Manager */
+    /* 6. Xft.dpi from X Resource Manager */
     scale = readXftScale();
     if (scale > 0.0) return (jdouble)scale;
 


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description

Add a Mutter DBus probe to `linux-hidpi` so `getLinuxNativeScaleFactor()`
returns the correct value on GNOME/Wayland sessions that use fractional
scaling. The probe sits between the existing GSettings step and the
`GDK_SCALE` / `GDK_DPI_SCALE` / `Xft.dpi` fallbacks, uses libgio via
`dlopen` (no new build-time dep), and returns the logical-monitor scale
of the primary display.

## 📄 Motivation and Context

On a 2018 MacBook Pro 15" with Retina panel (2880×1800) running Fedora 43,
GNOME 49 Wayland, GNOME picks **166.67% (5/3)** as the default scale —
the logical desktop is 1728×1080 and every GTK/Qt/Firefox app renders at
that scale. Any Compose Desktop / Swing / AWT app, though, opens its
window at ~1/3 the screen width: AWT renders at 1× because
`sun.java2d.uiScale` is never set.

Tracing [wgtunnel/desktop](https://github.com/wgtunnel/desktop) into
nucleus, I found that `readGnomeScaleFactor()` reads the GSettings
**integer** key `org.gnome.desktop.interface/scaling-factor`, which
stays at `0` on any session using `scale-monitor-framebuffer` —
fractional scaling replaces it, it doesn't populate it. The remaining
fallbacks (`GDK_SCALE`, `GDK_DPI_SCALE`, `Xft.dpi`) are also unset on a
pure Wayland session launched from a `.desktop` entry, so the detector
ultimately returns `0.0`.

The only process that knows the current fractional scale is Mutter; it
exposes it via `org.gnome.Mutter.DisplayConfig.GetCurrentState`. This PR
consults that interface before giving up.

## 🧪 How Has This Been Tested?

Tested on the setup above (Fedora 43, GNOME 49 Wayland, Mesa 26.0.4,
`scale-monitor-framebuffer` enabled).

**Direct JNI probe of the patched .so:**

| Env                        | Returned |
|----------------------------|---------:|
| default (Mutter reachable) | `1.6666666269302368` |
| `J2D_UISCALE=3`            | `3.0` (explicit override still wins) |
| `GDK_SCALE=2`              | `1.6666666269302368` (Mutter beats GDK, as intended) |

Value matches `gdbus call --session --dest org.gnome.Mutter.DisplayConfig
--object-path /org/gnome/Mutter/DisplayConfig --method
org.gnome.Mutter.DisplayConfig.GetCurrentState` exactly.

**End-to-end via a downstream Compose app:**

Published this branch to `mavenLocal` and pointed an unmodified
`wgtunnel/desktop` checkout at it:

```
Info: Applied Linux HiDPI scale: 1.6666666269302368
sun.java2d.uiScale = 1.6666666269302368
```

Window now opens at the correct physical size — same visual footprint
as Firefox / Nautilus / Settings. Before the patch the same setup
rendered at 1× and looked ~1/3 the expected width.

**Multi-monitor:**

Also verified side-by-side with a 1920×1080 external monitor
(logical-monitors: `(0,0, 1.6666…, primary, eDP-1)` +
`(1728,0, 1.0, secondary, DP-4)`). The probe picks the primary entry,
so `sun.java2d.uiScale` is set to `1.6666…` for the whole process.
AWT has no per-monitor DPI in JDK 21, so dragging between monitors
keeps the same scale — usable and readable on both panels, no
crash / Y-flip / input misalignment.

**Project checks:**

- `./gradlew :linux-hidpi:build` — compile + ktlint clean.

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project.
   Mirrors the existing `readGnomeScaleFactor()` pattern in the same
   file: `dlopen("libgio-2.0.so.0", RTLD_LAZY | RTLD_LOCAL)`,
   `dlsym`-ed function pointers, GError / GVariant / GObject refcount
   balance, any failure returns `0.0` so the remaining fallback chain
   still runs. No new hard link-time dependency.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
   `LinuxHiDpi.kt` KDoc now lists Mutter in the priority order.
