### PR TITLE
fix(graalvm): embed UTF-8 active code page in Windows manifest

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureGraalvmApplication.kt
@@ -293,7 +293,14 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                     val v3 = versionParts.getOrElse(2) { 0 }
                     val v4 = versionParts.getOrElse(3) { 0 }
 
-                    // Generate DPI-aware application manifest
+                    // Generate Windows side-by-side fusion manifest:
+                    //  - DPI awareness (Per-Monitor V2)
+                    //  - activeCodePage = UTF-8 (Windows 10 1903+) — works around a SubstrateVM
+                    //    bug where LoadLibraryA receives UTF-8 bytes interpreted as the system
+                    //    ANSI codepage, breaking native-image apps installed under non-ASCII
+                    //    paths (Hebrew/Arabic/Cyrillic/CJK usernames). See oracle/graal#8095
+                    //    and #10237 — the GraalVM team explicitly recommends this manifest.
+                    //  - longPathAware: opt into >MAX_PATH paths.
                     val manifestFile = File(rcDir, "dpiaware.manifest")
                     manifestFile.writeText(
                         """
@@ -304,6 +311,8 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                         |    <asmv3:windowsSettings>
                         |      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
                         |      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+                        |      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+                        |      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
                         |    </asmv3:windowsSettings>
                         |  </asmv3:application>
                         |</assembly>


### PR DESCRIPTION
## Summary

- Native-image apps built with BellSoft Liberica NIK 25 crash at startup with `UnsatisfiedLinkError: Can't load library: awt` when installed under a Windows path containing non-ASCII characters (Hebrew/Arabic/Cyrillic/CJK usernames). Root cause: SubstrateVM bug (oracle/graal#8095, #10237) — path strings reach `LoadLibraryA` as UTF-8 bytes that the system ANSI codepage then reinterprets.
- Augment the existing Windows side-by-side fusion manifest (already embedded via `rc.exe` for DPI awareness) with `<activeCodePage>UTF-8</activeCodePage>` — the workaround explicitly recommended by the GraalVM team. With `GetACP()` returning 65001, `LoadLibraryA` bytes are interpreted as UTF-8 and the bug is bypassed for the entire process. Also adds `<longPathAware>true</longPathAware>` for paths beyond `MAX_PATH`.
- Requires Windows 10 1903+ (May 2019) — covers the entire current Windows install base.

## Reproduction (before fix)

```
C:\Users\Public\אבג-test\NucleusDemo> nucleus-sample.exe
Exception in thread "main" java.lang.UnsatisfiedLinkError: Can't load library: awt
  at com.oracle.svm.core.jdk.NativeLibraries.loadLibraryRelative(NativeLibraries.java:141)
  at java.awt.Toolkit.loadLibraries(Toolkit.java:1293)
```

## Test plan

- [x] Build `:example:packageGraalvmNative` with BellSoft NIK 25.0.2+13 on Windows 11
- [x] Sanity check: launch from ASCII path → boots normally
- [x] Repro the crash by copying the bundle into `C:\Users\Public\אבג-test\NucleusDemo\` (Hebrew folder)
- [x] Apply fix, rebuild, repeat — binary boots from the Hebrew path with no `UnsatisfiedLinkError`
- [x] Validate on a real Windows account whose username contains non-ASCII characters (deferred to user-side)
- [ ] Smoke-test ASCII install paths to confirm no regression on existing setups

## References

- oracle/graal#8095 (GR-51123) — original bug report
- oracle/graal#10237 (GR-60338) — manifest workaround recommended by GraalVM maintainers
- kdroidFilter/ScheduleIt#13 — downstream report from a Hebrew Windows user