### PR TITLE
Migrate decorated-window-tao backend from tao to winit (macOS + Windows)

### DIFF
--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -313,6 +313,44 @@ jobs:
           path: media-control/src/main/resources/nucleus/native/win32-*/
           retention-days: 1
 
+      # decorated-window-tao: Rust crate (winit) + four C helpers.
+      # Linux is intentionally skipped — see decorated-window-tao/MIGRATION.md
+      # (Linux migration is Phase 3.4 of the tao -> winit move).
+      - name: Install Rust Windows targets (decorated-window-tao)
+        shell: bash
+        run: |
+          rustup target add x86_64-pc-windows-msvc
+          rustup target add aarch64-pc-windows-msvc
+
+      - name: Build decorated-window-tao Windows DLLs
+        shell: cmd
+        run: call decorated-window-tao\src\main\native\windows\build.bat
+
+      - name: Verify decorated-window-tao Windows natives
+        shell: bash
+        run: |
+          for f in \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao.dll \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao_windows_deco.dll \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao_gl.dll \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao_a11y.dll \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao_dnd.dll \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao.dll \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao_windows_deco.dll \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao_gl.dll \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao_a11y.dll \
+            decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao_dnd.dll; do
+            if [ ! -f "$f" ]; then echo "MISSING: $f" >&2; exit 1; fi
+            echo "OK: $f ($(wc -c < "$f") bytes)"
+          done
+
+      - name: Upload decorated-window-tao Windows DLLs
+        uses: actions/upload-artifact@v4
+        with:
+          name: decorated-window-tao-windows
+          path: decorated-window-tao/src/main/resources/nucleus/native/win32-*/
+          retention-days: 1
+
   macos:
     runs-on: macos-latest
     steps:
@@ -627,6 +665,37 @@ jobs:
         with:
           name: media-control-macos
           path: media-control/src/main/resources/nucleus/native/darwin-*/
+          retention-days: 1
+
+      # decorated-window-tao: Rust crate (winit) + two ObjC helpers
+      # (libnucleus_tao_metal, libnucleus_tao_dnd). Linux is skipped here —
+      # see decorated-window-tao/MIGRATION.md (Linux migration is Phase 3.4).
+      - name: Install Rust macOS targets (decorated-window-tao)
+        run: |
+          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
+
+      - name: Build decorated-window-tao macOS dylibs
+        run: bash decorated-window-tao/src/main/native/macos/build.sh
+
+      - name: Verify decorated-window-tao macOS natives
+        run: |
+          for f in \
+            decorated-window-tao/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_tao.dylib \
+            decorated-window-tao/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_tao_metal.dylib \
+            decorated-window-tao/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_tao_dnd.dylib \
+            decorated-window-tao/src/main/resources/nucleus/native/darwin-x64/libnucleus_tao.dylib \
+            decorated-window-tao/src/main/resources/nucleus/native/darwin-x64/libnucleus_tao_metal.dylib \
+            decorated-window-tao/src/main/resources/nucleus/native/darwin-x64/libnucleus_tao_dnd.dylib; do
+            if [ ! -f "$f" ]; then echo "MISSING: $f" >&2; exit 1; fi
+            echo "OK: $f ($(wc -c < "$f") bytes)"
+          done
+
+      - name: Upload decorated-window-tao macOS dylibs
+        uses: actions/upload-artifact@v4
+        with:
+          name: decorated-window-tao-macos
+          path: decorated-window-tao/src/main/resources/nucleus/native/darwin-*/
           retention-days: 1
 
   linux:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -176,6 +176,13 @@ jobs:
           pattern: 'media-control-*'
           merge-multiple: true
 
+      - name: Download decorated-window-tao artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: decorated-window-tao/src/main/resources/nucleus/native/
+          pattern: 'decorated-window-tao-*'
+          merge-multiple: true
+
       - name: Verify all natives present
         run: |
           EXPECTED=(
@@ -265,6 +272,22 @@ jobs:
             "media-control/src/main/resources/nucleus/native/darwin-x64/libnucleus_media_control_macos.dylib"
             "media-control/src/main/resources/nucleus/native/win32-x64/nucleus_media_control_windows.dll"
             "media-control/src/main/resources/nucleus/native/win32-aarch64/nucleus_media_control_windows.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_tao.dylib"
+            "decorated-window-tao/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_tao_metal.dylib"
+            "decorated-window-tao/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_tao_dnd.dylib"
+            "decorated-window-tao/src/main/resources/nucleus/native/darwin-x64/libnucleus_tao.dylib"
+            "decorated-window-tao/src/main/resources/nucleus/native/darwin-x64/libnucleus_tao_metal.dylib"
+            "decorated-window-tao/src/main/resources/nucleus/native/darwin-x64/libnucleus_tao_dnd.dylib"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao_windows_deco.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao_gl.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao_a11y.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-x64/nucleus_tao_dnd.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao_windows_deco.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao_gl.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao_a11y.dll"
+            "decorated-window-tao/src/main/resources/nucleus/native/win32-aarch64/nucleus_tao_dnd.dll"
           )
           MISSING=0
           for f in "${EXPECTED[@]}"; do

