### PR TITLE
Refactor: Use an interface for dark mode detector

### DIFF
--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/DarkModeDetector.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/DarkModeDetector.kt
@@ -8,21 +8,24 @@ import java.util.function.Consumer
 
 interface IDarkModeDetector {
     fun isDark(): Boolean
+
     fun registerListener(listener: Consumer<Boolean>)
+
     fun removeListener(listener: Consumer<Boolean>)
 }
 
 object NoopDarkModeDetector : IDarkModeDetector {
     override fun isDark(): Boolean = false
+
     override fun registerListener(listener: Consumer<Boolean>) = Unit
+
     override fun removeListener(listener: Consumer<Boolean>) = Unit
 }
 
-public fun getPlatformDarkModeDetector(): IDarkModeDetector {
-    return when (Platform.Current) {
+public fun getPlatformDarkModeDetector(): IDarkModeDetector =
+    when (Platform.Current) {
         Platform.MacOS -> MacOSThemeDetector
         Platform.Windows -> WindowsThemeDetector
         Platform.Linux -> LinuxPortalThemeDetector
         else -> NoopDarkModeDetector
     }
-}

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/DarkModeDetector.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/DarkModeDetector.kt
@@ -1,0 +1,28 @@
+package io.github.kdroidfilter.nucleus.darkmodedetector
+
+import io.github.kdroidfilter.nucleus.core.runtime.Platform
+import io.github.kdroidfilter.nucleus.darkmodedetector.linux.LinuxPortalThemeDetector
+import io.github.kdroidfilter.nucleus.darkmodedetector.mac.MacOSThemeDetector
+import io.github.kdroidfilter.nucleus.darkmodedetector.windows.WindowsThemeDetector
+import java.util.function.Consumer
+
+interface IDarkModeDetector {
+    fun isDark(): Boolean
+    fun registerListener(listener: Consumer<Boolean>)
+    fun removeListener(listener: Consumer<Boolean>)
+}
+
+object NoopDarkModeDetector : IDarkModeDetector {
+    override fun isDark(): Boolean = false
+    override fun registerListener(listener: Consumer<Boolean>) = Unit
+    override fun removeListener(listener: Consumer<Boolean>) = Unit
+}
+
+public fun getPlatformDarkModeDetector(): IDarkModeDetector {
+    return when (Platform.Current) {
+        Platform.MacOS -> MacOSThemeDetector
+        Platform.Windows -> WindowsThemeDetector
+        Platform.Linux -> LinuxPortalThemeDetector
+        else -> NoopDarkModeDetector
+    }
+}

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/IsSystemInDarkMode.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/IsSystemInDarkMode.kt
@@ -1,12 +1,12 @@
 package io.github.kdroidfilter.nucleus.darkmodedetector
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalInspectionMode
-import io.github.kdroidfilter.nucleus.core.runtime.Platform
-import io.github.kdroidfilter.nucleus.darkmodedetector.linux.isLinuxInDarkMode
-import io.github.kdroidfilter.nucleus.darkmodedetector.mac.isMacOsInDarkMode
-import io.github.kdroidfilter.nucleus.darkmodedetector.windows.isWindowsInDarkMode
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import java.util.function.Consumer
 
 /**
  * Composable function that returns whether the system is in dark mode.
@@ -18,11 +18,26 @@ fun isSystemInDarkMode(): Boolean {
     if (isInPreview) {
         return isSystemInDarkTheme()
     }
+    val darkModeDetector = remember { getPlatformDarkModeDetector() }
+    val darkModeState = remember { mutableStateOf(darkModeDetector.isDark()) }
 
-    return when (Platform.Current) {
-        Platform.MacOS -> isMacOsInDarkMode()
-        Platform.Windows -> isWindowsInDarkMode()
-        Platform.Linux -> isLinuxInDarkMode()
-        else -> false
+    DisposableEffect(Unit) {
+        debugln(TAG) { "Registering OS dark mode listener in Compose" }
+        val listener =
+            Consumer<Boolean> { newValue ->
+                debugln(TAG) { "OS dark mode updated: $newValue" }
+                darkModeState.value = newValue
+            }
+
+        darkModeDetector.registerListener(listener)
+
+        onDispose {
+            debugln(TAG) { "Removing OS dark mode listener in Compose" }
+            darkModeDetector.removeListener(listener)
+        }
     }
+
+    return darkModeState.value
 }
+
+private const val TAG = "PlatformThemeDetectorCompose"

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/IsSystemInDarkMode.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/IsSystemInDarkMode.kt
@@ -1,11 +1,11 @@
 package io.github.kdroidfilter.nucleus.darkmodedetector
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalInspectionMode
 import java.util.function.Consumer
 
 /**

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/linux/LinuxPortalThemeDetector.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/linux/LinuxPortalThemeDetector.kt
@@ -1,11 +1,7 @@
 package io.github.kdroidfilter.nucleus.darkmodedetector.linux
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
 import io.github.kdroidfilter.nucleus.darkmodedetector.IDarkModeDetector
+import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
 import java.util.function.Consumer
 
 private const val TAG = "LinuxPortalThemeDetector"
@@ -19,7 +15,7 @@ private const val TAG = "LinuxPortalThemeDetector"
  * The detector also monitors for SettingChanged signals in real-time via a background
  * D-Bus dispatch thread.
  */
-internal object LinuxPortalThemeDetector: IDarkModeDetector {
+internal object LinuxPortalThemeDetector : IDarkModeDetector {
     init {
         debugln(TAG) { "Initializing Linux portal theme observer via JNI" }
         NativeLinuxBridge.nativeStartObserving()

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/linux/LinuxPortalThemeDetector.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/linux/LinuxPortalThemeDetector.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
+import io.github.kdroidfilter.nucleus.darkmodedetector.IDarkModeDetector
 import java.util.function.Consumer
 
 private const val TAG = "LinuxPortalThemeDetector"
@@ -18,42 +19,19 @@ private const val TAG = "LinuxPortalThemeDetector"
  * The detector also monitors for SettingChanged signals in real-time via a background
  * D-Bus dispatch thread.
  */
-internal object LinuxPortalThemeDetector {
+internal object LinuxPortalThemeDetector: IDarkModeDetector {
     init {
         debugln(TAG) { "Initializing Linux portal theme observer via JNI" }
         NativeLinuxBridge.nativeStartObserving()
     }
 
-    fun isDark(): Boolean = NativeLinuxBridge.nativeIsDark()
+    override fun isDark(): Boolean = NativeLinuxBridge.nativeIsDark()
 
-    fun registerListener(listener: Consumer<Boolean>) {
+    override fun registerListener(listener: Consumer<Boolean>) {
         NativeLinuxBridge.registerListener(listener)
     }
 
-    fun removeListener(listener: Consumer<Boolean>) {
+    override fun removeListener(listener: Consumer<Boolean>) {
         NativeLinuxBridge.removeListener(listener)
     }
-}
-
-/**
- * A helper composable function that returns the current Linux dark mode state
- * via the XDG Desktop Portal, updating automatically when the system theme changes.
- */
-@Composable
-fun isLinuxInDarkMode(): Boolean {
-    val darkModeState = remember { mutableStateOf(LinuxPortalThemeDetector.isDark()) }
-    DisposableEffect(Unit) {
-        debugln(TAG) { "Registering Linux portal dark mode listener in Compose" }
-        val listener =
-            Consumer<Boolean> { newValue ->
-                debugln(TAG) { "Compose Linux portal dark mode updated: $newValue" }
-                darkModeState.value = newValue
-            }
-        LinuxPortalThemeDetector.registerListener(listener)
-        onDispose {
-            debugln(TAG) { "Removing Linux portal dark mode listener in Compose" }
-            LinuxPortalThemeDetector.removeListener(listener)
-        }
-    }
-    return darkModeState.value
 }

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/mac/MacOSThemeDetector.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/mac/MacOSThemeDetector.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
+import io.github.kdroidfilter.nucleus.darkmodedetector.IDarkModeDetector
 import java.util.function.Consumer
 
 private const val TAG = "MacOSThemeDetector"
@@ -14,42 +15,19 @@ private const val TAG = "MacOSThemeDetector"
  * to detect theme changes in macOS. It reads the system preference "AppleInterfaceStyle"
  * (which is "Dark" when in dark mode) from NSUserDefaults.
  */
-internal object MacOSThemeDetector {
+internal object MacOSThemeDetector: IDarkModeDetector {
     init {
         debugln(TAG) { "Initializing macOS theme observer via JNI" }
         NativeDarkModeBridge.nativeStartObserving()
     }
 
-    fun isDark(): Boolean = NativeDarkModeBridge.nativeIsDark()
+    override fun isDark(): Boolean = NativeDarkModeBridge.nativeIsDark()
 
-    fun registerListener(listener: Consumer<Boolean>) {
+    override fun registerListener(listener: Consumer<Boolean>) {
         NativeDarkModeBridge.registerListener(listener)
     }
 
-    fun removeListener(listener: Consumer<Boolean>) {
+    override fun removeListener(listener: Consumer<Boolean>) {
         NativeDarkModeBridge.removeListener(listener)
     }
-}
-
-/**
- * A helper composable function that returns the current macOS dark mode state,
- * updating automatically when the system theme changes.
- */
-@Composable
-internal fun isMacOsInDarkMode(): Boolean {
-    val darkModeState = remember { mutableStateOf(MacOSThemeDetector.isDark()) }
-    DisposableEffect(Unit) {
-        debugln(TAG) { "Registering macOS dark mode listener in Compose" }
-        val listener =
-            Consumer<Boolean> { newValue ->
-                debugln(TAG) { "Compose macOS dark mode updated: $newValue" }
-                darkModeState.value = newValue
-            }
-        MacOSThemeDetector.registerListener(listener)
-        onDispose {
-            debugln(TAG) { "Removing macOS dark mode listener in Compose" }
-            MacOSThemeDetector.removeListener(listener)
-        }
-    }
-    return darkModeState.value
 }

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/mac/MacOSThemeDetector.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/mac/MacOSThemeDetector.kt
@@ -1,11 +1,7 @@
 package io.github.kdroidfilter.nucleus.darkmodedetector.mac
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
 import io.github.kdroidfilter.nucleus.darkmodedetector.IDarkModeDetector
+import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
 import java.util.function.Consumer
 
 private const val TAG = "MacOSThemeDetector"
@@ -15,7 +11,7 @@ private const val TAG = "MacOSThemeDetector"
  * to detect theme changes in macOS. It reads the system preference "AppleInterfaceStyle"
  * (which is "Dark" when in dark mode) from NSUserDefaults.
  */
-internal object MacOSThemeDetector: IDarkModeDetector {
+internal object MacOSThemeDetector : IDarkModeDetector {
     init {
         debugln(TAG) { "Initializing macOS theme observer via JNI" }
         NativeDarkModeBridge.nativeStartObserving()

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/windows/WindowsThemeDetector.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/windows/WindowsThemeDetector.kt
@@ -1,11 +1,7 @@
 package io.github.kdroidfilter.nucleus.darkmodedetector.windows
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
 import io.github.kdroidfilter.nucleus.darkmodedetector.IDarkModeDetector
+import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
 import java.util.function.Consumer
 
 private const val TAG = "WindowsThemeDetector"
@@ -19,7 +15,7 @@ private const val TAG = "WindowsThemeDetector"
  * The detector monitors the registry for changes in real-time via a native
  * background thread using RegNotifyChangeKeyValue in async mode.
  */
-internal object WindowsThemeDetector: IDarkModeDetector {
+internal object WindowsThemeDetector : IDarkModeDetector {
     init {
         debugln(TAG) { "Initializing Windows theme observer via JNI" }
         NativeWindowsBridge.nativeStartObserving()

--- a/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/windows/WindowsThemeDetector.kt
+++ b/darkmode-detector/src/main/kotlin/io/github/kdroidfilter/nucleus/darkmodedetector/windows/WindowsThemeDetector.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import io.github.kdroidfilter.nucleus.darkmodedetector.debugln
+import io.github.kdroidfilter.nucleus.darkmodedetector.IDarkModeDetector
 import java.util.function.Consumer
 
 private const val TAG = "WindowsThemeDetector"
@@ -18,45 +19,19 @@ private const val TAG = "WindowsThemeDetector"
  * The detector monitors the registry for changes in real-time via a native
  * background thread using RegNotifyChangeKeyValue in async mode.
  */
-internal object WindowsThemeDetector {
+internal object WindowsThemeDetector: IDarkModeDetector {
     init {
         debugln(TAG) { "Initializing Windows theme observer via JNI" }
         NativeWindowsBridge.nativeStartObserving()
     }
 
-    fun isDark(): Boolean = NativeWindowsBridge.nativeIsDark()
+    override fun isDark(): Boolean = NativeWindowsBridge.nativeIsDark()
 
-    fun registerListener(listener: Consumer<Boolean>) {
+    override fun registerListener(listener: Consumer<Boolean>) {
         NativeWindowsBridge.registerListener(listener)
     }
 
-    fun removeListener(listener: Consumer<Boolean>) {
+    override fun removeListener(listener: Consumer<Boolean>) {
         NativeWindowsBridge.removeListener(listener)
     }
-}
-
-/**
- * Composable function that returns whether Windows is currently in dark mode.
- */
-@Composable
-internal fun isWindowsInDarkMode(): Boolean {
-    val darkModeState = remember { mutableStateOf(WindowsThemeDetector.isDark()) }
-
-    DisposableEffect(Unit) {
-        debugln(TAG) { "Registering Windows dark mode listener in Compose" }
-        val listener =
-            Consumer<Boolean> { newValue ->
-                debugln(TAG) { "Windows dark mode updated: $newValue" }
-                darkModeState.value = newValue
-            }
-
-        WindowsThemeDetector.registerListener(listener)
-
-        onDispose {
-            debugln(TAG) { "Removing Windows dark mode listener in Compose" }
-            WindowsThemeDetector.removeListener(listener)
-        }
-    }
-
-    return darkModeState.value
 }

--- a/docs/runtime/darkmode-detector.md
+++ b/docs/runtime/darkmode-detector.md
@@ -14,6 +14,40 @@ dependencies {
 
 ## Usage
 
+### Manual usage
+
+This is the core functionality - it’s totally up to you how you want to use it. Just don’t forget to dispose its callback (`removeListener`) when you don’t need it anymore.
+
+You can use Compose states, RxJava/Kotlin, or anything else you prefer.
+
+Here we’re using a coroutines Flow wrapper just for demonstration.
+
+```kt
+val isSystemDarkFlow: Flow<Boolean> = callbackFlow<Boolean> {
+    val listener: Consumer<Boolean> = { isDark: Boolean ->
+        trySend(isDark)
+    }
+
+    val darkModeDetector = getPlatformDarkModeDetector()
+
+    // emit initial value
+    trySend(darkModeDetector.isDark())
+
+    // listen to dark mode change events
+    darkModeDetector.registerListener(listener)
+    awaitClose {
+        darkModeDetector.removeListener(listener)
+    }
+}
+isSystemDarkFlow.collect {
+    println("dark mode changes, isDark: $it")
+}
+```
+
+### In compose
+
+There is already a composable function available out of the box, which you can use it in your compose applications.
+
 ```kotlin
 @Composable
 fun App() {


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->

Provide a way to use the dark mode detector module in an un-opinionated way.

## 📄 Motivation and Context

At the moment there is no common way for non-compose or custom setups to use this module. maybe someone wants to check system dark mode in non-compose logic. or an app which has no dependency to compose at all.

## 🧪 How Has This Been Tested?

Unfortunately due to internet shutdown in Iran I was unable to compile the project. there are no big changes in this PR just some refactoring! so I think everything should be fine.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

in order to help non-compose users can also benefit from this library as well - I suggest to separate this module into `darkmode-detector-core` and `darkmode-detector-compose`