### PR TITLE
fix(plugin-windows): wire perUserInstall to MSI perMachine

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -285,6 +285,7 @@ internal class ElectronBuilderConfigGenerator {
             TargetFormat.Msi -> {
                 yaml.appendLine("msi:")
                 appendIfNotNull(yaml, "  upgradeCode", distributions.windows.upgradeUuid)
+                yaml.appendLine("  perMachine: ${!distributions.windows.perUserInstall}")
             }
             TargetFormat.AppX -> generateAppXConfig(yaml, distributions.windows.appx)
             TargetFormat.Portable -> yaml.appendLine("portable: {}")


### PR DESCRIPTION
## Summary
- Map `windows.perUserInstall` (DSL) to electron-builder's `msi.perMachine` (inverted) in `ElectronBuilderConfigGenerator`. The flag was declared but never emitted in the generated `electron-builder.yml`, so MSI installers always used electron-builder's default `perMachine=false` (`ALLUSERS=2`) regardless of the DSL value.
- One-line change in `ElectronBuilderConfigGenerator.kt` under the `TargetFormat.Msi` branch.

## Behavior

| `perUserInstall` | `msi.perMachine` | `ALLUSERS` | Install path |
|---|---|---|---|
| `false` (default) | `true` | `1` | `C:\Program Files\<app>` |
| `true` | `false` | `2` | `%LOCALAPPDATA%\Programs\<app>` |

Mapping confirmed against electron-builder upstream (`CommonWindowsInstallerConfiguration.ts:12`, `templates/msi/template.xml:39-44`).

## Test plan
- [x] `:example:packageMsi` builds successfully.
- [x] `perUserInstall = false` (default): MSI inspected via `WindowsInstaller.Installer` COM → `ALLUSERS=1`. Installed → app lands in `C:\Program Files\NucleusDemo`.
- [x] `perUserInstall = true`: MSI rebuilt and inspected → `ALLUSERS=2`, `MSIINSTALLPERUSER=1`. Installed → app lands in `C:\Users\<user>\AppData\Local\Programs\NucleusDemo`.
- [x] `UpgradeCode` correctly carried through from `windows.upgradeUuid` in both runs.

Closes #222