--- a/decorated-window-tao/HANDOFF.md
+++ b/decorated-window-tao/HANDOFF.md
@@ -1,0 +1,219 @@
+# Handoff — migration `tao` → `winit`
+
+Document de reprise pour une nouvelle session Claude (potentiellement sur une autre machine). Lis ce fichier en premier, puis `MIGRATION.md` pour le plan complet.
+
+## TL;DR
+
+Migration big-bang du backend windowing du module `decorated-window-tao` de `tao 0.35` vers `winit 0.30`. **macOS et Windows sont migrés et committés**, **Linux reste à faire**, le pinch-to-zoom natif (motivation initiale) est planifié en Phase 4.
+
+PR ouverte : **https://github.com/kdroidFilter/Nucleus/pull/223** (base `wip/tao-experiment`).
+
+## État du repo
+
+- **Branche courante** : `wip/winit-migration` (poussée sur origin)
+- **Branche de base** : `wip/tao-experiment`
+- **Branche main** : `main` (pas la cible directe — la PR cible `wip/tao-experiment`)
+- **Repo** : https://github.com/kdroidFilter/Nucleus (a été renommé depuis `ComposeDeskKit`)
+
+### Commits sur la branche
+
+```
+b10dc0c8  ci: build and verify decorated-window-tao natives on macOS and Windows
+48d866a6  refactor(decorated-window-tao): migrate Windows backend from tao to winit
+098da980  refactor(decorated-window-tao): migrate macOS backend from tao to winit
+```
+
+## Contexte projet (rappel)
+
+**ComposeDeskKit (Nucleus)** — Toolkit Gradle pour applications JVM desktop sur macOS, Windows, Linux. Le module `decorated-window-tao` fournit un backend de fenêtrage alternatif basé jusqu'à présent sur la crate Rust `tao`, avec interop JNI vers Kotlin/Compose.
+
+**Pourquoi migrer vers winit ?**
+1. `tao 0.35` ne livre pas de gestes macOS natifs (`PinchGesture`, `RotationGesture`, `DoubleTapGesture`) — bloquant pour le besoin originel multitouch / pinch-to-zoom
+2. `tao` est en mode maintenance (Tauri est revenu sur `winit`)
+3. `tao` traîne une dépendance GTK sur Linux dont nous n'utilisons quasiment rien
+4. ~7 contournements ObjC parallèles déjà en place (a11y, traffic-lights, drag, deep links, dnd, main-thread dispatch, NucleusTaoMetal) — le coût marginal d'un nouveau bypass dépasse celui d'un changement de crate
+
+`winit 0.30` apporte les gestes nativement, supprime GTK Linux, et a une maintenance active. `raw-window-handle 0.6` reste compatible (feature `rwh_06`).
+
+## Ce qui est fait ✅
+
+### Phase 0 — Préparation
+- Branche `wip/winit-migration` créée
+- `MIGRATION.md` rédigé (plan en 6 phases avec checkboxes)
+
+### Phase 1 — Cargo
+- `Cargo.toml` : `tao = "0.35"` → `winit = { version = "0.30", features = ["rwh_06"] }`
+- `gtk = "0.18"` et `gdkx11-sys = "0.18"` retirés
+- `glib = "0.18"` **conservé temporairement** pour le code GDK legacy dans `linux/{handles,cursor}.rs` (sera retiré en 3.4)
+- `Cargo.lock` mis à jour
+
+### Phase 2 — macOS
+Tous fichiers Rust dans `decorated-window-tao/src/main/native/src/` :
+- `state.rs`, `events.rs`, `keymap.rs`, `cursor.rs` — imports `tao::*` → `winit::*`
+- `event_loop.rs` — réécrit autour de `ApplicationHandler<UserEvent>` (le gros morceau)
+- `platform/macos/handles.rs` — nouvelle fonction `ns_view_pointer(window: &Window) -> i64` qui extrait le NSView via `raw_window_handle::AppKit`
+- `platform/macos/ime.rs`, `platform/macos/text_overlay.rs` — utilisent `ns_view_pointer`
+- `window_jni.rs` — `nativeDragWindow` utilise `ns_view_pointer` + nouveau helper ObjC
+- ObjC : `macos/window_drag.m` — ajout de `nucleus_tao_ns_view_to_ns_window(int64) -> int64` car winit ne livre que NSView (pas NSWindow) via `RawWindowHandle::AppKit`
+- `platform/macos/ffi.rs` — déclaration de la nouvelle fonction extern
+
+### Phase 3.5 — Windows
+- `platform/windows/handles.rs` — `WindowExtWindows::hwnd()` → `RawWindowHandle::Win32` ; nouvelle fn `hwnd_pointer(window: &Window) -> i64`
+- `platform/windows/a11y.rs` — **aucun changement** (UIA via DLL sœur, indépendant)
+
+### CI
+- `.github/workflows/build-natives.yaml` :
+  - Job `macos` : install Rust targets, run `decorated-window-tao/src/main/native/macos/build.sh`, verify 6 dylibs (3 × 2 archs), upload `decorated-window-tao-macos`
+  - Job `windows` : install Rust MSVC targets, run `decorated-window-tao/src/main/native/windows/build.bat`, verify 10 DLLs (5 × 2 archs), upload `decorated-window-tao-windows`
+  - Job `linux` : **pas touché** (Linux pas migré)
+- `.github/workflows/pre-merge.yaml` : download des artifacts + 16 paths EXPECTED ajoutés au verify
+
+## Ce qui reste ❌
+
+### Phase 3.4 — Linux (le prochain gros morceau)
+
+Fichiers à toucher :
+- `decorated-window-tao/src/main/native/src/platform/linux/handles.rs` — supprimer le passage par `WindowExtUnix::gtk_window()`. Lire directement `Window::window_handle()` qui expose `RawWindowHandle::Xlib` / `Wayland` (winit le fait sans GTK)
+- `decorated-window-tao/src/main/native/src/platform/linux/cursor.rs` — **supprimer** la branche GDK (`gdk_window_set_device_cursor`), utiliser `Window::set_cursor()` standard de winit. Vérifier que le bug "curseur reset au mouvement" de tao n'existe pas avec winit
+- `decorated-window-tao/src/main/native/src/platform/linux/a11y.rs` — **aucun changement** (AccessKit + AT-SPI2 via D-Bus, indépendant)
+- `decorated-window-tao/src/main/native/Cargo.toml` — retirer `glib = "0.18"`
+- `decorated-window-tao/src/main/native/src/event_loop.rs` — déjà adapté pour winit (`EventLoopBuilderExtX11` + `EventLoopBuilderExtWayland`), mais la branche `#[cfg(target_os = "linux")]` qui appelle `gtk_window().realize()` a déjà été retirée
+- `.github/workflows/build-natives.yaml` — ajouter le job `linux` pour `decorated-window-tao`
+- `.github/workflows/pre-merge.yaml` — ajouter les 2 paths Linux dans EXPECTED (libnucleus_tao.so x64 + aarch64)
+- `decorated-window-tao/src/main/native/linux/build.sh` — vérifier qu'il fonctionne toujours après suppression GTK
+
+Critères de réussite :
+- `cargo build` clean sur Linux
+- Sample lance sous X11 + Wayland
+- Curseurs corrects, HiDPI OK, AccessKit + Orca OK
+
+### Phase 4 — Multitouch macOS (besoin originel)
+
+`winit::event::WindowEvent::PinchGesture { delta, phase }` est désormais directement disponible. À router via :
+- `events.rs` — ajouter `EVENT_GESTURE_MAGNIFY = 22`, `GESTURE_FIXED_SCALE = 1000.0`, `GESTURE_STATE_*`
+- `event_loop.rs` — `WindowEvent::PinchGesture` et `WindowEvent::DoubleTapGesture` (smartMagnify)
+- Côté Kotlin : `TaoEventCode.GESTURE_MAGNIFY`, `EventCallback.onGestureEvent`, `TaoWindow.onGestureEvent`, `Modifier.onMagnify { ... }`
+- Sample : `Image` zoomable
+
+### Phase 5 — Validation cross-OS
+
+À faire principalement après Phase 3.4 et 4. Checklist détaillée dans `MIGRATION.md`.
+
+### Phase 6 — Renommage
+
+`decorated-window-tao` → `decorated-window-winit`. Touche le module Gradle, les noms Kotlin (`TaoApplication`, `TaoWindow`, etc.), les symboles natifs (`nucleus_tao_*` → `nucleus_winit_*`), les workflows CI. À faire en tout dernier, gros chantier mécanique.
+
+## Décisions techniques importantes
+
+### 1. Fix du SIGABRT à la fermeture (macOS)
+
+**Problème** : `winit 0.30` leak un `CFRunLoopObserver` après que `run_app` retourne. La boucle AWT toujours active fire l'observer une fois de plus, où il essaie d'`upgrade()` un `Weak<PanicInfo>` déjà droppé → panique → SIGABRT (exit 134).
+
+**Solution** dans `event_loop.rs::user_event` pour `UserEvent::Exit` :
+```rust
+#[cfg(target_os = "macos")]
+std::process::exit(0);
+#[cfg(not(target_os = "macos"))]
+event_loop.exit();
+```
+
+C'est sale mais nécessaire jusqu'à un fix upstream de winit. Justification dans le commentaire du code.
+
+### 2. NSView → NSWindow via helper ObjC
+
+`raw_window_handle 0.6` n'expose que `ns_view: NonNull<c_void>` dans `AppKitWindowHandle` — pas de `ns_window`. Le helper ObjC `nucleus_tao_ns_view_to_ns_window` dans `window_drag.m` fait `[(__bridge NSView*)view window]`. Déclaré dans `platform/macos/ffi.rs`.
+
+### 3. Renommages d'API winit vs tao
+
+| tao | winit 0.30 |
+|---|---|
+| `WindowEvent::ReceivedImeText(s)` | `WindowEvent::Ime(Ime::Commit(s))` |
+| `Event::MainEventsCleared` | méthode `about_to_wait` du handler |
+| `Event::RedrawRequested(window_id)` (top-level) | `WindowEvent::RedrawRequested` (no payload) |
+| `set_always_on_top(bool)` | `set_window_level(WindowLevel::AlwaysOnTop \| Normal)` |
+| `set_focus()` | `focus_window()` |
+| `set_inner_size(s)` | `request_inner_size(s)` (retourne `Option<PhysicalSize>`) |
+| `WindowEvent::ModifiersChanged(state)` | reçoit `Modifiers`, lecture via `.state()` |
+| `KeyboardInput.physical_key: KeyCode` | `PhysicalKey`, extraire via `PhysicalKey::Code(code)` |
+| `CursorIcon::Hand` | `CursorIcon::Pointer` (W3C) |
+| `KeyCode::Plus`, `KeyCode::NumpadStar` | n'existent pas (retirés) |
+
+### 4. `UserEvent::SetFocusable` est devenu un no-op
+
+`winit 0.30` n'expose pas `set_focusable` cross-platform. Si un besoin réel apparaît, brancher via `WindowExtMacOS::set_can_become_key_window` côté Mac et équivalents par OS.
+
+### 5. Variable d'env Linux
+
+L'ancienne `NUCLEUS_TAO_LINUX_RENDERER=x11` est traduite vers `WINIT_UNIX_BACKEND=x11` à l'init du loop pour préserver la compat ascendante.
+
+## Gotchas rencontrées pendant la migration
+
+1. **`KeyCode::Plus` mange le reste du match** : sans le `Plus` dans `winit::keyboard::KeyCode`, le pattern `Plus =>` devient un binding catch-all et toutes les arms suivantes sont unreachable. Compilation passe mais 70+ warnings. **À traiter en supprimant `Plus` du match si jamais une autre variante manque** (peu probable mais possible).
+
+2. **`raw_window_handle` doit s'importer depuis `winit::raw_window_handle`** sur macOS et Windows. La crate `raw-window-handle` directe n'est exposée que pour la cible Linux dans le Cargo.toml.
+
+3. **Linux any_thread** : winit a séparé en deux extension traits. Les deux doivent être appelées avec syntax fully-qualified pour éviter l'ambiguité :
+   ```rust
+   EventLoopBuilderExtX11::with_any_thread(&mut builder, true);
+   EventLoopBuilderExtWayland::with_any_thread(&mut builder, true);
+   ```
+
+4. **Le swizzle a11y dans `a11y.m`** cible `objc_getClass("TaoView")` ligne 1561. Avec winit la classe ObjC s'appellera autrement (probablement `WinitView`). **À traiter** : changer pour `object_getClass(view)` dynamique au moment de `nucleus_tao_a11y_attach`. Pas urgent — l'a11y n'a pas régressé visuellement encore (à confirmer avec VoiceOver).
+
+5. **AWT initialise NSApp avant nous**. C'est ce qui cause le bug fermeture (point 1 ci-dessus). Pas de solution propre côté winit pour l'instant.
+
+## Comment tester
+
+```bash
+# Build natif macOS (les deux archs)
+cd decorated-window-tao/src/main/native/macos && ./build.sh
+
+# Build natif Windows (sur Windows uniquement)
+cd decorated-window-tao\src\main\native\windows && build.bat
+
+# Cross-check Windows depuis Mac (juste cargo check, pas de link)
+cd decorated-window-tao/src/main/native
+cargo check --target x86_64-pc-windows-gnu
+
+# Lancer le sample (macOS)
+./gradlew :example:run
+# → fenêtre Compose s'ouvre, fermer doit donner exit 0 (pas 134)
+```
+
+## Comment continuer
+
+### Reprendre Phase 3.4 (Linux)
+
+1. `git checkout wip/winit-migration && git pull`
+2. Lire `decorated-window-tao/src/main/native/src/platform/linux/handles.rs` et `cursor.rs` — c'est ce qui reste à migrer
+3. Pour le verify côté Linux : se baser sur les autres Linux jobs dans `build-natives.yaml` (matrix x64+aarch64)
+4. Comme Linux runner GitHub n'a pas X11/Wayland en display mode, le sample ne se lancera pas en CI — on valide le **build** uniquement, le runtime test reste manuel
+5. Une fois Linux passe, ajouter `:decorated-window-tao:check` à `tasks.register("preMerge")` dans le top-level `build.gradle.kts`
+
+### Workflow général
+
+- Chaque phase = 1 commit + push + verifier la PR sur GitHub
+- La PR existante #223 reçoit les commits supplémentaires automatiquement (push sur la même branche)
+
+## Fichiers de référence
+
+| Fichier | Quoi |
+|---|---|
+| `decorated-window-tao/MIGRATION.md` | Plan complet en 6 phases avec checkboxes |
+| `decorated-window-tao/HANDOFF.md` | Ce fichier |
+| `decorated-window-tao/src/main/native/Cargo.toml` | État actuel des deps Rust |
+| `decorated-window-tao/src/main/native/src/event_loop.rs` | Cœur de la migration (ApplicationHandler) |
+| `decorated-window-tao/src/main/native/src/platform/macos/handles.rs` | Pattern `ns_view_pointer` à reproduire pour Linux/Windows |
+| `decorated-window-tao/src/main/native/macos/window_drag.m` | Helper ObjC `nucleus_tao_ns_view_to_ns_window` |
+| `decorated-window-tao/src/main/native/src/platform/linux/handles.rs` | À migrer Phase 3.4 |
+| `decorated-window-tao/src/main/native/src/platform/linux/cursor.rs` | À migrer Phase 3.4 |
+| `.github/workflows/build-natives.yaml` | Pattern à suivre pour ajouter Linux |
+| `CLAUDE.md` (racine) | Conventions projet (Kotlin, JNI, etc.) |
+| `~/.claude/CLAUDE.md` (global utilisateur) | Préférences perso : pas de Co-Authored-By, anglais en commentaires, code Kotlin idiomatique, ne pas sur-expliquer (senior dev) |
+
+## Note sur les commits
+
+L'utilisateur a précisé dans son CLAUDE.md global :
+- Pas de `Co-Authored-By` ni attribution AI dans les commits/PRs
+- Conventional commits avec scope (ex: `refactor(decorated-window-tao): ...`)
+- Body décrivant le pourquoi pas le quoi

