### PR TITLE
fix(aot): avoid Windows CreateProcess 206 by launching AOT training w…

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractGenerateAotCacheTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AbstractGenerateAotCacheTask.kt
@@ -22,10 +22,112 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import java.io.File
+import java.io.IOException
 
 private const val AOT_CACHE_FILENAME = "app.aot"
 private const val MIN_AOT_JDK_VERSION = 25
 private const val DEFAULT_SAFETY_TIMEOUT_SECONDS = 300L
+
+/**
+ * Builds the Java launcher argument list for AOT training (excluding the java executable path).
+ */
+internal fun buildAotJavaArgs(
+    classpath: String,
+    javaOptions: List<String>,
+    mainClass: String,
+    aotCacheFile: File,
+): List<String> =
+    buildList {
+        add("-XX:AOTCacheOutput=${aotCacheFile.absolutePath}")
+        add("-Dnucleus.aot.mode=training")
+        add("-cp")
+        add(classpath)
+        addAll(javaOptions)
+        add(mainClass)
+    }
+
+/**
+ * Writes Java launcher arguments as a UTF-8 argument file (`@argfile`), one argument per line.
+ */
+internal fun writeJavaArgFile(
+    file: File,
+    args: List<String>,
+) {
+    val content =
+        args
+            .joinToString(separator = System.lineSeparator()) { arg -> escapeArgForArgFile(arg) } +
+            System.lineSeparator()
+    file.writeText(content, Charsets.UTF_8)
+}
+
+/**
+ * Escapes a single Java launcher argument for `@argfile`.
+ *
+ * The argument is quoted when it contains whitespace, quotes, backslashes, or is empty.
+ * Newline characters are rejected because each argfile line encodes one argument.
+ */
+internal fun escapeArgForArgFile(arg: String): String {
+    require('\n' !in arg && '\r' !in arg) {
+        "Java @argfile argument must not contain newline characters"
+    }
+    val requiresQuotes = arg.isEmpty() || arg.any { it.isWhitespace() || it == '"' || it == '\\' }
+    if (!requiresQuotes) return arg
+    val escaped =
+        arg
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+    return "\"$escaped\""
+}
+
+/**
+ * Builds candidate directories for AOT argument/log temp files.
+ *
+ * Preference order:
+ * 1. `java.io.tmpdir`
+ * 2. app directory
+ * 3. AOT cache output directory
+ */
+internal fun buildAotTempFileCandidateDirs(
+    appDir: File,
+    aotCacheFile: File,
+    tmpDirPath: String? = System.getProperty("java.io.tmpdir"),
+): List<File> =
+    listOfNotNull(
+        tmpDirPath?.takeIf { it.isNotBlank() }?.let(::File),
+        appDir,
+        aotCacheFile.parentFile,
+    ).map { it.absoluteFile }.distinctBy { it.path }
+
+/**
+ * Creates a temp file under candidate directories in order.
+ *
+ * This avoids hard dependency on `java.io.tmpdir` writability.
+ */
+internal fun createAotTempFileWithFallback(
+    prefix: String,
+    suffix: String,
+    candidateDirs: List<File>,
+): File {
+    var firstFailure: IOException? = null
+    val attemptedDirs = mutableListOf<String>()
+    for (dir in candidateDirs) {
+        attemptedDirs += dir.absolutePath
+        try {
+            return File.createTempFile(prefix, suffix, dir).also { it.deleteOnExit() }
+        } catch (e: IOException) {
+            if (firstFailure == null) {
+                firstFailure = e
+            } else {
+                firstFailure.addSuppressed(e)
+            }
+        }
+    }
+
+    throw GradleException(
+        "Failed to create temporary file '$prefix*$suffix' in candidate directories: ${attemptedDirs.joinToString(", ")}",
+        firstFailure,
+    )
+}
 
 /**
  * Generates a JDK 25+ AOT cache for a Compose Desktop distributable.
@@ -343,65 +445,89 @@ abstract class AbstractGenerateAotCacheTask : AbstractNucleusTask() {
         mainClass: String,
         aotCacheFile: File,
     ) {
-        val args = mutableListOf(javaExe)
-        args += "-XX:AOTCacheOutput=${aotCacheFile.absolutePath}"
-        args += "-Dnucleus.aot.mode=training"
-        args += "-cp"
-        args += classpath
-        args += javaOptions
-        args += mainClass
+        val javaArgs =
+            buildAotJavaArgs(
+                classpath = classpath,
+                javaOptions = javaOptions,
+                mainClass = mainClass,
+                aotCacheFile = aotCacheFile,
+            )
+        val candidateDirs = buildAotTempFileCandidateDirs(appDir, aotCacheFile)
+        var argFile: File? = null
+        try {
+            val javaLauncherArgs =
+                try {
+                    argFile = createAotTempFileWithFallback("nucleus-aot-", ".args", candidateDirs)
+                    writeJavaArgFile(requireNotNull(argFile), javaArgs)
+                    listOf(javaExe, "@${requireNotNull(argFile).absolutePath}")
+                } catch (e: GradleException) {
+                    if (isWindows()) {
+                        throw GradleException(
+                            "Failed to create AOT @argfile on Windows. " +
+                                "Cannot safely fall back to command-line arguments due to CreateProcess length limits.",
+                            e,
+                        )
+                    }
+                    logger.warn("[aotCache] Failed to create @argfile, falling back to direct Java args: ${e.message}")
+                    listOf(javaExe) + javaArgs
+                }
 
-        val logFile = File.createTempFile("nucleus-aot-", ".log")
-        val processBuilder =
-            ProcessBuilder(args)
-                .directory(appDir)
-                .redirectErrorStream(true)
-                .redirectOutput(logFile)
+            val logFile = createAotTempFileWithFallback("nucleus-aot-", ".log", candidateDirs)
+            var xvfbProcess: Process? = null
+            try {
+                val processBuilder =
+                    ProcessBuilder(javaLauncherArgs)
+                        .directory(appDir)
+                        .redirectErrorStream(true)
+                        .redirectOutput(logFile)
 
-        val isLinux = System.getProperty("os.name").lowercase().contains("linux")
-        val needsXvfb = isLinux && System.getenv("DISPLAY").isNullOrEmpty()
+                val isLinux = System.getProperty("os.name").lowercase().contains("linux")
+                val needsXvfb = isLinux && System.getenv("DISPLAY").isNullOrEmpty()
+                if (needsXvfb) {
+                    val display = ":99"
+                    xvfbProcess =
+                        ProcessBuilder("Xvfb", display, "-screen", "0", "1280x1024x24")
+                            .redirectErrorStream(true)
+                            .start()
+                    Thread.sleep(1000)
+                    processBuilder.environment()["DISPLAY"] = display
+                    logger.lifecycle("[aotCache] Started Xvfb on $display")
+                }
 
-        var xvfbProcess: Process? = null
-        if (needsXvfb) {
-            val display = ":99"
-            xvfbProcess =
-                ProcessBuilder("Xvfb", display, "-screen", "0", "1280x1024x24")
-                    .redirectErrorStream(true)
-                    .start()
-            Thread.sleep(1000)
-            processBuilder.environment()["DISPLAY"] = display
-            logger.lifecycle("[aotCache] Started Xvfb on $display")
-        }
+                val process = processBuilder.start()
 
-        val process = processBuilder.start()
+                val deadline = System.currentTimeMillis() + safetyTimeoutSeconds.get() * 1000
+                while (process.isAlive && System.currentTimeMillis() < deadline) {
+                    Thread.sleep(500)
+                }
+                if (process.isAlive) {
+                    logger.warn("[aotCache] App did not self-terminate within safety timeout, forcing kill")
+                    process.destroyForcibly()
+                }
 
-        val deadline = System.currentTimeMillis() + safetyTimeoutSeconds.get() * 1000
-        while (process.isAlive && System.currentTimeMillis() < deadline) {
-            Thread.sleep(500)
-        }
-        if (process.isAlive) {
-            logger.warn("[aotCache] App did not self-terminate within safety timeout, forcing kill")
-            process.destroyForcibly()
-        }
+                val exitCode = process.waitFor()
 
-        val exitCode = process.waitFor()
-        xvfbProcess?.destroyForcibly()
+                val output = logFile.readText().takeLast(3000)
+                if (output.isNotBlank()) {
+                    logger.lifecycle("[aotCache] Output (exit $exitCode):\n$output")
+                }
 
-        val output = logFile.readText().takeLast(3000)
-        if (output.isNotBlank()) {
-            logger.lifecycle("[aotCache] Output (exit $exitCode):\n$output")
-        }
-        logFile.delete()
-
-        // Clean up JVM crash dumps
-        appDir.listFiles()?.filter { it.name.startsWith("hs_err_pid") }?.forEach { hsErr ->
-            logger.lifecycle("[aotCache] JVM crash dump: ${hsErr.name}")
-            // Only read text-based .log files; .mdmp files are binary minidumps
-            // that can be hundreds of MB and would cause OOM with readText()
-            if (hsErr.extension == "log") {
-                logger.lifecycle(hsErr.readText().take(2000))
+                // Clean up JVM crash dumps
+                appDir.listFiles()?.filter { it.name.startsWith("hs_err_pid") }?.forEach { hsErr ->
+                    logger.lifecycle("[aotCache] JVM crash dump: ${hsErr.name}")
+                    // Only read text-based .log files; .mdmp files are binary minidumps
+                    // that can be hundreds of MB and would cause OOM with readText()
+                    if (hsErr.extension == "log") {
+                        logger.lifecycle(hsErr.readText().take(2000))
+                    }
+                    hsErr.delete()
+                }
+            } finally {
+                xvfbProcess?.destroyForcibly()
+                logFile.delete()
             }
-            hsErr.delete()
+        } finally {
+            argFile?.delete()
         }
     }
 

--- a/plugin-build/plugin/src/test/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AotArgFileSupportTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/io/github/kdroidfilter/nucleus/desktop/application/tasks/AotArgFileSupportTest.kt
@@ -1,0 +1,121 @@
+package io.github.kdroidfilter.nucleus.desktop.application.tasks
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class AotArgFileSupportTest {
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    @Test
+    fun `buildAotJavaArgs preserves expected argument order`() {
+        val aotCacheFile = tmpDir.newFile("app.aot")
+        val args =
+            buildAotJavaArgs(
+                classpath = "/tmp/lib/a.jar:/tmp/lib/b.jar",
+                javaOptions = listOf("-Xmx1g", "-Dfoo=bar"),
+                mainClass = "com.example.Main",
+                aotCacheFile = aotCacheFile,
+            )
+
+        assertEquals("-XX:AOTCacheOutput=${aotCacheFile.absolutePath}", args[0])
+        assertEquals("-Dnucleus.aot.mode=training", args[1])
+        assertEquals("-cp", args[2])
+        assertEquals("/tmp/lib/a.jar:/tmp/lib/b.jar", args[3])
+        assertEquals("-Xmx1g", args[4])
+        assertEquals("-Dfoo=bar", args[5])
+        assertEquals("com.example.Main", args[6])
+    }
+
+    @Test
+    fun `escapeArgForArgFile quotes and escapes whitespace quotes and backslashes`() {
+        val escaped = escapeArgForArgFile("-Dfoo=\"C:\\Program Files\\Nucleus\"")
+
+        assertEquals("\"-Dfoo=\\\"C:\\\\Program Files\\\\Nucleus\\\"\"", escaped)
+    }
+
+    @Test
+    fun `escapeArgForArgFile quotes empty string`() {
+        assertEquals("\"\"", escapeArgForArgFile(""))
+    }
+
+    @Test
+    fun `writeJavaArgFile writes utf8 escaped args one per line`() {
+        val file = tmpDir.newFile("nucleus-aot.args")
+        val args =
+            listOf(
+                "-Xmx1g",
+                "-cp",
+                "C:\\Program Files\\Nucleus\\lib\\a.jar;D:\\项目\\b.jar",
+                "-Dfoo=\"a b\"",
+                "com.example.Main",
+            )
+
+        writeJavaArgFile(file, args)
+
+        val lines = file.readLines(Charsets.UTF_8)
+        assertEquals(args.size, lines.size)
+        assertEquals("-Xmx1g", lines[0])
+        assertEquals("-cp", lines[1])
+        assertEquals("\"C:\\\\Program Files\\\\Nucleus\\\\lib\\\\a.jar;D:\\\\项目\\\\b.jar\"", lines[2])
+        assertEquals("\"-Dfoo=\\\"a b\\\"\"", lines[3])
+        assertEquals("com.example.Main", lines[4])
+    }
+
+    @Test
+    fun `writeJavaArgFile escapes windows path with backslashes but no spaces`() {
+        val file = tmpDir.newFile("nucleus-aot-nospace.args")
+
+        writeJavaArgFile(file, listOf("C:\\Windows\\System32"))
+
+        val lines = file.readLines(Charsets.UTF_8)
+        assertEquals(1, lines.size)
+        assertEquals("\"C:\\\\Windows\\\\System32\"", lines[0])
+    }
+
+    @Test
+    fun `escapeArgForArgFile rejects newline characters`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            escapeArgForArgFile("line1\nline2")
+        }
+    }
+
+    @Test
+    fun `buildAotTempFileCandidateDirs keeps deterministic order and de-duplicates`() {
+        val appDir = tmpDir.newFolder("app")
+        val aotDir = tmpDir.newFolder("aot")
+        val aotFile = File(aotDir, "app.aot")
+
+        val dirs =
+            buildAotTempFileCandidateDirs(
+                appDir = appDir,
+                aotCacheFile = aotFile,
+                tmpDirPath = appDir.absolutePath,
+            )
+
+        assertEquals(2, dirs.size)
+        assertEquals(appDir.absoluteFile, dirs[0])
+        assertEquals(aotDir.absoluteFile, dirs[1])
+    }
+
+    @Test
+    fun `createAotTempFileWithFallback falls back when earlier directory is not writable`() {
+        val writableDir = tmpDir.newFolder("writable")
+        val impossibleDir = File(writableDir, "missing-parent/child")
+
+        val tempFile =
+            createAotTempFileWithFallback(
+                prefix = "nucleus-aot-",
+                suffix = ".args",
+                candidateDirs = listOf(impossibleDir, writableDir),
+            )
+
+        assertTrue(tempFile.exists())
+        assertEquals(writableDir.absoluteFile, tempFile.parentFile.absoluteFile)
+    }
+}


### PR DESCRIPTION
## 🚀 Description
This PR fixes AOT training startup on Windows by switching from a long inline JVM command to Java `@argfile` launch.

Before:
- `ProcessBuilder` assembled a full Java command including a potentially very long `-cp` value.

After:
- AOT JVM arguments are written to a temporary UTF-8 args file.
- The process is launched with `java @<args-file>`.
- Existing AOT training behavior is preserved (timeout handling, Xvfb flow on Linux, crash dump cleanup, cfg injection).

## 📄 Motivation and Context
On Windows, very long command lines can exceed the `CreateProcessW` limit and fail with:
- `CreateProcess error=206`

This is more likely in `release + enableAotCache` scenarios where classpaths are larger and paths are deeper.
Using Java argument files avoids command-line length pressure while keeping behavior cross-platform and user-transparent.

References:
- [CreateProcessW docs](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw)
- [Java argfile docs](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html)

## 🧪 How Has This Been Tested?
### Automated tests
- `./gradlew :plugin-build:plugin:test --tests "io.github.kdroidfilter.nucleus.desktop.application.tasks.AotArgFileSupportTest"`
- `./gradlew :plugin-build:plugin:check`

### Added unit tests
`AotArgFileSupportTest` verifies:
1. AOT JVM args assembly order/content remains correct.
2. Argfile escaping handles whitespace, quotes, and backslashes.
3. Argfile writing is UTF-8 and supports non-ASCII paths + quoted JVM properties.

### Manual verification plan (recommended for reviewer)
1. On Windows, enable `enableAotCache=true`.
2. Use a long workspace path / large dependency set.
3. Run `packageReleaseDistributionForCurrentOS`.
4. Confirm no `CreateProcess error=206` and `app.aot` is generated and injected.

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.