### PR TITLE
fix(azure-publisher-name): add publisherName support for azure artifact signing

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -48,14 +48,15 @@ windows {
 | Sectigo | `http://timestamp.sectigo.com` |
 | GlobalSign | `http://timestamp.globalsign.com` |
 
-### Azure Trusted Signing
+### Azure Artifact Signing
 
-For cloud-based signing with [Azure Trusted Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/):
+For cloud-based signing with [Azure Artifact Signing](https://learn.microsoft.com/en-us/azure/artifact-signing/):
 
 ```kotlin
 windows {
     signing {
         enabled = true
+        publisherName = "Your Publisher Name"
         azureTenantId = "your-tenant-id"
         azureEndpoint = "https://your-region.codesigning.azure.net"
         azureCertificateProfileName = "your-profile"

--- a/docs/comparison/packaging.md
+++ b/docs/comparison/packaging.md
@@ -146,27 +146,27 @@ Conveyor's delta update system is a genuine differentiator: a single-line change
 
 ### 4. Code Signing & Notarization
 
-| Tool | macOS Signing | macOS Notarization | Windows PFX | Azure Trusted Signing | Other Cloud HSMs | Score |
-|------|:------------:|:------------------:|:-----------:|:---------------------:|:----------------:|:-----:|
-| **Nucleus** | ✅ | ✅ | ✅ | ✅ | ❌ | **10** |
-| Conveyor | ✅ | ✅ | ✅ (+ self-sign + SSL certs) | ✅ | ✅ (6 providers) | **10** |
-| install4j | ✅ | ✅ | ✅ | ❌ | ❌ | **8** |
-| jDeploy | ✅¹ | ✅¹ | ✅¹ | ❌ | ❌ | **7** |
-| jpackage | ✅ (`--mac-sign`) | ✅ (`--mac-app-store`) | ❌ | ❌ | ❌ | **3** |
-| Compose MP | ✅ | ✅ | ❌ | ❌ | ❌ | **5** |
-| JavaPackager | ✅ | ❌ | ✅ (Jsign) | ❌ | ❌ | **3** |
+| Tool | macOS Signing | macOS Notarization | Windows PFX | Azure Artifact Signing | Other Cloud HSMs | Score |
+|------|:------------:|:------------------:|:-----------:|:----------------------:|:----------------:|:-----:|
+| **Nucleus** | ✅ | ✅ | ✅ |           ✅            | ❌ | **10** |
+| Conveyor | ✅ | ✅ | ✅ (+ self-sign + SSL certs) |           ✅            | ✅ (6 providers) | **10** |
+| install4j | ✅ | ✅ | ✅ |           ❌            | ❌ | **8** |
+| jDeploy | ✅¹ | ✅¹ | ✅¹ |           ❌            | ❌ | **7** |
+| jpackage | ✅ (`--mac-sign`) | ✅ (`--mac-app-store`) | ❌ |           ❌            | ❌ | **3** |
+| Compose MP | ✅ | ✅ | ❌ |           ❌            | ❌ | **5** |
+| JavaPackager | ✅ | ❌ | ✅ (Jsign) |           ❌            | ❌ | **3** |
 
 ¹ jDeploy pre-signs and notarizes installers using its own certificate; optional custom signing via GitHub Action ([FAQ](https://www.jdeploy.com/docs/faq/)).
 
 ??? info "Sources"
-    - **Nucleus**: [`MacOSSigningSettings.kt`](https://github.com/kdroidFilter/Nucleus/blob/main/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/MacOSSigningSettings.kt), [`WindowsSigningSettings.kt`](https://github.com/kdroidFilter/Nucleus/blob/main/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/WindowsSigningSettings.kt) — Azure Trusted Signing via `azureTenantId`, `azureEndpoint`, `azureCertificateProfileName`
-    - **Conveyor**: [Keys and certificates](https://conveyor.hydraulic.dev/21.1/configs/keys-and-certificates/) — macOS notarization (App Store Connect API keys), Windows self-signing, Azure Trusted Signing, Azure Key Vault, AWS KMS, SSL.com eSigner, DigiCert ONE, Google Cloud KMS, HSMs (SafeNet, YubiKey)
+    - **Nucleus**: [`MacOSSigningSettings.kt`](https://github.com/kdroidFilter/Nucleus/blob/main/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/MacOSSigningSettings.kt), [`WindowsSigningSettings.kt`](https://github.com/kdroidFilter/Nucleus/blob/main/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/WindowsSigningSettings.kt) — Azure Artifact Signing via `azureTenantId`, `azureEndpoint`, `azureCertificateProfileName`
+    - **Conveyor**: [Keys and certificates](https://conveyor.hydraulic.dev/21.1/configs/keys-and-certificates/) — macOS notarization (App Store Connect API keys), Windows self-signing, Azure Artifact Signing, Azure Key Vault, AWS KMS, SSL.com eSigner, DigiCert ONE, Google Cloud KMS, HSMs (SafeNet, YubiKey)
     - **install4j**: [Features](https://www.ej-technologies.com/install4j/features) — cross-platform signing and notarization
     - **jpackage**: [Oracle man page](https://docs.oracle.com/en/java/javase/23/docs/specs/man/jpackage.html) — `--mac-sign`, `--mac-signing-key-user-name`, `--mac-app-store`
     - **Compose MP**: [Native distributions](https://kotlinlang.org/docs/multiplatform/compose-native-distribution.html) — macOS signing and notarization DSL
     - **JavaPackager**: [v1.7.4 release](https://github.com/fvarrui/JavaPackager/releases/tag/v1.7.4) — Jsign 5.0 for Windows signing
 
-Conveyor has the broadest signing provider support (6 cloud HSM services). Nucleus focuses on the two most common paths (PFX + Azure Trusted Signing) with CI-ready composite actions for secret management.
+Conveyor has the broadest signing provider support (6 cloud HSM services). Nucleus focuses on the two most common paths (PFX + Azure Artifact Signing) with CI-ready composite actions for secret management.
 
 ---
 
@@ -423,7 +423,7 @@ A modern CLI tool that uniquely supports **cross-compilation** — build for Win
 
 **Updates**: Sparkle 2 on macOS with delta patches (configurable, default 5 versions), MSIX native 64 KB-chunk delta on Windows, apt repositories on Linux ([update modes](https://conveyor.hydraulic.dev/21.1/configs/update-modes/)).
 
-**Signing**: Self-signing for free distribution, purchased Authenticode/SSL certificates (.p12/.pfx), macOS notarization via App Store Connect API keys, plus 6 cloud signing providers: Azure Trusted Signing, Azure Key Vault, AWS KMS, SSL.com eSigner, DigiCert ONE, Google Cloud KMS, and HSM support (SafeNet, YubiKey) ([keys and certificates](https://conveyor.hydraulic.dev/21.1/configs/keys-and-certificates/)).
+**Signing**: Self-signing for free distribution, purchased Authenticode/SSL certificates (.p12/.pfx), macOS notarization via App Store Connect API keys, plus 6 cloud signing providers: Azure Artifact Signing, Azure Key Vault, AWS KMS, SSL.com eSigner, DigiCert ONE, Google Cloud KMS, and HSM support (SafeNet, YubiKey) ([keys and certificates](https://conveyor.hydraulic.dev/21.1/configs/keys-and-certificates/)).
 
 **OS integration**: Registers URL schemes (`app.url-schemes`) and file associations (`app.file-associations`) at OS level, but does **not** provide a runtime library — apps must implement receiving logic themselves ([OS integration](https://conveyor.hydraulic.dev/21.1/configs/os-integration/)).
 
@@ -495,7 +495,7 @@ Bundles JRE with application into a directory structure. Game-focused (libGDX/LW
 4. **First JVM tool with AOT cache** — Project Leyden (JDK 25+), no GraalVM required
 5. **First JVM tool with integrated GraalVM Native Image support** — compile Compose Desktop apps to standalone native binaries (~0.5s cold boot, ~100–150 MB RAM, no bundled JRE). Three startup tiers: standard JVM → AOT cache (Leyden) → native image
 6. **Broadest store distribution** — 4 stores (MAS, MS Store, Flathub, Snap Store), unique JVM sandbox pipeline
-7. **Full signing matrix** — macOS + notarization, Windows PFX + Azure Trusted Signing
+7. **Full signing matrix** — macOS + notarization, Windows PFX + Azure Artifact Signing
 8. **Free and open source** (MIT)
 9. **Native SSL runtime** — unique JNI module using the OS trust store (macOS Security.framework, Windows Crypt32, Linux PEM bundles); pre-wired OkHttp and Ktor adapters; no cacerts manipulation needed at runtime
 10. **Build-time CA cert patching** — import custom PEM/DER certificates into the bundled JVM's `cacerts` at packaging time (Conveyor also offers this via `app.jvm.additional-ca-certs`)

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -61,7 +61,7 @@ curl -s https://nucleusframework.dev/llms-full.txt   # complete
 - Platform-specific configuration (macOS, Windows, Linux)
 - macOS 26 Liquid Glass and SDK version patching
 - Sandboxing pipeline details
-- Code signing and notarization (Windows PFX, Azure Trusted Signing, macOS Developer ID)
+- Code signing and notarization (Windows PFX, Azure Artifact Signing, macOS Developer ID)
 - Auto-update runtime API with Compose integration example
 - Publishing to GitHub Releases and S3
 - CI/CD workflows and all composite actions

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1268,7 +1268,7 @@ Create an `.msixbundle` containing both amd64 and arm64 `.appx` files. See [CI/C
 
 ## Code Signing
 
-See [Code Signing](../code-signing.md#windows) for full details on PFX certificates and Azure Trusted Signing.
+See [Code Signing](../code-signing.md#windows) for full details on PFX certificates and Azure Artifact Signing.
 
 ```kotlin
 windows {
@@ -1913,9 +1913,9 @@ windows {
 | Sectigo | `http://timestamp.sectigo.com` |
 | GlobalSign | `http://timestamp.globalsign.com` |
 
-### Azure Trusted Signing
+### Azure Artifact Signing
 
-For cloud-based signing with [Azure Trusted Signing](https://learn.microsoft.com/en-us/azure/trusted-signing/):
+For cloud-based signing with [Azure Artifact Signing](https://learn.microsoft.com/en-us/azure/artifact-signing/):
 
 ```kotlin
 windows {
@@ -3212,7 +3212,7 @@ GraalVM Native Image compilation **requires [BellSoft Liberica NIK 25](https://b
 
 Some libraries and use cases make native image compilation **extremely difficult or impractical**. Nucleus can handle most standard Compose Desktop dependencies automatically, but the following categories will likely require extensive manual configuration — or may not work at all:
 
-**Libraries that are very hard to support:** 
+**Libraries that are very hard to support:**
     - **Heavy JNA users** — Libraries that rely extensively on JNA (Java Native Access) for dynamic function calls. JNA's runtime proxy generation is fundamentally at odds with native-image's closed-world assumption. Examples: some system tray libraries, platform bridge libraries.
     - **Full-text search engines** — Apache Lucene, Elasticsearch client, and similar libraries use heavy reflection, dynamic class loading, custom classloaders, and `MethodHandle`-based access patterns that are nearly impossible to capture statically.
     - **Dynamic scripting engines** — Embedding Groovy, JRuby, Nashorn, or other scripting runtimes that rely on runtime code generation.
@@ -4034,7 +4034,7 @@ Cancellation is bidirectional: cancelling the JVM `Job` cancels the native corou
 
 Nucleus provides reusable composite actions and ready-to-use GitHub Actions workflows for building, packaging, and publishing desktop applications across all platforms.
 
-**Use Nucleus actions in your own project:** 
+**Use Nucleus actions in your own project:**
     All composite actions can be referenced directly from the Nucleus repository — no need to copy them into your project:
 
     ```yaml
@@ -5540,7 +5540,7 @@ NucleusDecoratedWindowTheme(
     windowStyle = myWindowStyle,
     titleBarStyle = myTitleBarStyle,
 ) {
-    DecoratedWindow(...) 
+    DecoratedWindow(...)
 }
 ```
 
@@ -13303,7 +13303,7 @@ Conveyor's delta update system is a genuine differentiator: a single-line change
 
 ### 4. Code Signing & Notarization
 
-| Tool | macOS Signing | macOS Notarization | Windows PFX | Azure Trusted Signing | Other Cloud HSMs | Score |
+| Tool | macOS Signing | macOS Notarization | Windows PFX | Azure Artifact Signing | Other Cloud HSMs | Score |
 |------|:------------:|:------------------:|:-----------:|:---------------------:|:----------------:|:-----:|
 | **Nucleus** | ✅ | ✅ | ✅ | ✅ | ❌ | **10** |
 | Conveyor | ✅ | ✅ | ✅ (+ self-sign + SSL certs) | ✅ | ✅ (6 providers) | **10** |
@@ -13316,14 +13316,14 @@ Conveyor's delta update system is a genuine differentiator: a single-line change
 ¹ jDeploy pre-signs and notarizes installers using its own certificate; optional custom signing via GitHub Action ([FAQ](https://www.jdeploy.com/docs/faq/)).
 
 ??? info "Sources"
-    - **Nucleus**: [`MacOSSigningSettings.kt`](https://github.com/kdroidFilter/Nucleus/blob/main/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/MacOSSigningSettings.kt), [`WindowsSigningSettings.kt`](https://github.com/kdroidFilter/Nucleus/blob/main/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/WindowsSigningSettings.kt) — Azure Trusted Signing via `azureTenantId`, `azureEndpoint`, `azureCertificateProfileName`
-    - **Conveyor**: [Keys and certificates](https://conveyor.hydraulic.dev/21.1/configs/keys-and-certificates/) — macOS notarization (App Store Connect API keys), Windows self-signing, Azure Trusted Signing, Azure Key Vault, AWS KMS, SSL.com eSigner, DigiCert ONE, Google Cloud KMS, HSMs (SafeNet, YubiKey)
+    - **Nucleus**: [`MacOSSigningSettings.kt`](https://github.com/kdroidFilter/Nucleus/blob/main/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/MacOSSigningSettings.kt), [`WindowsSigningSettings.kt`](https://github.com/kdroidFilter/Nucleus/blob/main/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/WindowsSigningSettings.kt) — Azure Artifact Signing via `azureTenantId`, `azureEndpoint`, `azureCertificateProfileName`
+    - **Conveyor**: [Keys and certificates](https://conveyor.hydraulic.dev/21.1/configs/keys-and-certificates/) — macOS notarization (App Store Connect API keys), Windows self-signing, Azure Artifact Signing, Azure Key Vault, AWS KMS, SSL.com eSigner, DigiCert ONE, Google Cloud KMS, HSMs (SafeNet, YubiKey)
     - **install4j**: [Features](https://www.ej-technologies.com/install4j/features) — cross-platform signing and notarization
     - **jpackage**: [Oracle man page](https://docs.oracle.com/en/java/javase/23/docs/specs/man/jpackage.html) — `--mac-sign`, `--mac-signing-key-user-name`, `--mac-app-store`
     - **Compose MP**: [Native distributions](https://kotlinlang.org/docs/multiplatform/compose-native-distribution.html) — macOS signing and notarization DSL
     - **JavaPackager**: [v1.7.4 release](https://github.com/fvarrui/JavaPackager/releases/tag/v1.7.4) — Jsign 5.0 for Windows signing
 
-Conveyor has the broadest signing provider support (6 cloud HSM services). Nucleus focuses on the two most common paths (PFX + Azure Trusted Signing) with CI-ready composite actions for secret management.
+Conveyor has the broadest signing provider support (6 cloud HSM services). Nucleus focuses on the two most common paths (PFX + Azure Artifact Signing) with CI-ready composite actions for secret management.
 
 ---
 
@@ -13576,7 +13576,7 @@ A modern CLI tool that uniquely supports **cross-compilation** — build for Win
 
 **Updates**: Sparkle 2 on macOS with delta patches (configurable, default 5 versions), MSIX native 64 KB-chunk delta on Windows, apt repositories on Linux ([update modes](https://conveyor.hydraulic.dev/21.1/configs/update-modes/)).
 
-**Signing**: Self-signing for free distribution, purchased Authenticode/SSL certificates (.p12/.pfx), macOS notarization via App Store Connect API keys, plus 6 cloud signing providers: Azure Trusted Signing, Azure Key Vault, AWS KMS, SSL.com eSigner, DigiCert ONE, Google Cloud KMS, and HSM support (SafeNet, YubiKey) ([keys and certificates](https://conveyor.hydraulic.dev/21.1/configs/keys-and-certificates/)).
+**Signing**: Self-signing for free distribution, purchased Authenticode/SSL certificates (.p12/.pfx), macOS notarization via App Store Connect API keys, plus 6 cloud signing providers: Azure Artifact Signing, Azure Key Vault, AWS KMS, SSL.com eSigner, DigiCert ONE, Google Cloud KMS, and HSM support (SafeNet, YubiKey) ([keys and certificates](https://conveyor.hydraulic.dev/21.1/configs/keys-and-certificates/)).
 
 **OS integration**: Registers URL schemes (`app.url-schemes`) and file associations (`app.file-associations`) at OS level, but does **not** provide a runtime library — apps must implement receiving logic themselves ([OS integration](https://conveyor.hydraulic.dev/21.1/configs/os-integration/)).
 
@@ -13648,7 +13648,7 @@ Bundles JRE with application into a directory structure. Game-focused (libGDX/LW
 4. **First JVM tool with AOT cache** — Project Leyden (JDK 25+), no GraalVM required
 5. **First JVM tool with integrated GraalVM Native Image support** — compile Compose Desktop apps to standalone native binaries (~0.5s cold boot, ~100–150 MB RAM, no bundled JRE). Three startup tiers: standard JVM → AOT cache (Leyden) → native image
 6. **Broadest store distribution** — 4 stores (MAS, MS Store, Flathub, Snap Store), unique JVM sandbox pipeline
-7. **Full signing matrix** — macOS + notarization, Windows PFX + Azure Trusted Signing
+7. **Full signing matrix** — macOS + notarization, Windows PFX + Azure Artifact Signing
 8. **Free and open source** (MIT)
 9. **Native SSL runtime** — unique JNI module using the OS trust store (macOS Security.framework, Windows Crypt32, Linux PEM bundles); pre-wired OkHttp and Ktor adapters; no cacerts manipulation needed at runtime
 10. **Build-time CA cert patching** — import custom PEM/DER certificates into the bundled JVM's `cacerts` at packaging time (Conveyor also offers this via `app.jvm.additional-ca-certs`)
@@ -13940,7 +13940,7 @@ dependencies {
 | Flatpak config | Not available | Full `flatpak { }` DSL |
 | Store pipeline | Not available | Automatic dual pipeline for store formats (PKG, AppX, Flatpak) with sandboxing for PKG and Flatpak |
 | Auto-update | Not available | Built-in with YML metadata |
-| Code signing | macOS only | + Windows PFX / Azure Trusted Signing |
+| Code signing | macOS only | + Windows PFX / Azure Artifact Signing |
 | DMG appearance | Not customizable (jpackage defaults) | Full `dmg { }` DSL: background, icon size, window layout, content positioning, format ([details](targets/macos.md#dmg-customization)) |
 | Artifact naming | Fixed | Template with `artifactName` |
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -659,7 +659,7 @@ dependencies {
 | Flatpak config | Not available | Full `flatpak { }` DSL |
 | Store pipeline | Not available | Automatic dual pipeline for store formats (PKG, AppX, Flatpak) with sandboxing for PKG and Flatpak |
 | Auto-update | Not available | Built-in with YML metadata |
-| Code signing | macOS only | + Windows PFX / Azure Trusted Signing |
+| Code signing | macOS only | + Windows PFX / Azure Artifact Signing |
 | DMG appearance | Not customizable (jpackage defaults) | Full `dmg { }` DSL: background, icon size, window layout, content positioning, format ([details](targets/macos.md#dmg-customization)) |
 | Artifact naming | Fixed | Template with `artifactName` |
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -150,25 +150,25 @@ dependencies {
 
 ## What Changes
 
-| Feature | Before (compose) | After (nucleus) |
-|---------|-------------------|-----------------|
-| DSL entry point | `compose.desktop.application` | `nucleus.application` |
-| DSL imports | `org.jetbrains.compose.desktop.application.dsl.*` | `io.github.kdroidfilter.nucleus.desktop.application.dsl.*` |
-| Target formats | DMG, PKG, MSI, EXE, DEB, RPM | + NSIS, AppX, Portable, AppImage, Snap, Flatpak, archives |
-| Native lib cleanup | Manual | `cleanupNativeLibs = true` |
-| AOT cache | Not available | `enableAotCache = true` |
-| Splash screen | Manual | `splashImage = "splash.png"` |
-| Deep links | Manual (macOS only via Info.plist) | Cross-platform `protocol("name", "scheme")` |
-| File associations | Limited | Cross-platform `fileAssociation()` |
-| NSIS config | Not available | Full `nsis { }` DSL |
-| AppX config | Not available | Full `appx { }` DSL |
-| Snap config | Not available | Full `snap { }` DSL |
-| Flatpak config | Not available | Full `flatpak { }` DSL |
-| Store pipeline | Not available | Automatic dual pipeline for store formats (PKG, AppX, Flatpak) with sandboxing for PKG and Flatpak |
-| Auto-update | Not available | Built-in with YML metadata |
-| Code signing | macOS only | + Windows PFX / Azure Trusted Signing |
+| Feature | Before (compose) | After (nucleus)                                                                                                                       |
+|---------|-------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| DSL entry point | `compose.desktop.application` | `nucleus.application`                                                                                                                 |
+| DSL imports | `org.jetbrains.compose.desktop.application.dsl.*` | `io.github.kdroidfilter.nucleus.desktop.application.dsl.*`                                                                            |
+| Target formats | DMG, PKG, MSI, EXE, DEB, RPM | + NSIS, AppX, Portable, AppImage, Snap, Flatpak, archives                                                                             |
+| Native lib cleanup | Manual | `cleanupNativeLibs = true`                                                                                                            |
+| AOT cache | Not available | `enableAotCache = true`                                                                                                               |
+| Splash screen | Manual | `splashImage = "splash.png"`                                                                                                          |
+| Deep links | Manual (macOS only via Info.plist) | Cross-platform `protocol("name", "scheme")`                                                                                           |
+| File associations | Limited | Cross-platform `fileAssociation()`                                                                                                    |
+| NSIS config | Not available | Full `nsis { }` DSL                                                                                                                   |
+| AppX config | Not available | Full `appx { }` DSL                                                                                                                   |
+| Snap config | Not available | Full `snap { }` DSL                                                                                                                   |
+| Flatpak config | Not available | Full `flatpak { }` DSL                                                                                                                |
+| Store pipeline | Not available | Automatic dual pipeline for store formats (PKG, AppX, Flatpak) with sandboxing for PKG and Flatpak                                    |
+| Auto-update | Not available | Built-in with YML metadata                                                                                                            |
+| Code signing | macOS only | + Windows PFX / Azure Artifact Signing                                                                                                |
 | DMG appearance | Not customizable (jpackage defaults) | Full `dmg { }` DSL: background, icon size, window layout, content positioning, format ([details](targets/macos.md#dmg-customization)) |
-| Artifact naming | Fixed | Template with `artifactName` |
+| Artifact naming | Fixed | Template with `artifactName`                                                                                                          |
 
 ## Important Differences from Compose Desktop
 

--- a/docs/targets/windows.md
+++ b/docs/targets/windows.md
@@ -217,7 +217,7 @@ Create an `.msixbundle` containing both amd64 and arm64 `.appx` files. See [CI/C
 
 ## Code Signing
 
-See [Code Signing](../code-signing.md#windows) for full details on PFX certificates and Azure Trusted Signing.
+See [Code Signing](../code-signing.md#windows) for full details on PFX certificates and Azure Artifact Signing.
 
 ```kotlin
 windows {

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/WindowsSigningSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/WindowsSigningSettings.kt
@@ -34,12 +34,19 @@ abstract class WindowsSigningSettings {
     /** Signing hash algorithm. Default: [SigningAlgorithm.Sha256] */
     var algorithm: SigningAlgorithm = SigningAlgorithm.Sha256
 
-    // --- Azure Trusted Signing ---
+    /**
+     * Publisher name, exactly as in the code signing certificate.
+     * Required by electron-builder when signing with Azure Artifact Signing.
+     * If unset, falls back to `nativeDistributions.vendor`.
+     */
+    var publisherName: String? = null
 
-    /** Azure tenant ID for Trusted Signing */
+    // --- Azure Artifact Signing ---
+
+    /** Azure tenant ID for Artifact Signing */
     var azureTenantId: String? = null
 
-    /** Azure Trusted Signing endpoint URL */
+    /** Azure Artifact Signing endpoint URL */
     var azureEndpoint: String? = null
 
     /** Azure certificate profile name */

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -316,6 +316,7 @@ internal class ElectronBuilderConfigGenerator {
 
         if (signing.azureTenantId != null) {
             yaml.appendLine("  azureSignOptions:")
+            appendIfNotNull(yaml, "    publisherName", signing.publisherName ?: distributions.vendor)
             appendIfNotNull(yaml, "    endpoint", signing.azureEndpoint)
             appendIfNotNull(yaml, "    certificateProfileName", signing.azureCertificateProfileName)
             appendIfNotNull(yaml, "    codeSigningAccountName", signing.azureCodeSigningAccountName)


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
Adds `publisherName` to Windows signing and uses that to set the `publisherName` passed to electron-builder. Falls back to using `vendor` if it's not specified.

This also renames Azure Trusted Signing to Azure Artifact Signing in the docs to match the new name of the service.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #219. Windows builds fail to sign with Azure without this change.

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Completely untested. I'm not sure how to get a snapshot version onto the GH build server and I don't have access to Windows to test locally.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.