--- a/decorated-window-tao/MIGRATION.md
+++ b/decorated-window-tao/MIGRATION.md
@@ -1,0 +1,324 @@
+# Migration `tao` → `winit`
+
+Plan de migration big-bang (sans dual-stack) pour le backend windowing du module `decorated-window-tao`.
+
+## Contexte
+
+Le backend actuel s'appuie sur `tao 0.35` qui :
+- N'expose pas les gestes macOS (`PinchGesture`, `RotationGesture`, etc.) — bloque la fonctionnalité multitouch.
+- Est en mode maintenance (l'écosystème Tauri est revenu sur `winit`).
+- Force une dépendance GTK sur Linux dont nous n'utilisons quasiment rien.
+- Nous a déjà imposé plusieurs contournements via code natif parallèle (a11y, traffic-lights, drag, deep links, dnd, main-thread dispatch).
+
+`winit 0.30` apporte :
+- Support natif des gestures macOS (`WindowEvent::PinchGesture`, `RotationGesture`, `DoubleTapGesture`).
+- Support direct Xlib/Wayland sur Linux **sans GTK**.
+- Maintenance active et large adoption.
+- Compatibilité `raw-window-handle 0.6` via feature `rwh_06` (alignée avec le code existant).
+
+## Stratégie
+
+- **Big-bang sur la branche `wip/winit-migration`** — pas de dual-stack `cfg`-gaté (la duplication d'`event_loop.rs` est plus coûteuse que le risque de migration unifiée).
+- **Aucun changement côté Kotlin/JNI/ObjC** pendant les phases 1-5 — la surface publique reste stable.
+- **Renommage du module en phase 6** uniquement.
+
+## Impact attendu
+
+| Composant | Effort | Risque |
+|---|---|---|
+| Event loop Rust (`event_loop.rs`) | Moyen — réécriture mécanique vers `ApplicationHandler` | Moyen |
+| macOS `NSView`/`NSWindow` handles | Faible — `raw_window_handle` | Faible |
+| **macOS a11y** (`a11y.m`, 1838 lignes) | **30 min** — un swizzle à dynamiser | **Faible** |
+| Linux GTK | **Suppression**, pas migration | Faible |
+| Linux a11y (D-Bus AT-SPI2) | Aucun changement | Trivial |
+| Windows a11y (UIA via DLL sœur) | Aucun changement | Trivial |
+| Windows `HWND` | Faible — `raw_window_handle` | Faible |
+| Gestures macOS | **Bonus gratuit** | — |
+
+---
+
+## Phase 0 — Préparation
+
+- [ ] Créer la branche `wip/winit-migration` à partir de `wip/tao-experiment`
+- [ ] Geler tout nouveau bypass tao pendant la migration
+- [ ] Vérifier que `./gradlew preMerge` est vert au point de départ
+- [ ] Lecture confirmatoire de `a11y.m` pour valider que le swizzle est la seule friction
+
+---
+
+## Phase 1 — Cargo + scaffolding
+
+**Objectif** : remplacer la dépendance, le code ne compile pas encore.
+
+- [ ] `Cargo.toml` : remplacer
+  ```toml
+  tao = "0.35"
+  ```
+  par
+  ```toml
+  winit = { version = "0.30", features = ["rwh_06"] }
+  ```
+- [ ] Retirer `gtk = "0.18"` du `Cargo.toml` (Linux)
+- [ ] Retirer `gdkx11-sys = "0.18"` du `Cargo.toml` (Linux)
+- [ ] Vérifier que `raw-window-handle = "0.6"` reste pinné explicitement
+- [ ] `cargo check` — recense toutes les erreurs (~30-50 attendues), guide la phase 2
+
+---
+
+## Phase 2 — Event loop (cœur de la migration)
+
+**Objectif** : `event_loop.rs` compile sur les 3 OS via `winit`.
+
+### 2.1 Restructuration `ApplicationHandler`
+
+- [ ] Créer un struct `NucleusApp` qui encapsule l'état (le contenu actuel du closure)
+- [ ] Implémenter `ApplicationHandler<UserEvent> for NucleusApp` :
+  - [ ] `resumed(&mut self, event_loop)` → équivalent `StartCause::Init` → dispatch `EVENT_LAUNCHED`
+  - [ ] `user_event(&mut self, event_loop, ev)` → traitement des `UserEvent::*`
+  - [ ] `window_event(&mut self, event_loop, id, ev)` → match sur `WindowEvent`
+  - [ ] `about_to_wait(&mut self, event_loop)` → dispatch `EVENT_MAIN_EVENTS_CLEARED`
+- [ ] Remplacer `EventLoop::run(closure)` par `event_loop.run_app(&mut app)`
+
+### 2.2 Mapping des événements
+
+- [ ] `WindowEvent::ReceivedImeText(s)` → `WindowEvent::Ime(Ime::Commit(s))`
+- [ ] `Event::MainEventsCleared` → `Event::AboutToWait` (devient `about_to_wait` sur le handler)
+- [ ] `Event::RedrawRequested` (top-level) → `WindowEvent::RedrawRequested` (déplacé dans `WindowEvent`)
+- [ ] `WindowEvent::ModifiersChanged(state)` : `state` devient `Modifiers`, lecture via `.state().shift_key()` etc.
+- [ ] `WindowEvent::KeyboardInput { event, .. }` : champ identique, type `KeyEvent` à vérifier
+- [ ] `WindowEvent::Focused`, `CursorMoved`, `CursorLeft`, `MouseInput`, `MouseWheel`, `Resized`, `Moved`, `ScaleFactorChanged`, `CloseRequested`, `Destroyed` : aucun changement
+- [ ] `MouseScrollDelta::LineDelta`/`PixelDelta` : aucun changement
+
+### 2.3 API Window
+
+- [ ] `WindowBuilder::new().build(&event_loop)` → `event_loop.create_window(WindowAttributes::default()...)`
+- [ ] `Window::set_always_on_top(bool)` → `Window::set_window_level(WindowLevel::AlwaysOnTop|Normal)`
+- [ ] `Window::set_focus()` → `Window::focus_window()`
+- [ ] `set_visible`, `set_title`, `request_redraw`, `set_maximized`, `set_minimized`, `set_focusable`, `set_min_inner_size`, `set_inner_size`, `set_outer_position`, `set_fullscreen`, `set_window_icon`, `scale_factor`, `inner_size`, `id` : aucun changement
+
+### 2.4 EventLoopProxy
+
+- [ ] `EventLoopProxy<UserEvent>::send_event(...)` : API identique en winit 0.30 — aucun changement
+
+### 2.5 Initialisation Linux any-thread
+
+- [ ] Remplacer `tao::platform::unix::EventLoopBuilderExtUnix::with_any_thread(true)` par :
+  ```rust
+  #[cfg(all(unix, not(target_os = "macos")))]
+  {
+      use winit::platform::wayland::EventLoopBuilderExtWayland;
+      use winit::platform::x11::EventLoopBuilderExtX11;
+      // appeler with_any_thread(true) sur les deux extensions
+  }
+  ```
+
+### 2.6 Validation phase 2
+
+- [ ] `cargo check` propre sur les 3 OS
+- [ ] `cargo build` produit les 6 binaires natifs (3 OS × 2 archs)
+
+---
+
+## Phase 3 — Plateformes spécifiques
+
+### 3.1 macOS — handles
+
+- [ ] `platform/macos/handles.rs` : remplacer `WindowExtMacOS::ns_view()` par `Window::window_handle()` + `RawWindowHandle::AppKit { ns_view }`
+- [ ] `platform/macos/ime.rs` : idem
+- [ ] `window_jni.rs` : remplacer `WindowExtMacOS::ns_window()` par accès via `RawWindowHandle::AppKit` + `[ns_view window]`
+
+### 3.2 macOS — a11y (swizzle dynamique)
+
+Le code actuel cible `objc_getClass("TaoView")` (ligne 1561 de `a11y.m`). Avec winit la classe ObjC s'appelle différemment.
+
+- [ ] Modifier `nucleus_tao_swizzle_taoview_a11y_once()` pour récupérer la classe dynamiquement à partir du `NSView*` reçu en paramètre :
+  ```objc
+  Class c = object_getClass(view);
+  ```
+- [ ] Stocker un `NSMutableSet<NSString*>` des classes déjà swizzlées (pattern déjà présent ligne 1614 pour le focus forwarder)
+- [ ] Tester avec **VoiceOver** : navigation, lecture, activation, rotors
+
+### 3.3 macOS — main thread / event loop helpers
+
+- [ ] `platform/macos/main_thread.rs` : adapter à la boucle winit (vérifier `pump_app_events` ou équivalent)
+- [ ] Les helpers ObjC (`NucleusTaoMetal.m`, `main_thread_dispatch.m`, `window_drag.m`, `apple_events.m`, `dnd.m`) consomment des `NSView*`/`NSWindow*` — **aucun changement nécessaire**
+
+### 3.4 Linux — suppression GTK
+
+- [ ] `platform/linux/handles.rs` : retirer le passage par `WindowExtUnix::gtk_window()`. Lire directement `Window::window_handle()` qui expose `RawWindowHandle::Xlib`/`Wayland`
+- [ ] `platform/linux/cursor.rs` : **supprimer** la branche GDK (`gdk_window_set_device_cursor`). Utiliser `Window::set_cursor(CursorIcon::*)` standard de winit. Vérifier que le bug "curseur reset au mouvement" de tao n'existe pas avec winit (test manuel).
+- [ ] Retirer toutes les imports `gtk::*` et `gdkx11_sys::*`
+- [ ] `platform/linux/a11y.rs` (AccessKit + AT-SPI2) : **aucun changement**
+
+### 3.5 Windows — handles
+
+- [ ] `platform/windows/handles.rs` : remplacer `WindowExtWindows::hwnd()` par `Window::window_handle()` + `RawWindowHandle::Win32 { hwnd, .. }`
+- [ ] La DLL custom de décoration consomme un `HWND` → **aucun changement**
+- [ ] `platform/windows/a11y.rs` : **aucun changement**
+
+---
+
+## Phase 4 — Multitouch macOS (besoin originel)
+
+**Objectif** : exposer `pinch` + `smartMagnify` via une API Compose.
+
+### 4.1 Côté Rust
+
+- [ ] Ajouter dans `events.rs` :
+  ```rust
+  pub(crate) const EVENT_GESTURE_MAGNIFY: jint = 22;
+  pub(crate) const GESTURE_FIXED_SCALE: f64 = 1000.0;
+  pub(crate) const GESTURE_STATE_BEGAN: jint = 0;
+  pub(crate) const GESTURE_STATE_CHANGED: jint = 1;
+  pub(crate) const GESTURE_STATE_ENDED: jint = 2;
+  pub(crate) const GESTURE_STATE_CANCELLED: jint = 3;
+  ```
+- [ ] Ajouter le helper `dispatch_gesture(handle, kind, state, scale_fixed, x_fixed, y_fixed)` dans `events.rs`
+- [ ] Router `WindowEvent::PinchGesture { delta, phase }` dans `event_loop.rs` → `dispatch_gesture(...)`
+- [ ] Router `WindowEvent::DoubleTapGesture` (smartMagnify) → `dispatch_gesture(...)` avec un `kind` distinct
+
+### 4.2 Côté Kotlin
+
+- [ ] `TaoEventCode.kt` : ajouter `GESTURE_MAGNIFY = 22` et l'objet `GestureState`
+- [ ] `NativeTaoBridge.kt` : ajouter `EventCallback.onGestureEvent(handle, kind, state, scaleFixed, xFixed, yFixed)`
+- [ ] `TaoWindow.kt` : ajouter `fun interface GestureEventListener` + `fun onGestureEvent(listener: GestureEventListener)` + `internal fun dispatchGesture(...)`
+- [ ] `TaoApplication.kt` : router `onGestureEvent` vers `window.dispatchGesture(...)`
+- [ ] Créer `Modifier.onMagnify { delta, center, state -> }` dans le module Compose côté API publique
+
+### 4.3 GraalVM
+
+- [ ] Mettre à jour `decorated-window-tao/src/main/resources/META-INF/native-image/.../reachability-metadata.json` avec les nouvelles méthodes JNI
+
+### 4.4 Sample
+
+- [ ] Ajouter une démo `Image` zoomable au pinch dans `example/`
+- [ ] Test trackpad : pinch in/out, smartMagnify (double-tap 2 doigts)
+- [ ] Vérifier que `onPointerScroll` fonctionne toujours (pan trackpad 2 doigts)
+
+---
+
+## Phase 5 — Validation cross-OS
+
+### 5.1 macOS
+
+- [ ] Sample `example` lance et affiche
+- [ ] Lifecycle : open / resize / minimize / maximize / close
+- [ ] Input : souris, clavier, scroll, IME, touches mortes
+- [ ] Décoration custom (traffic lights via `NucleusTaoMetal.m`)
+- [ ] Drag-window via barre de titre
+- [ ] Drag & drop fichiers
+- [ ] Deep links (Apple Events)
+- [ ] **AccessKit + VoiceOver** (zone à surveiller post-swizzle)
+- [ ] HiDPI : Retina + écran externe non-Retina + bascule entre écrans
+- [ ] Pinch-to-zoom fonctionnel
+- [ ] CI macOS verte (x64 + aarch64)
+
+### 5.2 Linux
+
+- [ ] Sample lance sous **X11** (Ubuntu/Fedora)
+- [ ] Sample lance sous **Wayland** (GNOME / KDE)
+- [ ] Curseurs corrects sous X11 et Wayland (text, hand, resize)
+- [ ] HiDPI 4K
+- [ ] AccessKit + Orca
+- [ ] D-Bus features (`notification-linux`, `launcher-linux`) intactes
+- [ ] Clavier + IME
+- [ ] CI Linux verte (x64 + aarch64)
+
+### 5.3 Windows
+
+- [ ] Sample lance sous Windows 10 et 11
+- [ ] Décoration custom (traffic-light style)
+- [ ] HiDPI multi-écrans (scales différents)
+- [ ] Launcher Windows (badge, jump list)
+- [ ] Notifications WinRT
+- [ ] UIA / Narrator
+- [ ] CI Windows verte (x64 + aarch64)
+
+### 5.4 Cross-OS
+
+- [ ] `./gradlew preMerge` vert
+- [ ] `./gradlew packageDistributionForCurrentOS` produit un binaire fonctionnel sur chaque OS
+- [ ] `./gradlew packageReleaseDistributionForCurrentOS` (ProGuard) OK
+- [ ] GraalVM native-image build OK (`./gradlew nativeCompile` dans `example`)
+
+---
+
+## Phase 6 — Cleanup & renaming
+
+**Objectif** : supprimer toute trace de `tao` dans les noms et la documentation.
+
+### 6.1 Module Gradle
+
+- [ ] Renommer le répertoire `decorated-window-tao` → `decorated-window-winit`
+- [ ] Mettre à jour `settings.gradle.kts` (déclaration du module)
+- [ ] Mettre à jour les `build.gradle.kts` consommateurs (samples, autres modules)
+
+### 6.2 Lib native
+
+- [ ] Décider : conserver `nucleus_tao` comme nom de lib (stabilité ABI) **ou** renommer en `nucleus_winit`
+- [ ] Si renommage : adapter `build.sh`, `build.bat`, `Cargo.toml` (`name = "nucleus_winit"`), tous les `JNIEXPORT` ObjC, `NativeLibraryLoader`
+- [ ] Adapter le chemin des artefacts dans `src/main/resources/nucleus/native/...`
+
+### 6.3 Kotlin
+
+- [ ] `TaoApplication` → `WinitApplication`
+- [ ] `TaoWindow` → `WinitWindow`
+- [ ] `TaoEventCode` → `WinitEventCode`
+- [ ] `NativeTaoBridge` → `NativeWinitBridge`
+- [ ] `TaoMainDispatcher` → `WinitMainDispatcher`
+- [ ] Adapter le package : `io.github.kdroidfilter.nucleus.window.tao` → `.winit`
+- [ ] Adapter tous les samples + modules consommateurs
+
+### 6.4 Symboles natifs
+
+- [ ] Renommer `nucleus_tao_*` → `nucleus_winit_*` dans tous les `.m`, `.c`, `.cpp`, `.rs`
+- [ ] Synchroniser les `extern "C" fn` Rust et les déclarations C
+- [ ] Mettre à jour les noms dans `reachability-metadata.json`
+
+### 6.5 CI
+
+- [ ] `build-natives.yaml` : noms d'artefacts (si renommage natif)
+- [ ] `pre-merge.yaml`, `publish-maven.yaml`, `publish-plugin.yaml`, `test-packaging.yaml`, `test-graalvm.yaml`, `release-graalvm.yaml` : tableaux EXPECTED + chemins de download
+
+### 6.6 Documentation
+
+- [ ] Mettre à jour `CLAUDE.md` (références au backend tao)
+- [ ] Mettre à jour le `README.md` du module
+- [ ] Archiver `MIGRATION.md` dans `docs/` (ou supprimer)
+- [ ] Ajouter une note de release notable (les utilisateurs doivent renommer leurs imports)
+
+---
+
+## Risques résiduels & rollback
+
+| Risque | Mitigation |
+|---|---|
+| `WindowEvent::Focused` subtilement différent (winit corrige certains bugs de focus stealing) | Test manuel sur les 3 OS |
+| `set_outer_position` muet sur Wayland (limitation Wayland, déjà le cas avec tao) | Comportement identique, aucun changement |
+| Bug surprise dans winit 0.30 sur un OS | `git revert` la branche entière, fallback sur tao via `wip/tao-experiment` |
+| Cours du `swizzle a11y` rate sur la classe winit | Test VoiceOver dès le début de phase 5.1 ; le swizzle dynamique sur `object_getClass(view)` rend le code robuste à toute renommée |
+| `pump_app_events` macOS comportement différent | Vérifier le flow main-thread dispatcher dès phase 3.3 |
+
+---
+
+## Bonus collatéraux
+
+- ✅ Pinch-to-zoom natif sans code custom
+- ✅ Suppression de la dette GTK sur Linux (-2 dépendances système)
+- ✅ `WindowEvent::Touch` moderne disponible pour usage tactile futur
+- ✅ Meilleure intégration IME sur Wayland (text-input v3)
+- ✅ Maintenance active : winit suit les évolutions OS (Apple Silicon, Wayland, Windows 11)
+- ✅ Support potentiel futur de l'intégration AccessKit native de winit (cleanup post-migration optionnel)
+
+---
+
+## Ordre d'exécution recommandé
+
+1. Phase 0 : 30 min
+2. Phase 1 + 2 : 1-2 jours (cœur de la migration)
+3. Phase 3 : 1 jour (parallélisable par OS)
+4. Phase 4 : 0.5 jour (gestures macOS)
+5. Phase 5 : 1 jour (validation manuelle sur 3 OS)
+6. Phase 6 : 0.5 jour (renaming mécanique)
+
+**Total estimé : 4-5 jours de travail**, exécutables en une seule branche, mergeable en un seul PR.

--- a/decorated-window-tao/src/main/native/Cargo.lock
+++ b/decorated-window-tao/src/main/native/Cargo.lock
@@ -3,6 +3,22 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "accesskit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,7 +32,7 @@ dependencies = [
  "accesskit_consumer",
  "atspi-common",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "zvariant",
 ]
 
@@ -45,6 +61,62 @@ dependencies = [
  "serde",
  "zbus",
 ]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.11.1",
+ "cc",
+ "jni 0.22.4",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "async-broadcast"
@@ -97,7 +169,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -128,7 +200,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -154,7 +226,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -175,29 +247,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "atk"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
-dependencies = [
- "atk-sys",
- "glib",
- "libc",
-]
-
-[[package]]
-name = "atk-sys"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
 ]
 
 [[package]]
