### PR TITLE
feat(plugin-mac): add notarytool keychain-profile auth mode

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -122,7 +122,9 @@ macOS {
 
 ### Notarization
 
-Apple notarization is required for distributing outside the Mac App Store on macOS 10.15+:
+Apple notarization is required for distributing outside the Mac App Store on macOS 10.15+. Two authentication modes are supported (mutually exclusive — App Store Connect API key support is planned):
+
+#### Mode 1 — Apple ID + app-specific password
 
 ```kotlin
 macOS {
@@ -134,13 +136,43 @@ macOS {
 }
 ```
 
-> **Tip:** Use `xcrun notarytool store-credentials` to save credentials in the keychain:
-> ```bash
-> xcrun notarytool store-credentials "AC_PASSWORD" \
->   --apple-id "dev@example.com" \
->   --team-id "TEAMID" \
->   --password "app-specific-password"
-> ```
+Equivalent Gradle properties:
+
+| Gradle property | Description |
+|-----------------|-------------|
+| `compose.desktop.mac.notarization.appleID` | Apple ID email |
+| `compose.desktop.mac.notarization.password` | App-specific password (or `@keychain:` reference) |
+| `compose.desktop.mac.notarization.teamID` | Apple Team ID |
+
+#### Mode 2 — `notarytool` keychain profile
+
+Store credentials once with `xcrun notarytool store-credentials`, then reference the profile by name:
+
+```bash
+xcrun notarytool store-credentials "AC_PASSWORD" \
+  --apple-id "dev@example.com" \
+  --team-id "TEAMID" \
+  --password "app-specific-password"
+```
+
+```kotlin
+macOS {
+    notarization {
+        keychainProfile.set("AC_PASSWORD")
+        // Optional — defaults to the user's login keychain:
+        // keychainPath.set("/Users/me/Library/Keychains/login.keychain-db")
+    }
+}
+```
+
+Equivalent Gradle properties:
+
+| Gradle property | Description |
+|-----------------|-------------|
+| `compose.desktop.mac.notarization.keychainProfile` | Profile name created via `store-credentials` |
+| `compose.desktop.mac.notarization.keychainPath` | Optional path to the keychain holding the profile |
+
+> Configuring both modes in the same build is rejected at validation time. Pick one.
 
 ### CI/CD: macOS Signing
 

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/MacOSNotarizationSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/dsl/MacOSNotarizationSettings.kt
@@ -43,6 +43,29 @@ abstract class MacOSNotarizationSettings {
             set(NucleusProperties.macNotarizationTeamID(providers))
         }
 
+    /**
+     * Name of a `notarytool` keychain profile created via `xcrun notarytool store-credentials`.
+     * When set, notarization uses `--keychain-profile <name>` instead of `--apple-id`/`--team-id`/password.
+     * Mutually exclusive with the `appleID`/`password`/`teamID` mode.
+     */
+    @get:Input
+    @get:Optional
+    val keychainProfile: Property<String> =
+        objects.nullableProperty<String>().apply {
+            set(NucleusProperties.macNotarizationKeychainProfile(providers))
+        }
+
+    /**
+     * Optional path to the keychain that stores the `keychainProfile` credentials.
+     * Forwarded to `notarytool` as `--keychain <path>`. Only used when [keychainProfile] is set.
+     */
+    @get:Input
+    @get:Optional
+    val keychainPath: Property<String> =
+        objects.nullableProperty<String>().apply {
+            set(NucleusProperties.macNotarizationKeychainPath(providers))
+        }
+
     @Deprecated("This option is no longer supported and got replaced by teamID", level = DeprecationLevel.ERROR)
     @get:Internal
     val ascProvider: Property<String> =

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/NucleusProjectProperties.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/NucleusProjectProperties.kt
@@ -22,6 +22,8 @@ internal object NucleusProperties {
     internal const val MAC_NOTARIZATION_APPLE_ID = "compose.desktop.mac.notarization.appleID"
     internal const val MAC_NOTARIZATION_PASSWORD = "compose.desktop.mac.notarization.password"
     internal const val MAC_NOTARIZATION_TEAM_ID_PROVIDER = "compose.desktop.mac.notarization.teamID"
+    internal const val MAC_NOTARIZATION_KEYCHAIN_PROFILE = "compose.desktop.mac.notarization.keychainProfile"
+    internal const val MAC_NOTARIZATION_KEYCHAIN_PATH = "compose.desktop.mac.notarization.keychainPath"
     internal const val CHECK_JDK_VENDOR = "compose.desktop.packaging.checkJdkVendor"
     internal const val DISABLE_MULTIMODULE_RESOURCES = "org.jetbrains.compose.resources.multimodule.disable"
     internal const val SYNC_RESOURCES_PROPERTY = "compose.ios.resources.sync"
@@ -49,6 +51,12 @@ internal object NucleusProperties {
 
     @Suppress("MaxLineLength")
     fun macNotarizationTeamID(providers: ProviderFactory): Provider<String> = providers.valueOrNull(MAC_NOTARIZATION_TEAM_ID_PROVIDER)
+
+    @Suppress("MaxLineLength")
+    fun macNotarizationKeychainProfile(providers: ProviderFactory): Provider<String> = providers.valueOrNull(MAC_NOTARIZATION_KEYCHAIN_PROFILE)
+
+    @Suppress("MaxLineLength")
+    fun macNotarizationKeychainPath(providers: ProviderFactory): Provider<String> = providers.valueOrNull(MAC_NOTARIZATION_KEYCHAIN_PATH)
 
     fun checkJdkVendor(providers: ProviderFactory): Provider<Boolean> = providers.valueOrNull(CHECK_JDK_VENDOR).toBooleanProvider(true)
 

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/configureJvmApplication.kt
@@ -872,10 +872,12 @@ internal fun JvmApplicationContext.configureCommonNotarizationSettings(notarizat
     val notarization = app.nativeDistributions.macOS.notarization
     notarizationTask.nonValidatedNotarizationSettings = notarization
     notarizationTask.onlyIf {
-        val configured =
+        val hasAppleId =
             !notarization.appleID.orNull.isNullOrEmpty() &&
                 !notarization.password.orNull.isNullOrEmpty() &&
                 !notarization.teamID.orNull.isNullOrEmpty()
+        val hasKeychainProfile = !notarization.keychainProfile.orNull.isNullOrEmpty()
+        val configured = hasAppleId || hasKeychainProfile
         if (!configured) {
             it.logger.info("Notarization skipped: macOS notarization settings are not configured")
         }

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/validation/ValidatedMacOSNotarizationSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/validation/ValidatedMacOSNotarizationSettings.kt
@@ -8,36 +8,98 @@ package io.github.kdroidfilter.nucleus.desktop.application.internal.validation
 import io.github.kdroidfilter.nucleus.desktop.application.dsl.MacOSNotarizationSettings
 import io.github.kdroidfilter.nucleus.desktop.application.internal.NucleusProperties
 
-internal data class ValidatedMacOSNotarizationSettings(
-    val appleID: String,
-    val password: String,
-    val teamID: String,
-)
+internal sealed class NotarizationAuth {
+    data class AppleId(
+        val appleID: String,
+        val password: String,
+        val teamID: String,
+    ) : NotarizationAuth()
+
+    data class KeychainProfile(
+        val profileName: String,
+        val keychainPath: String?,
+    ) : NotarizationAuth()
+}
+
+/**
+ * Builds the `notarytool` authentication arguments and an optional stdin payload
+ * (the Apple ID password is fed via stdin to keep it off the command line).
+ */
+internal fun NotarizationAuth.toNotaryToolArgs(): Pair<List<String>, String?> =
+    when (this) {
+        is NotarizationAuth.AppleId ->
+            listOf("--apple-id", appleID, "--team-id", teamID) to password
+        is NotarizationAuth.KeychainProfile ->
+            buildList {
+                add("--keychain-profile")
+                add(profileName)
+                keychainPath?.let {
+                    add("--keychain")
+                    add(it)
+                }
+            } to null
+    }
+
+internal data class ValidatedMacOSNotarizationSettings(val auth: NotarizationAuth)
 
 internal fun MacOSNotarizationSettings?.validate(): ValidatedMacOSNotarizationSettings {
     checkNotNull(this) {
         ERR_NOTARIZATION_SETTINGS_ARE_NOT_PROVIDED
     }
 
-    check(!appleID.orNull.isNullOrEmpty()) {
-        ERR_APPLE_ID_IS_EMPTY
+    val appleId = appleID.orNull?.takeUnless { it.isEmpty() }
+    val pwd = password.orNull?.takeUnless { it.isEmpty() }
+    val team = teamID.orNull?.takeUnless { it.isEmpty() }
+    val profile = keychainProfile.orNull?.takeUnless { it.isEmpty() }
+    val keychainPathValue = keychainPath.orNull?.takeUnless { it.isEmpty() }
+
+    val appleIdMode = appleId != null || pwd != null || team != null
+    val keychainMode = profile != null
+
+    check(!(appleIdMode && keychainMode)) {
+        ERR_MUTUALLY_EXCLUSIVE
     }
-    check(!password.orNull.isNullOrEmpty()) {
-        ERR_PASSWORD_IS_EMPTY
+    check(appleIdMode || keychainMode) {
+        ERR_NO_MODE_CONFIGURED
     }
-    check(!teamID.orNull.isNullOrEmpty()) {
-        TEAM_ID_IS_EMPTY
+
+    return if (profile != null) {
+        ValidatedMacOSNotarizationSettings(
+            NotarizationAuth.KeychainProfile(
+                profileName = profile,
+                keychainPath = keychainPathValue,
+            ),
+        )
+    } else {
+        checkNotNull(appleId) { ERR_APPLE_ID_IS_EMPTY }
+        checkNotNull(pwd) { ERR_PASSWORD_IS_EMPTY }
+        checkNotNull(team) { ERR_TEAM_ID_IS_EMPTY }
+        ValidatedMacOSNotarizationSettings(
+            NotarizationAuth.AppleId(
+                appleID = appleId,
+                password = pwd,
+                teamID = team,
+            ),
+        )
     }
-    return ValidatedMacOSNotarizationSettings(
-        appleID = appleID.orNull!!,
-        password = password.orNull!!,
-        teamID = teamID.orNull!!,
-    )
 }
 
 private const val ERR_PREFIX = "Notarization settings error:"
 private const val ERR_NOTARIZATION_SETTINGS_ARE_NOT_PROVIDED =
     "$ERR_PREFIX notarization settings are not provided"
+private val ERR_NO_MODE_CONFIGURED =
+    """|$ERR_PREFIX no authentication mode configured. Configure one of:
+       |  * Apple ID mode: appleID + password + teamID
+       |    (Gradle properties: ${NucleusProperties.MAC_NOTARIZATION_APPLE_ID},
+       |     ${NucleusProperties.MAC_NOTARIZATION_PASSWORD},
+       |     ${NucleusProperties.MAC_NOTARIZATION_TEAM_ID_PROVIDER});
+       |  * Keychain profile mode: keychainProfile (created via 'xcrun notarytool store-credentials')
+       |    (Gradle property: ${NucleusProperties.MAC_NOTARIZATION_KEYCHAIN_PROFILE});
+    """.trimMargin()
+private val ERR_MUTUALLY_EXCLUSIVE =
+    """|$ERR_PREFIX appleID/password/teamID and keychainProfile are mutually exclusive.
+       |Configure only one authentication mode.
+    """.trimMargin()
 private val ERR_APPLE_ID_IS_EMPTY =
     """|$ERR_PREFIX appleID is null or empty. To specify:
                |  * Use '${NucleusProperties.MAC_NOTARIZATION_APPLE_ID}' Gradle property;
@@ -48,7 +110,7 @@ private val ERR_PASSWORD_IS_EMPTY =
                |  * Use '${NucleusProperties.MAC_NOTARIZATION_PASSWORD}' Gradle property;
                |  * Or use 'nativeDistributions.macOS.notarization.password' DSL property;
     """.trimMargin()
-private val TEAM_ID_IS_EMPTY =
+private val ERR_TEAM_ID_IS_EMPTY =
     """|$ERR_PREFIX teamID is null or empty. To specify:
                |  * Use '${NucleusProperties.MAC_NOTARIZATION_TEAM_ID_PROVIDER}' Gradle property;
                |  * Or use 'nativeDistributions.macOS.notarization.teamID' DSL property;

--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractNotarizationTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractNotarizationTask.kt
@@ -12,6 +12,7 @@ import io.github.kdroidfilter.nucleus.desktop.application.internal.NotarizationR
 import io.github.kdroidfilter.nucleus.desktop.application.internal.files.checkExistingFile
 import io.github.kdroidfilter.nucleus.desktop.application.internal.files.findOutputFileOrDir
 import io.github.kdroidfilter.nucleus.desktop.application.internal.validation.ValidatedMacOSNotarizationSettings
+import io.github.kdroidfilter.nucleus.desktop.application.internal.validation.toNotaryToolArgs
 import io.github.kdroidfilter.nucleus.desktop.application.internal.validation.validate
 import io.github.kdroidfilter.nucleus.desktop.tasks.AbstractNucleusTask
 import io.github.kdroidfilter.nucleus.internal.utils.MacUtils
@@ -64,17 +65,15 @@ abstract class AbstractNotarizationTask
             packageFile: File,
         ) {
             logger.lifecycle("Uploading '${packageFile.name}' for notarization")
+            val (authArgs, stdin) = notarization.auth.toNotaryToolArgs()
             val args =
-                listOfNotNull(
-                    "notarytool",
-                    "submit",
-                    "--wait",
-                    "--apple-id",
-                    notarization.appleID,
-                    "--team-id",
-                    notarization.teamID,
-                    packageFile.absolutePath,
-                )
+                buildList {
+                    add("notarytool")
+                    add("submit")
+                    add("--wait")
+                    addAll(authArgs)
+                    add(packageFile.absolutePath)
+                }
 
             var submissionId: String? = null
             var stdout = ""
@@ -83,7 +82,7 @@ abstract class AbstractNotarizationTask
                 runExternalTool(
                     tool = MacUtils.xcrun,
                     args = args,
-                    stdinStr = notarization.password,
+                    stdinStr = stdin,
                     checkExitCodeIsNormal = false,
                     processStdout = { output ->
                         stdout = output
@@ -110,11 +109,7 @@ abstract class AbstractNotarizationTask
                             appendLine(appleLog)
                         } else if (submissionId != null) {
                             appendLine("To fetch the log manually run:")
-                            appendLine(
-                                "  xcrun notarytool log $submissionId" +
-                                    " --apple-id ${notarization.appleID}" +
-                                    " --team-id ${notarization.teamID}",
-                            )
+                            appendLine("  xcrun notarytool log $submissionId ${authArgs.joinToString(" ")}")
                         }
                     }
                 error(errMsg)
@@ -138,21 +133,19 @@ abstract class AbstractNotarizationTask
         ): String? {
             if (submissionId == null) return null
 
+            val (authArgs, stdin) = notarization.auth.toNotaryToolArgs()
             return try {
                 var logContent = ""
                 runExternalTool(
                     tool = MacUtils.xcrun,
                     args =
-                        listOf(
-                            "notarytool",
-                            "log",
-                            submissionId,
-                            "--apple-id",
-                            notarization.appleID,
-                            "--team-id",
-                            notarization.teamID,
-                        ),
-                    stdinStr = notarization.password,
+                        buildList {
+                            add("notarytool")
+                            add("log")
+                            add(submissionId)
+                            addAll(authArgs)
+                        },
+                    stdinStr = stdin,
                     processStdout = { logContent = it },
                 )
                 logContent.ifEmpty { null }

--- a/plugin-build/plugin/src/test/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/validation/ValidatedMacOSNotarizationSettingsTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/io/github/kdroidfilter/nucleus/desktop/application/internal/validation/ValidatedMacOSNotarizationSettingsTest.kt
@@ -1,0 +1,167 @@
+package io.github.kdroidfilter.nucleus.desktop.application.internal.validation
+
+import io.github.kdroidfilter.nucleus.desktop.application.dsl.MacOSNotarizationSettings
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class ValidatedMacOSNotarizationSettingsTest {
+    private fun newSettings(): MacOSNotarizationSettings {
+        val project = ProjectBuilder.builder().build()
+        return project.objects.newInstance(MacOSNotarizationSettings::class.java)
+    }
+
+    private fun assertFailsWith(message: String, block: () -> Unit) {
+        try {
+            block()
+            fail("Expected IllegalStateException containing: $message")
+        } catch (e: IllegalStateException) {
+            assertTrue(
+                "Expected message to contain '$message', got: ${e.message}",
+                e.message?.contains(message) == true,
+            )
+        }
+    }
+
+    @Test
+    fun `null settings reject with not-provided error`() {
+        val settings: MacOSNotarizationSettings? = null
+        assertFailsWith("notarization settings are not provided") {
+            settings.validate()
+        }
+    }
+
+    @Test
+    fun `no mode configured fails with explicit guidance`() {
+        val settings = newSettings()
+        assertFailsWith("no authentication mode configured") {
+            settings.validate()
+        }
+    }
+
+    @Test
+    fun `complete apple-id mode validates as AppleId auth`() {
+        val settings = newSettings()
+        settings.appleID.set("dev@example.com")
+        settings.password.set("@keychain:AC_PASSWORD")
+        settings.teamID.set("TEAMID")
+
+        val validated = settings.validate()
+        val auth = validated.auth as NotarizationAuth.AppleId
+        assertEquals("dev@example.com", auth.appleID)
+        assertEquals("@keychain:AC_PASSWORD", auth.password)
+        assertEquals("TEAMID", auth.teamID)
+    }
+
+    @Test
+    fun `apple-id missing password fails`() {
+        val settings = newSettings()
+        settings.appleID.set("dev@example.com")
+        settings.teamID.set("TEAMID")
+
+        assertFailsWith("password is null or empty") {
+            settings.validate()
+        }
+    }
+
+    @Test
+    fun `apple-id missing teamID fails`() {
+        val settings = newSettings()
+        settings.appleID.set("dev@example.com")
+        settings.password.set("pwd")
+
+        assertFailsWith("teamID is null or empty") {
+            settings.validate()
+        }
+    }
+
+    @Test
+    fun `apple-id missing appleID fails`() {
+        val settings = newSettings()
+        settings.password.set("pwd")
+        settings.teamID.set("TEAMID")
+
+        assertFailsWith("appleID is null or empty") {
+            settings.validate()
+        }
+    }
+
+    @Test
+    fun `keychainProfile alone validates with null path`() {
+        val settings = newSettings()
+        settings.keychainProfile.set("AC_PASSWORD")
+
+        val validated = settings.validate()
+        val auth = validated.auth as NotarizationAuth.KeychainProfile
+        assertEquals("AC_PASSWORD", auth.profileName)
+        assertNull(auth.keychainPath)
+    }
+
+    @Test
+    fun `keychainProfile with explicit keychainPath validates`() {
+        val settings = newSettings()
+        settings.keychainProfile.set("AC_PASSWORD")
+        settings.keychainPath.set("/Users/me/Library/Keychains/login.keychain-db")
+
+        val validated = settings.validate()
+        val auth = validated.auth as NotarizationAuth.KeychainProfile
+        assertEquals("AC_PASSWORD", auth.profileName)
+        assertEquals("/Users/me/Library/Keychains/login.keychain-db", auth.keychainPath)
+    }
+
+    @Test
+    fun `apple-id and keychainProfile together fail with mutual-exclusivity error`() {
+        val settings = newSettings()
+        settings.appleID.set("dev@example.com")
+        settings.password.set("pwd")
+        settings.teamID.set("TEAMID")
+        settings.keychainProfile.set("AC_PASSWORD")
+
+        assertFailsWith("mutually exclusive") {
+            settings.validate()
+        }
+    }
+
+    @Test
+    fun `empty strings are treated as not-set`() {
+        val settings = newSettings()
+        settings.appleID.set("")
+        settings.password.set("")
+        settings.teamID.set("")
+        settings.keychainProfile.set("")
+
+        assertFailsWith("no authentication mode configured") {
+            settings.validate()
+        }
+    }
+
+    @Test
+    fun `toNotaryToolArgs builds apple-id args with password as stdin`() {
+        val auth = NotarizationAuth.AppleId("dev@example.com", "pwd", "TEAMID")
+        val (args, stdin) = auth.toNotaryToolArgs()
+        assertEquals(listOf("--apple-id", "dev@example.com", "--team-id", "TEAMID"), args)
+        assertEquals("pwd", stdin)
+    }
+
+    @Test
+    fun `toNotaryToolArgs builds keychain-profile args with no stdin`() {
+        val auth = NotarizationAuth.KeychainProfile("AC_PASSWORD", null)
+        val (args, stdin) = auth.toNotaryToolArgs()
+        assertEquals(listOf("--keychain-profile", "AC_PASSWORD"), args)
+        assertNull(stdin)
+    }
+
+    @Test
+    fun `toNotaryToolArgs appends keychain path when set`() {
+        val auth = NotarizationAuth.KeychainProfile("AC_PASSWORD", "/path/to/login.keychain-db")
+        val (args, stdin) = auth.toNotaryToolArgs()
+        assertEquals(
+            listOf("--keychain-profile", "AC_PASSWORD", "--keychain", "/path/to/login.keychain-db"),
+            args,
+        )
+        assertNull(stdin)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a second macOS notarization auth mode: `notarytool --keychain-profile` (created via `xcrun notarytool store-credentials`), alongside the existing Apple ID + app-specific password mode.
- New DSL properties: `notarization.keychainProfile` and optional `notarization.keychainPath`. New Gradle properties: `compose.desktop.mac.notarization.keychainProfile` / `...keychainPath`.
- Validation refactored to a `NotarizationAuth` sealed class (`AppleId` / `KeychainProfile`), ready for a future App Store Connect API key branch.
- Modes are mutually exclusive — validation rejects mixed configurations with a clear error.
- `onlyIf` gate accepts either mode, so a keychain-profile-only configuration is not silently skipped.
- `notarytool submit` and `notarytool log` invocations now build their argv from the resolved auth, dropping the hardcoded apple-id flags.
- `docs/code-signing.md` updated with the two modes and a `store-credentials` example.

## Backwards compatibility

No breaking change: existing Apple ID + password + teamID configurations continue to behave identically.

## Out of scope

- App Store Connect API key support (`--key` / `--key-id` / `--issuer`) — the sealed class leaves room for it; will land in a follow-up.

## Test plan

- [x] `:plugin:compileKotlin` with config cache active
- [x] `:plugin:test` — 14 unit tests covering `validate()` (apple-id complete/partial, keychainProfile alone, keychainProfile + path, mutual exclusivity, empty strings) and `toNotaryToolArgs()` (apple-id args, keychain-profile args with and without `--keychain`)
- [x] `:plugin:detektMain` + `:plugin:ktlintMainSourceSetCheck` + `:plugin:ktlintTestSourceSetCheck` — no new violations on touched files
- [x] Plugin loads cleanly in `example` (`tasks --all` lists all `notarize*` tasks; `notarizeDmg --dry-run` succeeds with and without `-Pcompose.desktop.mac.notarization.keychainProfile=...`)
- [ ] Real `xcrun notarytool` invocation against Apple — requires a signed DMG and live Apple Developer credentials, not exercised in CI