### PR TITLE
fix(decorated-window): restore title bar focus block on Windows/Linux

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -40,6 +41,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.offset
+import io.github.kdroidfilter.nucleus.core.runtime.Platform
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 import kotlinx.coroutines.currentCoroutineContext
@@ -100,7 +102,17 @@ fun GenericTitleBarImpl(
         modifier =
             modifier
                 .background(backgroundBrush)
-                .layoutId(TITLE_BAR_LAYOUT_ID)
+                .then(
+                    // Block focus on Windows/Linux so Tab navigation cannot enter the Compose-driven
+                    // title bar drag area. On macOS the traffic-light buttons are native (outside the
+                    // Compose hit-test area), and focus must remain enabled so TextField/TextArea
+                    // children in the title bar can receive keyboard input (issue #206 / PR #208).
+                    if (Platform.Current == Platform.MacOS) {
+                        Modifier
+                    } else {
+                        Modifier.focusProperties { canFocus = false }
+                    },
+                ).layoutId(TITLE_BAR_LAYOUT_ID)
                 .height(style.metrics.height)
                 .onSizeChanged { with(density) { applyTitleBar(it.height.toDp(), state) } }
                 .fillMaxWidth(),


### PR DESCRIPTION
## Summary
- PR #208 removed `focusProperties { canFocus = false }` from the title bar `Box` in `decorated-window-core` so that `TextField`/`TextArea` children could receive keyboard focus inside a macOS title bar (issue #206).
- The change lives in the shared core module, so it also affects Windows and Linux — the PR's checklist confirms those platforms were never verified.
- On Windows (JNI `NativeWindowsTitleBar`) and Linux the title bar is a Compose-driven drag surface, so allowing Tab navigation to reach it is a regression.
- Make the focus block conditional via `Platform.Current`: disabled only on macOS (where traffic lights are native and the title bar hosts interactive Compose widgets), restored on Windows/Linux.

## Test plan
- [x] `./gradlew :decorated-window-core:compileKotlin`
- [x] `./gradlew :decorated-window-core:detekt :decorated-window-core:ktlintCheck`
- [ ] macOS (JNI): `TextField` inside `JewelTitleBar` still receives keyboard input (issue #206 behavior preserved).
- [ ] Windows (JNI): Tab navigation from main content no longer jumps into the title bar drag area.
- [ ] Linux (JNI): Tab navigation from main content no longer jumps into the title bar drag area.
- [ ] Window drag, double-click maximize and control buttons still behave normally on all three OSes.