@@ -264,15 +313,21 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block2"
-version = "0.6.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2",
 ]
@@ -297,34 +352,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cairo-rs"
-version = "0.18.5"
+name = "calloop"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags",
- "cairo-sys-rs",
- "glib",
- "libc",
- "once_cell",
- "thiserror",
+ "bitflags 2.11.1",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "cairo-sys-rs"
-version = "0.18.2"
+name = "calloop-wayland-source"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "glib-sys",
- "libc",
- "system-deps",
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -334,6 +396,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -360,6 +424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -396,11 +466,11 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.25.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -409,22 +479,13 @@ dependencies = [
 
 [[package]]
 name = "core-graphics-types"
-version = "0.2.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "libc",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -434,61 +495,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "dbus"
-version = "0.9.11"
+name = "cursor-icon"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.61.2",
+ "libloading",
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.1"
+name = "downcast-rs"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags",
- "block2",
- "libc",
- "objc2",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "dlopen2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
-dependencies = [
- "dlopen2_derive",
- "libc",
- "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "dlopen2_derive"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -567,16 +598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "field-offset"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
-dependencies = [
- "memoffset",
- "rustc_version",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,15 +635,6 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
 
 [[package]]
 name = "futures-channel"
@@ -700,88 +712,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "gdk"
-version = "0.18.2"
+name = "gethostname"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "cairo-rs",
- "gdk-pixbuf",
- "gdk-sys",
- "gio",
- "glib",
- "libc",
- "pango",
-]
-
-[[package]]
-name = "gdk-pixbuf"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
-dependencies = [
- "gdk-pixbuf-sys",
- "gio",
- "glib",
- "libc",
- "once_cell",
-]
-
-[[package]]
-name = "gdk-pixbuf-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
-dependencies = [
- "gio-sys",
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
-]
-
-[[package]]
-name = "gdk-sys"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
-dependencies = [
- "cairo-sys-rs",
- "gdk-pixbuf-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
- "libc",
- "pango-sys",
- "pkg-config",
- "system-deps",
-]
-
-[[package]]
-name = "gdkwayland-sys"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69"
-dependencies = [
- "gdk-sys",
- "glib-sys",
- "gobject-sys",
- "libc",
- "pkg-config",
- "system-deps",
-]
-
-[[package]]
-name = "gdkx11-sys"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
-dependencies = [
- "gdk-sys",
- "glib-sys",
- "libc",
- "system-deps",
- "x11",
+ "rustix 1.1.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -794,25 +731,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "gio"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "gio-sys",
- "glib",
- "libc",
- "once_cell",
- "pin-project-lite",
- "smallvec",
- "thiserror",
 ]
 
 [[package]]
@@ -834,7 +752,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -848,7 +766,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -884,58 +802,6 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "gtk"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a"
-dependencies = [
- "atk",
- "cairo-rs",
- "field-offset",
- "futures-channel",
- "gdk",
- "gdk-pixbuf",
- "gio",
- "glib",
- "gtk-sys",
- "gtk3-macros",
- "libc",
- "pango",
- "pkg-config",
-]
-
-[[package]]
-name = "gtk-sys"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
-dependencies = [
- "atk-sys",
- "cairo-sys-rs",
- "gdk-pixbuf-sys",
- "gdk-sys",
- "gio-sys",
- "glib-sys",
- "gobject-sys",
- "libc",
- "pango-sys",
- "system-deps",
-]
-
-[[package]]
-name = "gtk3-macros"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -978,109 +844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,9 +864,39 @@ dependencies = [
  "combine",
  "jni-sys 0.3.1",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1135,11 +928,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1151,34 +956,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libdbus-sys"
-version = "0.2.7"
+name = "libloading"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "pkg-config",
+ "cfg-if",
+ "windows-link",
 ]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1191,6 +1000,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -1207,14 +1025,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
  "raw-window-handle",
- "thiserror",
+ "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -1232,13 +1056,11 @@ dependencies = [
  "accesskit",
  "accesskit_unix",
  "cc",
- "gdkx11-sys",
  "glib",
- "gtk",
- "jni",
+ "jni 0.21.1",
  "once_cell",
  "raw-window-handle",
- "tao",
+ "winit",
  "x11-dl",
 ]
 
@@ -1265,101 +1087,95 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.4"
+name = "objc-sys"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
+ "objc-sys",
  "objc2-encode",
 ]
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.3.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
  "objc2",
- "objc2-core-foundation",
+ "objc2-core-data",
+ "objc2-core-image",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
 name = "objc2-cloud-kit"
-version = "0.3.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
  "objc2",
  "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-core-data"
-version = "0.3.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
+ "bitflags 2.11.1",
+ "block2",
  "objc2",
  "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
 ]
 
 [[package]]
 name = "objc2-core-image"
-version = "0.3.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
+ "block2",
  "objc2",
  "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
 name = "objc2-core-location"
-version = "0.3.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
+ "block2",
  "objc2",
+ "objc2-contacts",
  "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
-dependencies = [
- "bitflags",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
 ]
 
 [[package]]
@@ -1370,66 +1186,106 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
-version = "0.3.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch",
+ "libc",
  "objc2",
- "objc2-core-foundation",
 ]
 
 [[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
+name = "objc2-link-presentation"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "bitflags",
+ "block2",
  "objc2",
- "objc2-core-foundation",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-quartz-core"
-version = "0.3.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+ "block2",
  "objc2",
- "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-ui-kit"
-version = "0.3.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
  "objc2-core-data",
- "objc2-core-foundation",
- "objc2-core-graphics",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-core-text",
  "objc2-foundation",
+ "objc2-link-presentation",
  "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
 ]
 
 [[package]]
-name = "objc2-user-notifications"
-version = "0.3.2"
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
+ "block2",
  "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-core-location",
  "objc2-foundation",
 ]
 
@@ -1438,6 +1294,16 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "orbclient"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a570f6bca41d29acb2139229a7c873ec99bc9a313bd10804081d89bfac8ff329"
+dependencies = [
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -1450,28 +1316,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pango"
-version = "0.18.3"
+name = "owned_ttf_parser"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
- "gio",
- "glib",
- "libc",
- "once_cell",
- "pango-sys",
-]
-
-[[package]]
-name = "pango-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -1481,33 +1331,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1533,6 +1380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,27 +1395,8 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -1628,6 +1462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1650,11 +1493,20 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1668,14 +1520,27 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1695,10 +1560,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
+name = "scoped-tls"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
 
 [[package]]
 name = "semver"
@@ -1773,6 +1651,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,16 +1679,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
+name = "smithay-client-toolkit"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.11.1",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "syn"
@@ -1818,17 +1746,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,57 +1756,6 @@ dependencies = [
  "pkg-config",
  "toml",
  "version-compare",
-]
-
-[[package]]
-name = "tao"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
-dependencies = [
- "bitflags",
- "block2",
- "core-foundation",
- "core-graphics",
- "crossbeam-channel",
- "dbus",
- "dispatch2",
- "dlopen2",
- "dpi",
- "gdkwayland-sys",
- "gdkx11-sys",
- "gtk",
- "jni",
- "libc",
- "log",
- "ndk",
- "ndk-sys",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "objc2-ui-kit",
- "once_cell",
- "parking_lot",
- "percent-encoding",
- "raw-window-handle",
- "tao-macros",
- "unicode-segmentation",
- "url",
- "windows",
- "windows-core",
- "windows-version",
- "x11-dl",
-]
-
-[[package]]
-name = "tao-macros"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1907,7 +1773,7 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1917,7 +1783,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1932,13 +1807,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.3"
+name = "thiserror-impl"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
- "displaydoc",
- "zerovec",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -1969,17 +1870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime 0.6.3",
- "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2048,6 +1938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,24 +1965,6 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -2144,6 +2022,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,6 +2061,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.11.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2207,112 +2224,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link 0.1.3",
- "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-sys"
@@ -2320,7 +2235,25 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2329,7 +2262,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2338,31 +2271,29 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
-name = "windows-threading"
-version = "0.1.0"
+name = "windows-targets"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-version"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
-dependencies = [
- "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2372,10 +2303,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2384,10 +2327,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2396,16 +2357,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.11.1",
+ "block2",
+ "bytemuck",
+ "calloop",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
 
 [[package]]
 name = "winnow"
@@ -2441,22 +2472,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "x11"
-version = "2.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "x11-dl"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,27 +2483,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.8.2"
+name = "x11rb"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix 1.1.4",
+ "x11rb-protocol",
 ]
 
 [[package]]
