### PR TITLE
fix(decorated-dialog): apply title bar background to dialog content

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedDialogCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DecoratedDialogCore.kt
@@ -1,5 +1,6 @@
 package io.github.kdroidfilter.nucleus.window
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -289,7 +290,7 @@ fun DialogWindowScope.DecoratedDialogBody(
                     }
                 scope.content()
             },
-            modifier = undecoratedWindowBorder,
+            modifier = Modifier.background(titleBarBackground).then(undecoratedWindowBorder),
             measurePolicy = DecoratedDialogMeasurePolicy,
         )
     }


### PR DESCRIPTION
## Summary
- `DecoratedDialogBody` was missing `Modifier.background(titleBarBackground)` on its `Layout`, while `DecoratedWindowBody` applies it.
- As a result, the dialog content area stayed transparent/white instead of inheriting the theme color from the title bar — most visible with `JewelDecoratedDialog` on dark themes.
- Aligns dialog behavior with the decorated window.

## Test plan
- [ ] Open a `JewelDecoratedDialog` with a dark Jewel theme — content background matches the title bar
- [ ] Same with `MaterialDecoratedDialog` / Material 2 — no regression
- [ ] Light themes still render correctly
- [ ] Linux (Gnome/KDE) rounded shape still applies