### PR TITLE
implement GH api release processor for pre-releases

### DIFF
--- a/updater-runtime/build.gradle.kts
+++ b/updater-runtime/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
+    alias(libs.plugins.kotlinxSerialization)
     alias(libs.plugins.vanniktechMavenPublish)
 }
 
@@ -16,6 +17,7 @@ dependencies {
     api(project(":core-runtime"))
     implementation(kotlin("stdlib"))
     implementation(libs.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
     testImplementation(libs.junit)
 }
 

--- a/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/NucleusUpdater.kt
+++ b/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/NucleusUpdater.kt
@@ -179,7 +179,7 @@ class NucleusUpdater(
     private fun doCheckForUpdates(): UpdateResult {
         val platform = PlatformInfo.currentPlatform()
         val arch = PlatformInfo.currentArch()
-        val metadataUrl = config.provider.getUpdateMetadataUrl(config.channel, platform)
+        val metadataUrl = config.provider.resolveMetadataUrl(config.channel, platform, httpClient)
 
         val requestBuilder =
             HttpRequest

--- a/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/provider/GitHubProvider.kt
+++ b/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/provider/GitHubProvider.kt
@@ -1,6 +1,7 @@
 package io.github.kdroidfilter.nucleus.updater.provider
 
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
+import io.github.kdroidfilter.nucleus.updater.exception.NetworkException
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -77,15 +78,16 @@ class GitHubProvider(
         val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
         val status = response.statusCode()
         if (status != HTTP_OK) {
-            val rateLimitRemaining =
-                response.headers().firstValue("X-RateLimit-Remaining").orElse(null)
-            if (status == HTTP_FORBIDDEN && rateLimitRemaining == "0") {
-                throw RuntimeException(
-                    "GitHub API rate limit exceeded while listing releases for $owner/$repo. " +
-                        "Configure a token to raise the limit.",
-                )
-            }
-            throw RuntimeException("GitHub API returned HTTP $status while listing releases for $owner/$repo.")
+            val rateLimited =
+                status == HTTP_FORBIDDEN &&
+                    response.headers().firstValue("X-RateLimit-Remaining").orElse(null) == "0"
+            val detail =
+                if (rateLimited) {
+                    "rate limit exceeded — configure a token to raise the limit"
+                } else {
+                    "HTTP $status"
+                }
+            throw NetworkException("GitHub API failed while listing releases for $owner/$repo: $detail")
         }
 
         val releases = json.decodeFromString<List<GitHubRelease>>(response.body())

--- a/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/provider/GitHubProvider.kt
+++ b/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/provider/GitHubProvider.kt
@@ -1,19 +1,44 @@
 package io.github.kdroidfilter.nucleus.updater.provider
 
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 class GitHubProvider(
     val owner: String,
     val repo: String,
     val token: String? = null,
 ) : UpdateProvider {
+    /**
+     * Base URL for the GitHub REST API. Exposed as `internal` so tests in this module
+     * can redirect API traffic to a local server; not part of the public API.
+     */
+    internal var apiBaseUrl: String = "https://api.github.com"
+
     override fun getUpdateMetadataUrl(
         channel: String,
         platform: Platform,
     ): String {
-        val suffix = platformSuffix(platform)
-        val fileName = if (suffix.isEmpty()) "$channel.yml" else "$channel-$suffix.yml"
+        val fileName = metadataFileName(channel, platform)
         return "https://github.com/$owner/$repo/releases/latest/download/$fileName"
+    }
+
+    override fun resolveMetadataUrl(
+        channel: String,
+        platform: Platform,
+        httpClient: HttpClient,
+    ): String {
+        val fileName = metadataFileName(channel, platform)
+        if (channel.equals(LATEST_CHANNEL, ignoreCase = true)) {
+            return "https://github.com/$owner/$repo/releases/latest/download/$fileName"
+        }
+        val tag = findLatestPrereleaseTag(channel, httpClient)
+        return "https://github.com/$owner/$repo/releases/download/$tag/$fileName"
     }
 
     override fun getDownloadUrl(
@@ -28,6 +53,60 @@ class GitHubProvider(
             emptyMap()
         }
 
+    private fun metadataFileName(
+        channel: String,
+        platform: Platform,
+    ): String {
+        val suffix = platformSuffix(platform)
+        return if (suffix.isEmpty()) "$channel.yml" else "$channel-$suffix.yml"
+    }
+
+    private fun findLatestPrereleaseTag(
+        channel: String,
+        httpClient: HttpClient,
+    ): String {
+        val builder =
+            HttpRequest
+                .newBuilder()
+                .uri(URI.create("$apiBaseUrl/repos/$owner/$repo/releases?per_page=$PER_PAGE"))
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2026-03-10")
+        if (token != null) builder.header("Authorization", "Bearer $token")
+        val request = builder.GET().build()
+
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        val status = response.statusCode()
+        if (status != HTTP_OK) {
+            val rateLimitRemaining =
+                response.headers().firstValue("X-RateLimit-Remaining").orElse(null)
+            if (status == HTTP_FORBIDDEN && rateLimitRemaining == "0") {
+                throw RuntimeException(
+                    "GitHub API rate limit exceeded while listing releases for $owner/$repo. " +
+                        "Configure a token to raise the limit.",
+                )
+            }
+            throw RuntimeException("GitHub API returned HTTP $status while listing releases for $owner/$repo.")
+        }
+
+        val releases = json.decodeFromString<List<GitHubRelease>>(response.body())
+        val match =
+            releases.firstOrNull { release ->
+                release.prerelease && tagMatchesChannel(release.tagName, channel)
+            } ?: throw NoSuchElementException(
+                "No release found for channel '$channel' within the most recent $PER_PAGE releases. " +
+                    "Publish a fresh release on this channel.",
+            )
+        return match.tagName
+    }
+
+    private fun tagMatchesChannel(
+        tag: String,
+        channel: String,
+    ): Boolean {
+        val suffix = tag.substringAfter('-', missingDelimiterValue = "")
+        return suffix.startsWith(channel, ignoreCase = true)
+    }
+
     private fun platformSuffix(platform: Platform): String =
         when (platform) {
             Platform.Windows -> ""
@@ -35,4 +114,18 @@ class GitHubProvider(
             Platform.Linux -> "linux"
             Platform.Unknown -> ""
         }
+
+    @Serializable
+    internal data class GitHubRelease(
+        @SerialName("tag_name") val tagName: String,
+        val prerelease: Boolean,
+    )
+
+    private companion object {
+        const val LATEST_CHANNEL = "latest"
+        const val PER_PAGE = 100
+        const val HTTP_OK = 200
+        const val HTTP_FORBIDDEN = 403
+        val json = Json { ignoreUnknownKeys = true }
+    }
 }

--- a/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/provider/UpdateProvider.kt
+++ b/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/provider/UpdateProvider.kt
@@ -1,6 +1,7 @@
 package io.github.kdroidfilter.nucleus.updater.provider
 
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
+import java.net.http.HttpClient
 
 interface UpdateProvider {
     fun getUpdateMetadataUrl(
@@ -14,4 +15,18 @@ interface UpdateProvider {
     ): String
 
     fun authHeaders(): Map<String, String> = emptyMap()
+
+    /**
+     * Resolve the metadata (YAML) URL for the given channel, optionally consulting a
+     * remote service. The default delegates to [getUpdateMetadataUrl]; providers that
+     * need an HTTP round-trip (e.g. GitHub pre-release channels) should override this.
+     *
+     * The [httpClient] is supplied by [io.github.kdroidfilter.nucleus.updater.NucleusUpdater]
+     * so providers can reuse the configured client and credentials.
+     */
+    fun resolveMetadataUrl(
+        channel: String,
+        platform: Platform,
+        httpClient: HttpClient,
+    ): String = getUpdateMetadataUrl(channel, platform)
 }

--- a/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/provider/UpdateProvider.kt
+++ b/updater-runtime/src/main/kotlin/io/github/kdroidfilter/nucleus/updater/provider/UpdateProvider.kt
@@ -17,12 +17,30 @@ interface UpdateProvider {
     fun authHeaders(): Map<String, String> = emptyMap()
 
     /**
-     * Resolve the metadata (YAML) URL for the given channel, optionally consulting a
-     * remote service. The default delegates to [getUpdateMetadataUrl]; providers that
-     * need an HTTP round-trip (e.g. GitHub pre-release channels) should override this.
+     * Returns the URL of the metadata (YAML) file for the given [channel] and [platform],
+     * resolving it dynamically when the provider needs to consult a remote service first.
      *
-     * The [httpClient] is supplied by [io.github.kdroidfilter.nucleus.updater.NucleusUpdater]
-     * so providers can reuse the configured client and credentials.
+     * Called by [io.github.kdroidfilter.nucleus.updater.NucleusUpdater] before every update
+     * check. The default implementation delegates to [getUpdateMetadataUrl], which is
+     * sufficient for providers whose URLs can be computed without a network round-trip.
+     *
+     * Override this method when locating the metadata requires an HTTP request. For example,
+     * [GitHubProvider] overrides it to query the GitHub Releases API and select the most
+     * recent pre-release whose tag matches the requested channel — the stable channel keeps
+     * the static `releases/latest/download/...` redirect, while `beta` and `alpha` channels
+     * resolve to `releases/download/<tag>/...` URLs that the GitHub `latest` shortcut would
+     * otherwise skip.
+     *
+     * The [httpClient] is the same client that
+     * [io.github.kdroidfilter.nucleus.updater.UpdaterConfig.httpClient] configures (or the
+     * default one if none was supplied), so overrides should reuse it instead of constructing
+     * their own — this keeps redirect, proxy, and trust-store settings consistent across all
+     * traffic the updater generates. Implementations may call [httpClient] synchronously;
+     * the updater invokes this method from an IO dispatcher.
+     *
+     * Implementations may throw any exception to signal failure; [NoSuchElementException] is
+     * the conventional choice for "no release matches this channel". The updater surfaces
+     * such failures as [io.github.kdroidfilter.nucleus.updater.UpdateResult.Error].
      */
     fun resolveMetadataUrl(
         channel: String,

--- a/updater-runtime/src/test/kotlin/io/github/kdroidfilter/nucleus/updater/provider/GitHubProviderTest.kt
+++ b/updater-runtime/src/test/kotlin/io/github/kdroidfilter/nucleus/updater/provider/GitHubProviderTest.kt
@@ -1,0 +1,170 @@
+package io.github.kdroidfilter.nucleus.updater.provider
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import io.github.kdroidfilter.nucleus.core.runtime.Platform
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import java.net.InetSocketAddress
+import java.net.http.HttpClient
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+class GitHubProviderTest {
+    private lateinit var server: HttpServer
+    private lateinit var httpClient: HttpClient
+    private val apiCallCount = AtomicInteger(0)
+    private val lastAuthHeader = AtomicReference<String?>(null)
+    private var responseBody: String = "[]"
+    private var responseStatus: Int = HTTP_OK
+
+    @Before
+    fun startServer() {
+        apiCallCount.set(0)
+        lastAuthHeader.set(null)
+        responseBody = "[]"
+        responseStatus = HTTP_OK
+
+        server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext(
+            "/repos/",
+            HttpHandler { exchange: HttpExchange ->
+                apiCallCount.incrementAndGet()
+                lastAuthHeader.set(exchange.requestHeaders.getFirst("Authorization"))
+                val bytes = responseBody.toByteArray()
+                exchange.sendResponseHeaders(responseStatus, bytes.size.toLong())
+                exchange.responseBody.use { it.write(bytes) }
+            },
+        )
+        server.start()
+        httpClient = HttpClient.newHttpClient()
+    }
+
+    @After
+    fun stopServer() {
+        server.stop(0)
+    }
+
+    private fun newProvider(token: String? = null): GitHubProvider =
+        GitHubProvider("acme", "tool", token).apply {
+            apiBaseUrl = "http://127.0.0.1:${server.address.port}"
+        }
+
+    @Test
+    fun `stable channel makes no API call`() {
+        val provider = newProvider()
+
+        val url = provider.resolveMetadataUrl("latest", Platform.Linux, httpClient)
+
+        assertEquals("https://github.com/acme/tool/releases/latest/download/latest-linux.yml", url)
+        assertEquals(0, apiCallCount.get())
+    }
+
+    @Test
+    fun `beta channel finds matching pre-release`() {
+        responseBody =
+            jsonArray(
+                Release("v1.2.3-alpha.4", prerelease = true),
+                Release("v1.2.3-beta.5", prerelease = true),
+                Release("v1.2.2", prerelease = false),
+            )
+
+        val url = newProvider().resolveMetadataUrl("beta", Platform.Linux, httpClient)
+
+        assertEquals(
+            "https://github.com/acme/tool/releases/download/v1.2.3-beta.5/beta-linux.yml",
+            url,
+        )
+        assertEquals(1, apiCallCount.get())
+    }
+
+    @Test
+    fun `beta channel picks first match in API order`() {
+        responseBody =
+            jsonArray(
+                Release("v1.3.0-beta.2", prerelease = true),
+                Release("v1.3.0-beta.1", prerelease = true),
+                Release("v1.2.9-beta.7", prerelease = true),
+            )
+
+        val url = newProvider().resolveMetadataUrl("beta", Platform.Windows, httpClient)
+
+        assertEquals(
+            "https://github.com/acme/tool/releases/download/v1.3.0-beta.2/beta.yml",
+            url,
+        )
+    }
+
+    @Test
+    fun `skips non-prerelease entries with matching tag name`() {
+        responseBody =
+            jsonArray(
+                Release("v1.0.0-beta-leftover", prerelease = false),
+                Release("v1.0.0-beta.3", prerelease = true),
+            )
+
+        val url = newProvider().resolveMetadataUrl("beta", Platform.MacOS, httpClient)
+
+        assertEquals(
+            "https://github.com/acme/tool/releases/download/v1.0.0-beta.3/beta-mac.yml",
+            url,
+        )
+    }
+
+    @Test
+    fun `throws when no match in window`() {
+        val alphas = (1..NO_MATCH_RELEASE_COUNT).map { Release("v1.0.0-alpha.$it", prerelease = true) }
+        responseBody = jsonArray(*alphas.toTypedArray())
+
+        try {
+            newProvider().resolveMetadataUrl("beta", Platform.Linux, httpClient)
+            fail("expected NoSuchElementException")
+        } catch (e: NoSuchElementException) {
+            assertNotNull(e.message)
+            assertTrue(
+                "message should mention the window size",
+                e.message!!.contains("within the most recent 100 releases"),
+            )
+        }
+    }
+
+    @Test
+    fun `auth header sent when token configured`() {
+        responseBody = jsonArray(Release("v1.0.0-beta.1", prerelease = true))
+
+        newProvider(token = "ghp_test").resolveMetadataUrl("beta", Platform.Linux, httpClient)
+
+        assertEquals("Bearer ghp_test", lastAuthHeader.get())
+    }
+
+    @Test
+    fun `no auth header when token is null`() {
+        responseBody = jsonArray(Release("v1.0.0-beta.1", prerelease = true))
+
+        newProvider().resolveMetadataUrl("beta", Platform.Linux, httpClient)
+
+        assertNull(lastAuthHeader.get())
+    }
+
+    private data class Release(
+        val tag: String,
+        val prerelease: Boolean,
+    )
+
+    private fun jsonArray(vararg releases: Release): String =
+        releases.joinToString(prefix = "[", postfix = "]") { r ->
+            """{"tag_name":"${r.tag}","prerelease":${r.prerelease}}"""
+        }
+
+    private companion object {
+        const val HTTP_OK = 200
+        const val NO_MATCH_RELEASE_COUNT = 100
+    }
+}


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
On alpha/beta channels, downloads the more recent 100 releases from GH to search for the latest release on the channel.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Any release with the "latest" tag will overwrite that channel, so alpha/beta channels need to use the "pre-release" tag. Currently, Nucleus only checks the "latest" release on github for metadata

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested with a similar custom provider

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.