-name = "yoke-derive"
-version = "0.8.2"
+name = "x11rb-protocol"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
+ "bitflags 2.11.1",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "zbus"
@@ -2512,7 +2550,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",
@@ -2581,60 +2619,26 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "441a0064125265655bccc3a6af6bef56814d9277ac83fce48b1cd7e160b80eac"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "zbus_names",
  "zvariant",
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.7"
+name = "zerocopy"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerofrom-derive",
+ "zerocopy-derive",
 ]
 
 [[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
+name = "zerocopy-derive"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/decorated-window-tao/src/main/native/Cargo.toml
+++ b/decorated-window-tao/src/main/native/Cargo.toml
@@ -9,27 +9,21 @@ name = "nucleus_tao"
 crate-type = ["cdylib"]
 
 [dependencies]
-tao = "0.35"
+# Migrated from tao 0.35 — see decorated-window-tao/MIGRATION.md.
+# `rwh_06` keeps the existing raw-window-handle 0.6 surface our Linux/Windows
+# JNI handles depend on.
+winit = { version = "0.30", features = ["rwh_06"] }
 jni = "0.21"
 once_cell = "1.20"
 
-# Tao 0.35 exposes window handles via raw-window-handle 0.6. We use it on
-# Linux to pull the underlying X11 (Xlib) or Wayland (wl_surface + wl_display)
-# pointers and hand them to the EGL helper so we can drive Skia's GL backend
-# without going through GTK's drawing area. `gtk` is needed to call
-# `WidgetExt::realize()` on the Tao-owned GTK window — GDK realizes lazily,
-# and we need the underlying GdkWindow to exist before WINDOW_READY fires
-# (otherwise `gdk_x11_window_get_xid` returns 0). Tao 0.35 already pulls it
-# transitively, this entry just makes the trait import compile.
+# winit 0.30 talks directly to X11 (x11-dl) and Wayland (wayland-client) without
+# going through GTK. We still pull `raw-window-handle 0.6` explicitly so the
+# Linux JNI bridge can extract Xlib / Wayland pointers for the EGL helper.
+# `glib` is kept temporarily for the legacy GDK code path in `linux/handles.rs`
+# and `linux/cursor.rs`; it is removed in Phase 3.4 of the migration along with
+# the rest of the GTK shim.
 [target.'cfg(target_os = "linux")'.dependencies]
 raw-window-handle = "0.6"
-gtk = "0.18"
-# `gdkx11-sys` is already a transitive dep of tao; declaring it explicitly
-# lets us call `gdk_x11_display_get_xdisplay` to grab GDK's actual X11 Display*
-# (rather than tao's `XOpenDisplay(NULL)` second connection). GLX requires
-# the context, drawable and display to all come from the same X connection,
-# so reusing GDK's is the only way the GLX bridge can render into the GTK XID.
-gdkx11-sys = "0.18"
 glib = "0.18"
 # AT-SPI2 accessibility provider via AccessKit. Pure-Rust D-Bus (zbus) so we
 # don't have to link libatspi / libatk / glib at runtime. We're an XWayland

--- a/decorated-window-tao/src/main/native/macos/window_drag.m
+++ b/decorated-window-tao/src/main/native/macos/window_drag.m
@@ -54,6 +54,16 @@ void nucleus_tao_install_drag_monitor(void) {
         }];
 }
 
+// Returns the NSWindow pointer owning the given NSView, or 0 if the view is
+// not yet attached. Used by the Rust side to derive an NSWindow from the
+// NSView pointer exposed via raw-window-handle (winit only ships NSView).
+long nucleus_tao_ns_view_to_ns_window(long ns_view_ptr) {
+    if (ns_view_ptr == 0) return 0;
+    NSView *view = (__bridge NSView *)(void *)(intptr_t)ns_view_ptr;
+    NSWindow *window = view.window;
+    return (long)(uintptr_t)window;
+}
+
 // Posts `performWindowDragWithEvent:` to the next main-runloop tick using the
 // most recently captured NSLeftMouseDown event. Falls back to the current
 // event if no mouseDown has been captured yet.

--- a/decorated-window-tao/src/main/native/src/cursor.rs
+++ b/decorated-window-tao/src/main/native/src/cursor.rs
@@ -1,6 +1,6 @@
 // Cross-platform cursor JNI export.
 //
-// macOS / Windows go directly through Tao's `set_cursor_icon`; Linux delegates
+// macOS / Windows go directly through winit's `set_cursor`; Linux delegates
 // to a dedicated GDK/XInput2 helper (see `platform::linux::cursor`) because
 // GTK 3's per-device cursor table beats legacy `XDefineCursor`.
 
@@ -9,7 +9,7 @@ use jni::sys::{jint, jlong};
 use jni::JNIEnv;
 
 #[cfg(not(target_os = "linux"))]
-use tao::window::CursorIcon;
+use winit::window::CursorIcon;
 
 #[cfg(not(target_os = "linux"))]
 use crate::state::WINDOWS;
@@ -21,7 +21,7 @@ use crate::state::WINDOWS;
 fn cursor_from_code(code: jint) -> CursorIcon {
     match code {
         1 => CursorIcon::Text,
-        2 => CursorIcon::Hand,
+        2 => CursorIcon::Pointer,
         3 => CursorIcon::Crosshair,
         4 => CursorIcon::Wait,
         5 => CursorIcon::Move,
@@ -55,7 +55,7 @@ pub extern "system" fn Java_io_github_kdroidfilter_nucleus_window_tao_NativeTaoB
         };
         let Some(map) = guard.as_ref() else { return };
         if let Some(window) = map.get(&(handle as u64)) {
-            window.set_cursor_icon(cursor_from_code(code));
+            window.set_cursor(cursor_from_code(code));
         }
     }
 }

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -1,14 +1,18 @@
-// Tao event loop: builds the loop, owns the platform-main-thread dance on
-// macOS, and routes Tao events back to Kotlin via `events::dispatch*`.
+// winit event loop: builds the loop, owns the platform-main-thread dance on
+// macOS, and routes winit events back to Kotlin via `events::dispatch*`.
+//
+// Migrated from tao 0.35; see decorated-window-tao/MIGRATION.md.
 
 use std::collections::HashMap;
 
 use jni::sys::jint;
 
-use tao::dpi::LogicalSize;
-use tao::event::{ElementState, Event, MouseScrollDelta, StartCause, WindowEvent};
-use tao::event_loop::{ControlFlow, EventLoopBuilder};
-use tao::window::WindowBuilder;
+use winit::application::ApplicationHandler;
+use winit::dpi::{LogicalPosition, LogicalSize};
+use winit::event::{ElementState, Ime, MouseScrollDelta, StartCause, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::keyboard::PhysicalKey;
+use winit::window::{Fullscreen, Window, WindowAttributes, WindowId, WindowLevel};
 
 use crate::events::{
     current_modifier_bits, dispatch, dispatch_key, handle_for, mouse_button_code,
@@ -25,44 +29,358 @@ use crate::state::{CURRENT_MODIFIERS, EVENT_LOOP_PROXY, WINDOWS};
 #[cfg(target_os = "linux")]
 use crate::platform::linux::cursor::reapply_stored_cursor;
 
+/// Locks `WINDOWS`, looks up the window for `handle` and runs `f` on it.
+/// Returns `None` if the map is uninitialized or the handle is unknown.
+fn with_window<R>(handle: u64, f: impl FnOnce(&Window) -> R) -> Option<R> {
+    let guard = WINDOWS.lock().ok()?;
+    let map = guard.as_ref()?;
+    let window = map.get(&handle)?;
+    Some(f(window))
+}
+
+/// `ApplicationHandler` impl that mirrors the previous tao closure-based loop.
+/// All state lives in the global `WINDOWS` / `EVENT_LOOP_PROXY` mutexes — the
+/// struct itself is a zero-sized dispatcher.
+struct NucleusApp;
+
+impl ApplicationHandler<UserEvent> for NucleusApp {
+    fn new_events(&mut self, _event_loop: &ActiveEventLoop, cause: StartCause) {
+        if matches!(cause, StartCause::Init) {
+            dispatch(0, EVENT_LAUNCHED, 0, 0);
+        }
+    }
+
+    fn resumed(&mut self, _event_loop: &ActiveEventLoop) {
+        // No-op: window creation is driven by `UserEvent::CreateWindow` from the
+        // JVM side, not by the resume lifecycle event.
+    }
+
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, user: UserEvent) {
+        match user {
+            UserEvent::Wake => {
+                // No-op: the side-effect we want is the loop returning from
+                // its `Wait` so a following `about_to_wait` tick drains
+                // `TaoMainDispatcher`.
+            }
+            UserEvent::CreateWindow {
+                handle,
+                title,
+                width,
+                height,
+                decorations,
+                resizable,
+                visible,
+            } => {
+                #[allow(unused_mut)]
+                let mut attrs = WindowAttributes::default()
+                    .with_title(&title)
+                    .with_inner_size(LogicalSize::new(width, height))
+                    .with_decorations(decorations)
+                    .with_resizable(resizable)
+                    .with_visible(visible);
+                // Linux: request an ARGB visual so the X visual matches the
+                // canonical visual that Mesa's EGL exposes through its
+                // EGLConfigs. Without this, a non-canonical 24-bit RGB visual
+                // is assigned and `eglCreateWindowSurface` fails with
+                // EGL_BAD_CONFIG. The GLX path is unaffected — its
+                // `glXChooseVisual` already requests ALPHA_SIZE=8.
+                #[cfg(target_os = "linux")]
+                {
+                    attrs = attrs.with_transparent(true);
+                }
+
+                if let Ok(window) = event_loop.create_window(attrs) {
+                    let logical_w = width as jint;
+                    let logical_h = height as jint;
+
+                    {
+                        let mut guard = WINDOWS.lock().unwrap();
+                        if let Some(map) = guard.as_mut() {
+                            map.insert(handle, window);
+                        }
+                    }
+                    dispatch(handle, EVENT_WINDOW_READY, logical_w, logical_h);
+                }
+            }
+            UserEvent::SetVisible { handle, visible } => {
+                with_window(handle, |w| w.set_visible(visible));
+            }
+            UserEvent::SetTitle { handle, title } => {
+                with_window(handle, |w| w.set_title(&title));
+            }
+            UserEvent::RequestRedraw { handle } => {
+                with_window(handle, |w| w.request_redraw());
+            }
+            UserEvent::RequestClose { handle } => {
+                let mut guard = WINDOWS.lock().unwrap();
+                if let Some(map) = guard.as_mut() {
+                    if map.remove(&handle).is_some() {
+                        #[cfg(target_os = "linux")]
+                        crate::platform::linux::cursor::forget_cursor(handle);
+                        dispatch(handle, EVENT_DESTROYED, 0, 0);
+                    }
+                }
+            }
+            UserEvent::SetMaximized { handle, maximized } => {
+                with_window(handle, |w| w.set_maximized(maximized));
+            }
+            UserEvent::SetMinimized { handle, minimized } => {
+                with_window(handle, |w| w.set_minimized(minimized));
+            }
+            UserEvent::SetAlwaysOnTop { handle, always_on_top } => {
+                let level = if always_on_top {
+                    WindowLevel::AlwaysOnTop
+                } else {
+                    WindowLevel::Normal
+                };
+                with_window(handle, |w| w.set_window_level(level));
+            }
+            UserEvent::SetFocusable { handle, focusable } => {
+                // winit 0.30 doesn't expose `set_focusable` cross-platform.
+                // The per-platform `WindowExt*::with_skip_taskbar` covers the
+                // taskbar-skip side of focusability but not keyboard focus
+                // gating. Left as a no-op until we wire platform-specific
+                // helpers if a real need surfaces.
+                let _ = (handle, focusable);
+            }
+            UserEvent::Focus { handle } => {
+                with_window(handle, |w| {
+                    // Undo a prior `set_minimized(true)` first so the window is
+                    // eligible for foreground activation.
+                    w.set_minimized(false);
+                    w.focus_window();
+                });
+            }
+            UserEvent::SetMinInnerSize { handle, width, height } => {
+                with_window(handle, |w| {
+                    if width < 0.0 || height < 0.0 {
+                        w.set_min_inner_size(None::<LogicalSize<f64>>);
+                    } else {
+                        w.set_min_inner_size(Some(LogicalSize::new(width, height)));
+                        // winit only stores the constraint; Windows enforces
+                        // it via WM_GETMINMAXINFO during user-initiated
+                        // resizes. Clamp the current inner size now so the
+                        // minimum is honored immediately.
+                        let scale = w.scale_factor();
+                        let current = w.inner_size().to_logical::<f64>(scale);
+                        let new_w = current.width.max(width);
+                        let new_h = current.height.max(height);
+                        if new_w > current.width || new_h > current.height {
+                            let _ = w.request_inner_size(LogicalSize::new(new_w, new_h));
+                        }
+                    }
+                });
+            }
+            UserEvent::SetWindowIcon { handle, width, height, pixels } => {
+                with_window(handle, |w| {
+                    if pixels.is_empty() || width == 0 || height == 0 {
+                        w.set_window_icon(None);
+                    } else if let Ok(icon) =
+                        winit::window::Icon::from_rgba(pixels.clone(), width, height)
+                    {
+                        w.set_window_icon(Some(icon));
+                    }
+                });
+            }
+            UserEvent::SetInnerSize { handle, width, height } => {
+                with_window(handle, |w| {
+                    let _ = w.request_inner_size(LogicalSize::new(width, height));
+                });
+            }
+            UserEvent::SetOuterPosition { handle, x, y } => {
+                with_window(handle, |w| w.set_outer_position(LogicalPosition::new(x, y)));
+            }
+            UserEvent::SetFullscreen { handle, fullscreen } => {
+                with_window(handle, |w| {
+                    if fullscreen {
+                        w.set_fullscreen(Some(Fullscreen::Borderless(None)));
+                    } else {
+                        w.set_fullscreen(None);
+                    }
+                });
+            }
+            UserEvent::Exit => {
+                // winit 0.30 leaks a CFRunLoopObserver after `run_app`
+                // returns; AWT's still-running NSApp drives that observer
+                // one more time, where it tries to upgrade an already-dropped
+                // `Weak<PanicInfo>` and panics — turning a clean close into
+                // SIGABRT (exit 134). The JVM has nothing left to do at this
+                // point (Kotlin has already flushed `EVENT_DESTROYED` for
+                // every window), so short-circuit straight to process exit
+                // instead of unwinding through winit's stale observer.
+                #[cfg(target_os = "macos")]
+                std::process::exit(0);
+                #[cfg(not(target_os = "macos"))]
+                event_loop.exit();
+            }
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let Some(handle) = handle_for(window_id) else { return };
+        match event {
+            WindowEvent::CloseRequested => {
+                dispatch(handle, EVENT_CLOSE_REQUESTED, 0, 0);
+            }
+            WindowEvent::Destroyed => {
+                dispatch(handle, EVENT_DESTROYED, 0, 0);
+            }
+            WindowEvent::Resized(size) => {
+                dispatch(handle, EVENT_RESIZED, size.width as jint, size.height as jint);
+            }
+            WindowEvent::Moved(pos) => {
+                dispatch(handle, EVENT_MOVED, pos.x, pos.y);
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                dispatch(
+                    handle,
+                    EVENT_SCALE_FACTOR_CHANGED,
+                    (scale_factor * 1000.0) as jint,
+                    0,
+                );
+            }
+            WindowEvent::Focused(focused) => {
+                let code = if focused { EVENT_FOCUSED } else { EVENT_UNFOCUSED };
+                dispatch(handle, code, 0, 0);
+            }
+            WindowEvent::CursorMoved { position, .. } => {
+                // Re-apply our XI2 device cursor BEFORE dispatching the event
+                // to the JVM. (Legacy GTK quirk; harmless under winit but kept
+                // to preserve the per-device cursor table behavior on Linux.)
+                #[cfg(target_os = "linux")]
+                reapply_stored_cursor(handle);
+                dispatch(
+                    handle,
+                    EVENT_CURSOR_MOVED,
+                    (position.x * CURSOR_FIXED_SCALE) as jint,
+                    (position.y * CURSOR_FIXED_SCALE) as jint,
+                );
+            }
+            WindowEvent::CursorLeft { .. } => {
+                dispatch(handle, EVENT_CURSOR_LEFT, 0, 0);
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                let code = match state {
+                    ElementState::Pressed => EVENT_MOUSE_DOWN,
+                    ElementState::Released => EVENT_MOUSE_UP,
+                };
+                dispatch(handle, code, mouse_button_code(button), 0);
+            }
+            WindowEvent::MouseWheel { delta, .. } => {
+                // Pass the raw NSEvent values straight through; the JVM side
+                // reshapes them to match AWT's `preciseWheelRotation` semantics
+                // so Compose's `MacOSCocoaConfig` can apply its standard
+                // `× 10dp × -scrollAmount` formula.
+                let (code, dx, dy) = match delta {
+                    MouseScrollDelta::LineDelta(x, y) => {
+                        (EVENT_SCROLL_LINE, x as f64, y as f64)
+                    }
+                    MouseScrollDelta::PixelDelta(p) => (EVENT_SCROLL_PIXEL, p.x, p.y),
+                };
+                dispatch(
+                    handle,
+                    code,
+                    (dx * SCROLL_FIXED_SCALE) as jint,
+                    (dy * SCROLL_FIXED_SCALE) as jint,
+                );
+            }
+            WindowEvent::Ime(Ime::Commit(text)) => {
+                let mods = current_modifier_bits();
+                for ch in text.chars() {
+                    dispatch_key(
+                        handle,
+                        EVENT_KEY_TYPED,
+                        0,
+                        keymap::LOC_STANDARD,
+                        mods,
+                        ch as jint,
+                    );
+                }
+            }
+            WindowEvent::ModifiersChanged(modifiers) => {
+                if let Ok(mut g) = CURRENT_MODIFIERS.lock() {
+                    *g = pack_modifiers(modifiers.state());
+                }
+            }
+            WindowEvent::KeyboardInput { event: ke, .. } => {
+                let type_code = match ke.state {
+                    ElementState::Pressed => EVENT_KEY_DOWN,
+                    ElementState::Released => EVENT_KEY_UP,
+                };
+                let physical = match ke.physical_key {
+                    PhysicalKey::Code(code) => code,
+                    PhysicalKey::Unidentified(_) => return,
+                };
+                let (vk, location) = keymap::map(physical);
+                // First Unicode scalar of the produced text (if any). Modifier
+                // keys, arrows, etc. emit `text = None`; printable keys emit
+                // the post-layout / post-modifiers character — exactly what
+                // AWT delivers as `KeyEvent.keyChar`.
+                let code_point = ke
+                    .text
+                    .as_ref()
+                    .and_then(|s| s.chars().next())
+                    .map(|c| c as jint)
+                    .unwrap_or(0);
+                dispatch_key(
+                    handle,
+                    type_code,
+                    vk,
+                    location,
+                    current_modifier_bits(),
+                    code_point,
+                );
+            }
+            WindowEvent::RedrawRequested => {
+                dispatch(handle, EVENT_REDRAW_REQUESTED, 0, 0);
+            }
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        dispatch(0, EVENT_MAIN_EVENTS_CLEARED, 0, 0);
+    }
+}
+
 pub(crate) fn run_event_loop_blocking() {
-    // GTK backend selection. Default: let GDK auto-pick (= native Wayland on
-    // a Wayland session, X11 elsewhere). The Wayland-native path goes through
-    // a wl_subsurface child of GTK's wl_surface — see `nativeAttachWayland`
-    // in nucleus_tao_egl.c.
-    //
-    // Escape hatch for apps that need X11-specific features Wayland doesn't
-    // expose (always-on-top, programmatic window positioning, global pointer
-    // queries, …): set `NUCLEUS_TAO_LINUX_RENDERER=x11` to force XWayland.
-    // Setting `GDK_BACKEND` directly is also honored — we don't override an
-    // explicit user choice.
+    // Honor the legacy `NUCLEUS_TAO_LINUX_RENDERER=x11` env var by translating
+    // it to winit's `WINIT_UNIX_BACKEND=x11`, so apps that already set the old
+    // variable keep working.
     #[cfg(target_os = "linux")]
     {
         let force_x11 = std::env::var_os("NUCLEUS_TAO_LINUX_RENDERER")
             .map(|v| v.to_string_lossy().eq_ignore_ascii_case("x11"))
             .unwrap_or(false);
-        if force_x11 && std::env::var_os("GDK_BACKEND").is_none() {
-            std::env::set_var("GDK_BACKEND", "x11");
+        if force_x11 && std::env::var_os("WINIT_UNIX_BACKEND").is_none() {
+            std::env::set_var("WINIT_UNIX_BACKEND", "x11");
         }
     }
 
-    let mut builder = EventLoopBuilder::<UserEvent>::with_user_event();
-    // GTK enforces that gtk_main_init be called from the OS process main
-    // thread (= tid == pid). On a regular JVM the Java "main" thread is *not*
-    // process thread 0 — javaw / java spawn a worker for it — so Tao's stock
-    // assertion would panic at startup. `with_any_thread(true)` opts into the
-    // documented escape hatch (`EventLoopBuilderExtUnix`), letting us drive
-    // the GTK loop from whichever thread the JVM hands us. The caveat noted
-    // in the Tao docs (windows die with the thread) doesn't bite us: the
-    // event-loop thread is the process's main Java thread, which lives until
-    // the JVM exits.
+    let mut builder = EventLoop::<UserEvent>::with_user_event();
+    // Allow the event loop to run on a non-main OS thread on Linux. The JVM
+    // typically hands us a worker thread, not process tid 0, and winit's
+    // default assertion would panic at startup. The Wayland and X11 backends
+    // each carry their own escape-hatch trait — we set the flag on both so
+    // whichever backend winit picks at init time is happy.
     #[cfg(target_os = "linux")]
     {
-        use tao::platform::unix::EventLoopBuilderExtUnix;
-        builder.with_any_thread(true);
+        use winit::platform::wayland::EventLoopBuilderExtWayland;
+        use winit::platform::x11::EventLoopBuilderExtX11;
+        EventLoopBuilderExtX11::with_any_thread(&mut builder, true);
+        EventLoopBuilderExtWayland::with_any_thread(&mut builder, true);
     }
-    let event_loop = builder.build();
+    let event_loop = builder.build().expect("failed to build winit event loop");
     let _ = EVENT_LOOP_PROXY.set(event_loop.create_proxy());
+
+    // winit 0.30 defaults to `ControlFlow::Wait`, but we set it explicitly so
+    // the intent is visible to readers (and survives any future default flip).
+    event_loop.set_control_flow(ControlFlow::Wait);
 
     // Install the Cmd-Q interceptor once we're on the main thread (NSEvent
     // local monitors must be added there). Press-and-hold accent picker and
@@ -74,355 +392,15 @@ pub(crate) fn run_event_loop_blocking() {
         crate::platform::macos::ffi::nucleus_tao_install_drag_monitor();
     }
 
-    event_loop.run(move |event, target, control_flow| {
-        *control_flow = ControlFlow::Wait;
-
-        match event {
-            Event::NewEvents(StartCause::Init) => {
-                dispatch(0, EVENT_LAUNCHED, 0, 0);
-            }
-            Event::UserEvent(user) => match user {
-                UserEvent::Wake => {
-                    // No-op: the side-effect we want is the loop returning from
-                    // its `Wait` to dispatch this event, which guarantees a
-                    // following `MainEventsCleared` tick that drains
-                    // `TaoMainDispatcher`.
-                }
-                UserEvent::CreateWindow {
-                    handle,
-                    title,
-                    width,
-                    height,
-                    decorations,
-                    resizable,
-                    visible,
-                } => {
-                    #[allow(unused_mut)]
-                    let mut builder = WindowBuilder::new()
-                        .with_title(&title)
-                        .with_inner_size(LogicalSize::new(width, height))
-                        .with_decorations(decorations)
-                        .with_resizable(resizable)
-                        .with_visible(visible);
-                    // Linux: request an ARGB visual so the GTK window's X
-                    // visual matches the canonical visual that Mesa's EGL
-                    // exposes through its EGLConfigs. Without this, GDK
-                    // assigns a non-canonical 24-bit RGB visual and
-                    // `eglCreateWindowSurface` fails with EGL_BAD_CONFIG
-                    // because no EGLConfig advertises that visual ID.
-                    // The GLX path is unaffected — its `glXChooseVisual`
-                    // already requests ALPHA_SIZE=8, and ARGB GTK lets the
-                    // helper render directly into the parent without the
-                    // child-window fallback.
-                    #[cfg(target_os = "linux")]
-                    {
-                        builder = builder.with_transparent(true);
-                    }
-                    let window = builder.build(target);
-                    if let Ok(window) = window {
-                        let logical_w = width as jint;
-                        let logical_h = height as jint;
-
-                        // GTK realizes its widgets lazily, so the underlying
-                        // `GdkWindow` (= source of the X11 XID / Wayland
-                        // wl_surface that the EGL helper needs) doesn't
-                        // exist yet right after `build()`. Force realization
-                        // here so `nativeLinuxHandles` returns a valid handle
-                        // synchronously when the JVM-side WINDOW_READY
-                        // callback runs. macOS / Windows do this implicitly.
-                        #[cfg(target_os = "linux")]
-                        {
-                            use gtk::prelude::WidgetExt;
-                            use tao::platform::unix::WindowExtUnix;
-                            window.gtk_window().realize();
-                        }
-
-                        {
-                            let mut guard = WINDOWS.lock().unwrap();
-                            if let Some(map) = guard.as_mut() {
-                                map.insert(handle, window);
-                            }
-                        }
-                        dispatch(handle, EVENT_WINDOW_READY, logical_w, logical_h);
-                    }
-                }
-                UserEvent::SetVisible { handle, visible } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.set_visible(visible);
-                        }
-                    }
-                }
-                UserEvent::SetTitle { handle, title } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.set_title(&title);
-                        }
-                    }
-                }
-                UserEvent::RequestRedraw { handle } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.request_redraw();
-                        }
-                    }
-                }
-                UserEvent::RequestClose { handle } => {
-                    let mut guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_mut() {
-                        if map.remove(&handle).is_some() {
-                            #[cfg(target_os = "linux")]
-                            crate::platform::linux::cursor::forget_cursor(handle);
-                            dispatch(handle, EVENT_DESTROYED, 0, 0);
-                        }
-                    }
-                }
-                UserEvent::SetMaximized { handle, maximized } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.set_maximized(maximized);
-                        }
-                    }
-                }
-                UserEvent::SetMinimized { handle, minimized } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.set_minimized(minimized);
-                        }
-                    }
-                }
-                UserEvent::SetAlwaysOnTop { handle, always_on_top } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.set_always_on_top(always_on_top);
-                        }
-                    }
-                }
-                UserEvent::SetFocusable { handle, focusable } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.set_focusable(focusable);
-                        }
-                    }
-                }
-                UserEvent::Focus { handle } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            // Undo a prior `set_minimized(true)` first so the
-                            // window is eligible for foreground activation.
-                            w.set_minimized(false);
-                            w.set_focus();
-                        }
-                    }
-                }
-                UserEvent::SetMinInnerSize { handle, width, height } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            if width < 0.0 || height < 0.0 {
-                                w.set_min_inner_size::<LogicalSize<f64>>(None);
-                            } else {
-                                w.set_min_inner_size(Some(LogicalSize::new(width, height)));
-                                // Tao only stores the constraint; Windows enforces it via
-                                // WM_GETMINMAXINFO during user-initiated resizes. Clamp the
-                                // current inner size now so the minimum is honored immediately.
-                                let scale = w.scale_factor();
-                                let current = w.inner_size().to_logical::<f64>(scale);
-                                let new_w = current.width.max(width);
-                                let new_h = current.height.max(height);
-                                if new_w > current.width || new_h > current.height {
-                                    w.set_inner_size(LogicalSize::new(new_w, new_h));
-                                }
-                            }
-                        }
-                    }
-                }
-                UserEvent::SetWindowIcon { handle, width, height, pixels } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            if pixels.is_empty() || width == 0 || height == 0 {
-                                w.set_window_icon(None);
-                            } else if let Ok(icon) =
-                                tao::window::Icon::from_rgba(pixels, width, height)
-                            {
-                                w.set_window_icon(Some(icon));
-                            }
-                        }
-                    }
-                }
-                UserEvent::SetInnerSize { handle, width, height } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.set_inner_size(LogicalSize::new(width, height));
-                        }
-                    }
-                }
-                UserEvent::SetOuterPosition { handle, x, y } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.set_outer_position(tao::dpi::LogicalPosition::new(x, y));
-                        }
-                    }
-                }
-                UserEvent::SetFullscreen { handle, fullscreen } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            if fullscreen {
-                                w.set_fullscreen(Some(tao::window::Fullscreen::Borderless(None)));
-                            } else {
-                                w.set_fullscreen(None);
-                            }
-                        }
-                    }
-                }
-                UserEvent::Exit => {
-                    *control_flow = ControlFlow::Exit;
-                }
-            },
-            Event::WindowEvent { window_id, event, .. } => {
-                let Some(handle) = handle_for(window_id) else { return };
-                match event {
-                    WindowEvent::CloseRequested => {
-                        dispatch(handle, EVENT_CLOSE_REQUESTED, 0, 0);
-                    }
-                    WindowEvent::Destroyed => {
-                        dispatch(handle, EVENT_DESTROYED, 0, 0);
-                    }
-                    WindowEvent::Resized(size) => {
-                        dispatch(handle, EVENT_RESIZED, size.width as jint, size.height as jint);
-                    }
-                    WindowEvent::Moved(pos) => {
-                        dispatch(handle, EVENT_MOVED, pos.x, pos.y);
-                    }
-                    WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
-                        dispatch(handle, EVENT_SCALE_FACTOR_CHANGED, (scale_factor * 1000.0) as jint, 0);
-                    }
-                    WindowEvent::Focused(focused) => {
-                        let code = if focused { EVENT_FOCUSED } else { EVENT_UNFOCUSED };
-                        dispatch(handle, code, 0, 0);
-                    }
-                    WindowEvent::CursorMoved { position, .. } => {
-                        // Re-apply our XI2 device cursor BEFORE dispatching the
-                        // event to the JVM. tao's GTK signal handler ran first
-                        // and reset `gdk_window_set_cursor("default")` on the
-                        // parent for resize-edge detection — without this
-                        // re-apply our hover icon would only flash for a
-                        // single pixel of motion before being overwritten.
-                        #[cfg(target_os = "linux")]
-                        reapply_stored_cursor(handle);
-                        dispatch(
-                            handle,
-                            EVENT_CURSOR_MOVED,
-                            (position.x * CURSOR_FIXED_SCALE) as jint,
-                            (position.y * CURSOR_FIXED_SCALE) as jint,
-                        );
-                    }
-                    WindowEvent::CursorLeft { .. } => {
-                        dispatch(handle, EVENT_CURSOR_LEFT, 0, 0);
-                    }
-                    WindowEvent::MouseInput { state, button, .. } => {
-                        let code = match state {
-                            ElementState::Pressed => EVENT_MOUSE_DOWN,
-                            ElementState::Released => EVENT_MOUSE_UP,
-                            _ => return,
-                        };
-                        dispatch(handle, code, mouse_button_code(button), 0);
-                    }
-                    WindowEvent::MouseWheel { delta, .. } => {
-                        // Pass the raw NSEvent values straight through; the JVM
-                        // side reshapes them to match AWT's `preciseWheelRotation`
-                        // semantics so Compose's `MacOSCocoaConfig` can apply its
-                        // standard `× 10dp × -scrollAmount` formula.
-                        let (code, dx, dy) = match delta {
-                            MouseScrollDelta::LineDelta(x, y) => {
-                                (EVENT_SCROLL_LINE, x as f64, y as f64)
-                            }
-                            MouseScrollDelta::PixelDelta(p) => {
-                                (EVENT_SCROLL_PIXEL, p.x, p.y)
-                            }
-                            _ => return,
-                        };
-                        dispatch(
-                            handle,
-                            code,
-                            (dx * SCROLL_FIXED_SCALE) as jint,
-                            (dy * SCROLL_FIXED_SCALE) as jint,
-                        );
-                    }
-                    WindowEvent::ReceivedImeText(text) => {
-                        let mods = current_modifier_bits();
-                        for ch in text.chars() {
-                            dispatch_key(
-                                handle,
-                                EVENT_KEY_TYPED,
-                                0,
-                                keymap::LOC_STANDARD,
-                                mods,
-                                ch as jint,
-                            );
-                        }
-                    }
-                    WindowEvent::ModifiersChanged(state) => {
-                        if let Ok(mut g) = CURRENT_MODIFIERS.lock() {
-                            *g = pack_modifiers(state);
-                        }
-                    }
-                    WindowEvent::KeyboardInput { event: ke, .. } => {
-                        let type_code = match ke.state {
-                            ElementState::Pressed => EVENT_KEY_DOWN,
-                            ElementState::Released => EVENT_KEY_UP,
-                            _ => return,
-                        };
-                        let (vk, location) = keymap::map(ke.physical_key);
-                        // First Unicode scalar of the produced text (if any). Modifier
-                        // keys, arrows, etc. emit `text = None`; printable keys emit
-                        // the post-layout / post-modifiers character — exactly what
-                        // AWT delivers as `KeyEvent.keyChar`.
-                        let code_point = ke
-                            .text
-                            .and_then(|s| s.chars().next())
-                            .map(|c| c as jint)
-                            .unwrap_or(0);
-                        dispatch_key(
-                            handle,
-                            type_code,
-                            vk,
-                            location,
-                            current_modifier_bits(),
-                            code_point,
-                        );
-                    }
-                    _ => {}
-                }
-            }
-            Event::RedrawRequested(window_id) => {
-                if let Some(handle) = handle_for(window_id) {
-                    dispatch(handle, EVENT_REDRAW_REQUESTED, 0, 0);
-                }
-            }
-            Event::MainEventsCleared => {
-                dispatch(0, EVENT_MAIN_EVENTS_CLEARED, 0, 0);
-            }
-            _ => {}
-        }
-    });
+    let mut app = NucleusApp;
+    if let Err(err) = event_loop.run_app(&mut app) {
+        eprintln!("nucleus_tao: event loop terminated with error: {err}");
+    }
 }
 
 /// Ensure the WINDOWS map exists. Called from the JNI entry point before the
 /// loop starts so JNI calls posting `UserEvent`s have a place to look up
-/// windows from the Tao thread.
+/// windows from the event-loop thread.
 pub(crate) fn init_windows_map() {
     let mut guard = WINDOWS.lock().unwrap();
     if guard.is_none() {

--- a/decorated-window-tao/src/main/native/src/events.rs
+++ b/decorated-window-tao/src/main/native/src/events.rs
@@ -4,9 +4,9 @@
 use jni::objects::JValue;
 use jni::sys::{jint, jlong};
 
-use tao::event::MouseButton;
-use tao::keyboard::ModifiersState;
-use tao::window::WindowId;
+use winit::event::MouseButton;
+use winit::keyboard::ModifiersState;
+use winit::window::WindowId;
 
 use crate::state::{CURRENT_MODIFIERS, EVENT_CALLBACK, JAVA_VM, WINDOWS};
 

--- a/decorated-window-tao/src/main/native/src/keymap.rs
+++ b/decorated-window-tao/src/main/native/src/keymap.rs
@@ -5,7 +5,7 @@
 // build a `Key(nativeKeyCode, nativeKeyLocation)` that matches Compose Desktop
 // exactly.
 
-use tao::keyboard::KeyCode;
+use winit::keyboard::KeyCode;
 
 // AWT KEY_LOCATION_*
 pub const LOC_STANDARD: i32 = 1;
@@ -85,7 +85,6 @@ pub fn map(code: KeyCode) -> (i32, i32) {
         Period => (46, LOC_STANDARD),         // VK_PERIOD
         Slash => (47, LOC_STANDARD),          // VK_SLASH
         IntlBackslash => (92, LOC_STANDARD),
-        Plus => (521, LOC_STANDARD),          // VK_PLUS
 
         // Whitespace / editing
         Enter => (10, LOC_STANDARD),
@@ -154,7 +153,7 @@ pub fn map(code: KeyCode) -> (i32, i32) {
         Numpad7 => (103, LOC_NUMPAD),
         Numpad8 => (104, LOC_NUMPAD),
         Numpad9 => (105, LOC_NUMPAD),
-        NumpadMultiply | NumpadStar => (106, LOC_NUMPAD), // VK_MULTIPLY
+        NumpadMultiply => (106, LOC_NUMPAD), // VK_MULTIPLY
         NumpadAdd => (107, LOC_NUMPAD),                   // VK_ADD
         NumpadComma => (108, LOC_NUMPAD),                 // VK_SEPARATOR
         NumpadSubtract => (109, LOC_NUMPAD),              // VK_SUBTRACT

--- a/decorated-window-tao/src/main/native/src/platform/macos/ffi.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/ffi.rs
@@ -38,4 +38,5 @@ extern "C" {
     pub(crate) fn nucleus_tao_a11y_note_pushed();
     pub(crate) fn nucleus_tao_install_drag_monitor();
     pub(crate) fn nucleus_tao_start_window_drag(ns_window_ptr: i64);
+    pub(crate) fn nucleus_tao_ns_view_to_ns_window(ns_view_ptr: i64) -> i64;
 }

--- a/decorated-window-tao/src/main/native/src/platform/macos/handles.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/handles.rs
@@ -1,15 +1,29 @@
 // NSView pointer JNI export. The JVM uses this to attach a CAMetalLayer.
+//
+// winit ships only the NSView pointer through `raw-window-handle 0.6`; the
+// NSWindow is derived ObjC-side via `[view window]` when needed.
 
 use jni::objects::JClass;
 use jni::sys::jlong;
 use jni::JNIEnv;
 
-use tao::platform::macos::WindowExtMacOS;
+use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
+use winit::window::Window;
 
 use crate::state::WINDOWS;
 
+/// Returns the underlying `NSView` pointer (cast to `i64`) for use by ObjC
+/// helpers. Returns `0` if the handle cannot be resolved.
+pub(crate) fn ns_view_pointer(window: &Window) -> i64 {
+    let Ok(handle) = window.window_handle() else { return 0 };
+    match handle.as_raw() {
+        RawWindowHandle::AppKit(h) => h.ns_view.as_ptr() as i64,
+        _ => 0,
+    }
+}
+
 /// Returns the underlying NSView pointer so the JVM can attach a CAMetalLayer.
-/// Must be called on the macOS main thread (i.e. from a Tao event handler).
+/// Must be called on the macOS main thread (i.e. from a winit event handler).
 #[no_mangle]
 pub extern "system" fn Java_io_github_kdroidfilter_nucleus_window_tao_NativeTaoBridge_nativeNsViewHandle(
     _env: JNIEnv,
@@ -22,5 +36,5 @@ pub extern "system" fn Java_io_github_kdroidfilter_nucleus_window_tao_NativeTaoB
     };
     let Some(map) = guard.as_ref() else { return 0 };
     let Some(window) = map.get(&(handle as u64)) else { return 0 };
-    window.ns_view() as jlong
+    ns_view_pointer(window) as jlong
 }

--- a/decorated-window-tao/src/main/native/src/platform/macos/ime.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/ime.rs
@@ -5,11 +5,10 @@ use jni::objects::JClass;
 use jni::sys::{jint, jlong};
 use jni::JNIEnv;
 
-use tao::platform::macos::WindowExtMacOS;
-
 use crate::platform::macos::ffi::{
     nucleus_tao_activate_input_context, nucleus_tao_set_ime_local_rect,
 };
+use crate::platform::macos::handles::ns_view_pointer;
 use crate::state::WINDOWS;
 
 #[no_mangle]
@@ -24,7 +23,7 @@ pub extern "system" fn Java_io_github_kdroidfilter_nucleus_window_tao_NativeTaoB
     };
     let Some(map) = guard.as_ref() else { return };
     if let Some(window) = map.get(&(handle as u64)) {
-        let ns_view = window.ns_view() as i64;
+        let ns_view = ns_view_pointer(window);
         unsafe { nucleus_tao_activate_input_context(ns_view) };
     }
 }
@@ -59,8 +58,7 @@ pub extern "system" fn Java_io_github_kdroidfilter_nucleus_window_tao_NativeTaoB
         let ly = y_px as f64 / scale;
         let lw = (w_px as f64 / scale).max(1.0);
         let lh = (h_px as f64 / scale).max(1.0);
-        unsafe {
-            nucleus_tao_set_ime_local_rect(window.ns_view() as i64, lx, ly, lw, lh)
-        };
+        let ns_view = ns_view_pointer(window);
+        unsafe { nucleus_tao_set_ime_local_rect(ns_view, lx, ly, lw, lh) };
     }
 }

--- a/decorated-window-tao/src/main/native/src/platform/macos/text_overlay.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/text_overlay.rs
@@ -7,11 +7,10 @@ use jni::objects::JClass;
 use jni::sys::{jboolean, jlong, JNI_FALSE};
 use jni::JNIEnv;
 
-use tao::platform::macos::WindowExtMacOS;
-
 use crate::platform::macos::ffi::{
     nucleus_tao_attach_text_overlay, nucleus_tao_focus_text_overlay,
 };
+use crate::platform::macos::handles::ns_view_pointer;
 use crate::state::WINDOWS;
 
 #[no_mangle]
@@ -26,7 +25,7 @@ pub extern "system" fn Java_io_github_kdroidfilter_nucleus_window_tao_NativeTaoB
     };
     let Some(map) = guard.as_ref() else { return };
     if let Some(window) = map.get(&(handle as u64)) {
-        let ns_view = window.ns_view() as i64;
+        let ns_view = ns_view_pointer(window);
         unsafe { nucleus_tao_attach_text_overlay(ns_view) };
     }
 }

--- a/decorated-window-tao/src/main/native/src/platform/windows/handles.rs
+++ b/decorated-window-tao/src/main/native/src/platform/windows/handles.rs
@@ -1,14 +1,29 @@
 // HWND handle JNI export. The JVM-side WGL helper consumes this to attach a
 // rendering context, and the custom decoration helper installs its WndProc on
 // the same HWND.
+//
+// winit exposes the HWND through `raw-window-handle 0.6`'s
+// `RawWindowHandle::Win32`; we re-export it as a plain `jlong` so the JVM
+// side keeps its existing pointer-to-int contract.
 
 use jni::objects::JClass;
 use jni::sys::jlong;
 use jni::JNIEnv;
 
-use tao::platform::windows::WindowExtWindows;
+use winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
+use winit::window::Window;
 
 use crate::state::WINDOWS;
+
+/// Returns the underlying `HWND` (cast to `i64`) for the given winit window,
+/// or `0` if the handle cannot be resolved.
+pub(crate) fn hwnd_pointer(window: &Window) -> i64 {
+    let Ok(handle) = window.window_handle() else { return 0 };
+    match handle.as_raw() {
+        RawWindowHandle::Win32(h) => h.hwnd.get() as i64,
+        _ => 0,
+    }
+}
 
 /// Returns the underlying HWND so the JVM can attach a WGL context and apply
 /// custom decoration via the `nucleus_tao_windows_deco` helper.
@@ -24,5 +39,5 @@ pub extern "system" fn Java_io_github_kdroidfilter_nucleus_window_tao_NativeTaoB
     };
     let Some(map) = guard.as_ref() else { return 0 };
     let Some(window) = map.get(&(handle as u64)) else { return 0 };
-    window.hwnd() as isize as jlong
+    hwnd_pointer(window) as jlong
 }

--- a/decorated-window-tao/src/main/native/src/state.rs
+++ b/decorated-window-tao/src/main/native/src/state.rs
@@ -10,8 +10,8 @@ use jni::objects::GlobalRef;
 use jni::JavaVM;
 use once_cell::sync::OnceCell;
 
-use tao::event_loop::EventLoopProxy;
-use tao::window::Window;
+use winit::event_loop::EventLoopProxy;
+use winit::window::Window;
 
 use crate::events::UserEvent;
 

--- a/decorated-window-tao/src/main/native/src/window_jni.rs
+++ b/decorated-window-tao/src/main/native/src/window_jni.rs
@@ -204,15 +204,19 @@ pub extern "system" fn Java_io_github_kdroidfilter_nucleus_window_tao_NativeTaoB
 ) {
     #[cfg(target_os = "macos")]
     {
-        use tao::platform::macos::WindowExtMacOS;
         let guard = match WINDOWS.lock() {
             Ok(g) => g,
             Err(_) => return,
         };
         let Some(map) = guard.as_ref() else { return };
         if let Some(window) = map.get(&(handle as u64)) {
-            let ns_window = window.ns_window() as i64;
-            unsafe { crate::platform::macos::ffi::nucleus_tao_start_window_drag(ns_window) };
+            let ns_view = crate::platform::macos::handles::ns_view_pointer(window);
+            let ns_window = unsafe {
+                crate::platform::macos::ffi::nucleus_tao_ns_view_to_ns_window(ns_view)
+            };
+            if ns_window != 0 {
+                unsafe { crate::platform::macos::ffi::nucleus_tao_start_window_drag(ns_window) };
+            }
         }
         return;
     }


### PR DESCRIPTION
## Summary

Replaces `tao 0.35` with `winit 0.30` (rwh_06 feature) in the `decorated-window-tao` Rust backend. Linux is **not** migrated yet — it stays on tao via cfg-gated code, see `decorated-window-tao/MIGRATION.md` Phase 3.4.

Motivation: tao is in maintenance mode and lacks native macOS gesture events (`PinchGesture`, `RotationGesture`, `DoubleTapGesture`) — winit provides these out of the box, unblocking the multitouch / pinch-to-zoom feature originally requested.

## What changed

**Rust crate** (`decorated-window-tao/src/main/native/src/`)
- `event_loop.rs` rewritten around winit 0.30's `ApplicationHandler<UserEvent>` trait
- All `tao::*` imports replaced with `winit::*` equivalents on macOS + Windows
- `WindowEvent::ReceivedImeText` → `Ime::Commit`, `MainEventsCleared` → `about_to_wait`, top-level `RedrawRequested` → `WindowEvent::RedrawRequested`
- `set_always_on_top(bool)` → `set_window_level(WindowLevel)`, `set_focus()` → `focus_window()`, `set_inner_size(...)` → `request_inner_size(...)`
- `KeyboardInput.physical_key` becomes `PhysicalKey::Code(KeyCode)` — extraction added in the match arm
- macOS: `WindowExtMacOS::ns_view()` replaced with `raw_window_handle::AppKit`. New ObjC helper `nucleus_tao_ns_view_to_ns_window` bridges the NSView → NSWindow lookup that `window_drag.m` still expects
- Windows: `WindowExtWindows::hwnd()` replaced with `RawWindowHandle::Win32`
- `gtk` and `gdkx11-sys` removed from `Cargo.toml`; `glib` retained temporarily for the legacy GDK code path in `linux/{handles,cursor}.rs` until Phase 3.4

**`UserEvent::Exit` workaround** — winit 0.30 leaks a `CFRunLoopObserver` after `run_app` returns; AWT's still-running NSApp drives that observer one more time, where it tries to upgrade an already-dropped `Weak<PanicInfo>` and aborts with SIGABRT (exit 134). Verified locally: clean close, exit 0. The macOS branch of the Exit handler short-circuits with `std::process::exit(0)`; Linux/Windows keep `event_loop.exit()`.

**CI** — adds `decorated-window-tao` macOS + Windows builds to `build-natives.yaml`, downloads + verifies the artifacts in `pre-merge.yaml`. Linux build is intentionally skipped until Phase 3.4.

**Migration plan** — full big-bang plan checked in at `decorated-window-tao/MIGRATION.md` (6 phases, ~4-5 days).

## Test plan

- [x] `cargo build --release --target {aarch64,x86_64}-apple-darwin` clean
- [x] `cargo check --target x86_64-pc-windows-gnu` clean
- [x] `./build.sh` produces all three macOS dylibs locally
- [x] `./gradlew :example:run` launches, renders Compose UI, closes cleanly (exit 0 — no SIGABRT regression)
- [ ] CI — `pre-merge` passes (will be verified by this PR)
- [ ] Manual VoiceOver smoke test on macOS (a11y zone — handled by the swizzle which already uses `object_getClass(view)`-style dynamic resolution where it counts)
- [ ] Manual smoke test on Windows (decoration + UIA / Narrator) — pending CI machine
- [ ] Linux migration — follow-up PR (Phase 3.4)

## Out of scope

- Linux migration (Phase 3.4) — separate PR
- Pinch-to-zoom feature (Phase 4) — separate PR built on top of this
- Module renaming `decorated-window-tao` → `decorated-window-winit` (Phase 6) — separate PR at the end