### PR TITLE
feat(window): add fill-center title bar policy and BasicTitleBar APIs

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBarImpl.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBarImpl.kt
@@ -17,6 +17,7 @@ fun DecoratedDialogScope.DialogTitleBarImpl(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: LayoutDirection = LocalLayoutDirection.current,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
     onPlace: (() -> Unit)? = null,
     backgroundContent: @Composable () -> Unit = {},
@@ -30,10 +31,36 @@ fun DecoratedDialogScope.DialogTitleBarImpl(
         gradientStartColor = gradientStartColor,
         style = style,
         controlButtonsDirection = controlButtonsDirection,
+        layoutPolicy = layoutPolicy,
         applyTitleBar = applyTitleBar,
         onPlace = onPlace,
         backgroundContent = backgroundContent,
     ) { _ ->
         content(dialogState)
     }
+}
+
+@Suppress("FunctionNaming", "LongParameterList")
+@Composable
+fun DecoratedDialogScope.DialogTitleBarImpl(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: LayoutDirection = LocalLayoutDirection.current,
+    applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+    onPlace: (() -> Unit)? = null,
+    backgroundContent: @Composable () -> Unit = {},
+    content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
+) {
+    DialogTitleBarImpl(
+        modifier = modifier,
+        gradientStartColor = gradientStartColor,
+        style = style,
+        controlButtonsDirection = controlButtonsDirection,
+        layoutPolicy = TitleBarLayoutPolicy.Default,
+        applyTitleBar = applyTitleBar,
+        onPlace = onPlace,
+        backgroundContent = backgroundContent,
+        content = content,
+    )
 }

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarCore.kt
@@ -24,30 +24,23 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.layout.Measurable
-import androidx.compose.ui.layout.MeasurePolicy
-import androidx.compose.ui.layout.MeasureResult
-import androidx.compose.ui.layout.MeasureScope
-import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.ParentDataModifierNode
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.offset
 import io.github.kdroidfilter.nucleus.core.runtime.Platform
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
 import java.awt.Window
-import kotlin.math.max
 
 private const val GRADIENT_MIDPOINT = 0.5f
 
@@ -70,6 +63,7 @@ fun GenericTitleBarImpl(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: LayoutDirection = LocalLayoutDirection.current,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
     onPlace: (() -> Unit)? = null,
     backgroundContent: @Composable () -> Unit = {},
@@ -128,16 +122,24 @@ fun GenericTitleBarImpl(
                     scope.content(state)
                 }
             },
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize().onPlaced { onPlace?.invoke() },
             measurePolicy =
-                rememberTitleBarMeasurePolicy(window, state, applyTitleBar, controlButtonsDirection, onPlace),
+                rememberTitleBarMeasurePolicy(
+                    window = window,
+                    state = state,
+                    applyTitleBar = applyTitleBar,
+                    controlButtonsDirection = controlButtonsDirection,
+                    layoutPolicy = layoutPolicy,
+                ),
         )
     }
 }
 
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "LongParameterList")
 @Composable
-fun DecoratedWindowScope.TitleBarImpl(
+fun GenericTitleBarImpl(
+    window: Window,
+    state: DecoratedWindowState,
     modifier: Modifier = Modifier,
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
@@ -154,6 +156,7 @@ fun DecoratedWindowScope.TitleBarImpl(
         gradientStartColor = gradientStartColor,
         style = style,
         controlButtonsDirection = controlButtonsDirection,
+        layoutPolicy = TitleBarLayoutPolicy.Default,
         applyTitleBar = applyTitleBar,
         onPlace = onPlace,
         backgroundContent = backgroundContent,
@@ -161,140 +164,58 @@ fun DecoratedWindowScope.TitleBarImpl(
     )
 }
 
-class TitleBarMeasurePolicy(
-    private val window: Window,
-    private val state: DecoratedWindowState,
-    private val applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
-    private val controlButtonsDirection: LayoutDirection,
-    private val onPlace: (() -> Unit)? = null,
-) : MeasurePolicy {
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
-    override fun MeasureScope.measure(
-        measurables: List<Measurable>,
-        constraints: Constraints,
-    ): MeasureResult {
-        if (measurables.isEmpty()) {
-            return layout(width = constraints.minWidth, height = constraints.minHeight) {}
-        }
-
-        var maxSpaceVertically = constraints.minHeight
-        val contentConstraints = constraints.copy(minWidth = 0, minHeight = 0)
-
-        // Two-pass measurement: End items are measured independently so they
-        // don't reduce the available width for Start/Center items.  This keeps
-        // behaviour consistent with JBR where native caption buttons reserve
-        // space via padding insets rather than Compose item measurement.
-        val endMeasurables = mutableListOf<Pair<Measurable, Placeable>>()
-        val otherMeasurables = mutableListOf<Pair<Measurable, Placeable>>()
-
-        // Pass 1 – measure End-aligned items among themselves
-        var endOccupied = 0
-        for (it in measurables) {
-            val alignment = (it.parentData as? TitleBarChildDataNode)?.horizontalAlignment
-            if (alignment != Alignment.End) continue
-            val placeable = it.measure(contentConstraints.offset(horizontal = -endOccupied))
-            endOccupied += placeable.width
-            maxSpaceVertically = max(maxSpaceVertically, placeable.height)
-            endMeasurables += it to placeable
-        }
-
-        // Pass 2 – measure non-End items with full available width
-        var otherOccupied = 0
-        @Suppress("LoopWithTooManyJumpStatements")
-        for (it in measurables) {
-            val alignment = (it.parentData as? TitleBarChildDataNode)?.horizontalAlignment
-            if (alignment == Alignment.End) continue
-            val placeable = it.measure(contentConstraints.offset(horizontal = -otherOccupied))
-            if (constraints.maxWidth < otherOccupied + placeable.width) break
-            otherOccupied += placeable.width
-            maxSpaceVertically = max(maxSpaceVertically, placeable.height)
-            otherMeasurables += it to placeable
-        }
-
-        val measuredPlaceable = endMeasurables + otherMeasurables
-        val boxHeight = maxSpaceVertically
-
-        val contentPadding = applyTitleBar(boxHeight.toDp(), state)
-
-        // Use Ltr to get absolute left/right insets.
-        val leftInset = contentPadding.calculateLeftPadding(LayoutDirection.Ltr).roundToPx()
-        val rightInset = contentPadding.calculateRightPadding(LayoutDirection.Ltr).roundToPx()
-
-        val occupiedSpaceHorizontally = endOccupied + otherOccupied + leftInset + rightInset
-        val boxWidth = maxOf(constraints.minWidth, occupiedSpaceHorizontally)
-
-        return layout(boxWidth, boxHeight) {
-            onPlace?.invoke()
-
-            val placeableGroups =
-                measuredPlaceable.groupBy { (measurable, _) ->
-                    (measurable.parentData as? TitleBarChildDataNode)?.horizontalAlignment
-                        ?: Alignment.CenterHorizontally
-                }
-
-            val contentIsRtl = layoutDirection == LayoutDirection.Rtl
-            val controlsOnRight = controlButtonsDirection == LayoutDirection.Ltr
-
-            // Absolute occupied-space tracking for each side
-            var leftUsed = leftInset
-            var rightUsed = rightInset
-
-            // End items (control buttons) first — they claim the extreme edge
-            // before Start items, so they always stay at their designated side
-            // even when content and controls share the same edge.
-            placeableGroups[Alignment.End]?.forEach { (_, placeable) ->
-                val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
-                if (controlsOnRight) {
-                    placeable.place(boxWidth - rightUsed - placeable.width, y)
-                    rightUsed += placeable.width
-                } else {
-                    placeable.place(leftUsed, y)
-                    leftUsed += placeable.width
-                }
-            }
-
-            // Start items: leading edge of the content direction
-            placeableGroups[Alignment.Start]?.forEach { (_, placeable) ->
-                val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
-                if (contentIsRtl) {
-                    placeable.place(boxWidth - rightUsed - placeable.width, y)
-                    rightUsed += placeable.width
-                } else {
-                    placeable.place(leftUsed, y)
-                    leftUsed += placeable.width
-                }
-            }
-
-            // Center items: clamped between occupied edges
-            val centerPlaceable = placeableGroups[Alignment.CenterHorizontally].orEmpty()
-            val requiredCenterSpace = centerPlaceable.sumOf { it.second.width }
-            val minX = leftUsed
-            val maxX = boxWidth - rightUsed - requiredCenterSpace
-            var centerX = (boxWidth - requiredCenterSpace) / 2
-
-            if (minX <= maxX) {
-                centerX = centerX.coerceIn(minX, maxX)
-                centerPlaceable.forEach { (_, placeable) ->
-                    val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
-                    placeable.place(centerX, y)
-                    centerX += placeable.width
-                }
-            }
-        }
-    }
+@Suppress("FunctionNaming")
+@Composable
+fun DecoratedWindowScope.TitleBarImpl(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: LayoutDirection = LocalLayoutDirection.current,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
+    applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+    onPlace: (() -> Unit)? = null,
+    backgroundContent: @Composable () -> Unit = {},
+    content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
+) {
+    GenericTitleBarImpl(
+        window = window,
+        state = state,
+        modifier = modifier,
+        gradientStartColor = gradientStartColor,
+        style = style,
+        controlButtonsDirection = controlButtonsDirection,
+        layoutPolicy = layoutPolicy,
+        applyTitleBar = applyTitleBar,
+        onPlace = onPlace,
+        backgroundContent = backgroundContent,
+        content = content,
+    )
 }
 
+@Suppress("FunctionNaming")
 @Composable
-fun rememberTitleBarMeasurePolicy(
-    window: Window,
-    state: DecoratedWindowState,
-    applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+fun DecoratedWindowScope.TitleBarImpl(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: LayoutDirection = LocalLayoutDirection.current,
+    applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
     onPlace: (() -> Unit)? = null,
-): MeasurePolicy =
-    remember(window, state, applyTitleBar, controlButtonsDirection, onPlace) {
-        TitleBarMeasurePolicy(window, state, applyTitleBar, controlButtonsDirection, onPlace)
-    }
+    backgroundContent: @Composable () -> Unit = {},
+    content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
+) {
+    TitleBarImpl(
+        modifier = modifier,
+        gradientStartColor = gradientStartColor,
+        style = style,
+        controlButtonsDirection = controlButtonsDirection,
+        layoutPolicy = TitleBarLayoutPolicy.Default,
+        applyTitleBar = applyTitleBar,
+        onPlace = onPlace,
+        backgroundContent = backgroundContent,
+        content = content,
+    )
+}
 
 @Stable
 interface TitleBarScope {
@@ -309,7 +230,7 @@ interface TitleBarScope {
      * fullscreen on non-notch screens.
      *
      * Standard [clickable][androidx.compose.foundation.clickable] requires a
-     * complete Press → Release (tap) gesture. On some JDK/macOS combinations,
+     * complete Press -> Release (tap) gesture. On some JDK/macOS combinations,
      * the system injects phantom pointer-exit events between Press and Release
      * in fullscreen, which cancels the tap gesture and prevents `onClick` from
      * firing.

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarLayoutPolicy.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarLayoutPolicy.kt
@@ -27,6 +27,7 @@ interface TitleBarLayoutPolicy {
 
     companion object {
         val Default: TitleBarLayoutPolicy = DefaultTitleBarLayoutPolicy
+        val FillCenter: TitleBarLayoutPolicy = FillCenterTitleBarLayoutPolicy
     }
 }
 
@@ -307,4 +308,151 @@ private data class DefaultTitleBarMeasureResult(
     val measuredPlaceables: List<MeasuredLayoutChild>,
     val endOccupied: Int,
     val otherOccupied: Int,
+) : TitleBarMeasureResult
+
+private object FillCenterTitleBarLayoutPolicy : TitleBarLayoutPolicy {
+    override fun MeasureScope.prepareMeasure(scope: TitleBarMeasureScope): TitleBarMeasureResult {
+        var maxSpaceVertically = scope.constraints.minHeight
+        val contentConstraints = scope.constraints.copy(minWidth = 0, minHeight = 0)
+
+        val endMeasurables = mutableListOf<MeasuredLayoutChild>()
+        val startMeasurables = mutableListOf<MeasuredLayoutChild>()
+        var endOccupied = 0
+        var startOccupied = 0
+        var centerCount = 0
+        var centerMeasurable: Measurable? = null
+
+        for (child in scope.children) {
+            when (child.alignment) {
+                Alignment.End -> {
+                    val placeable = child.measurable.measure(contentConstraints.offset(horizontal = -endOccupied))
+                    endOccupied += placeable.width
+                    maxSpaceVertically = max(maxSpaceVertically, placeable.height)
+                    endMeasurables += MeasuredLayoutChild(child, placeable)
+                }
+
+                Alignment.Start -> {
+                    val placeable = child.measurable.measure(contentConstraints.offset(horizontal = -startOccupied))
+                    startOccupied += placeable.width
+                    maxSpaceVertically = max(maxSpaceVertically, placeable.height)
+                    startMeasurables += MeasuredLayoutChild(child, placeable)
+                }
+
+                Alignment.CenterHorizontally -> {
+                    centerCount += 1
+                    centerMeasurable = child.measurable
+                }
+            }
+        }
+
+        require(centerCount <= 1) {
+            "TitleBarLayoutPolicy.FillCenter supports at most one " +
+                "Alignment.CenterHorizontally child, but found $centerCount."
+        }
+
+        if (centerMeasurable != null && scope.constraints.minHeight != scope.constraints.maxHeight) {
+            // Compose only allows a Measurable to be measured once in a layout pass.
+            // Use intrinsic height here and defer the actual measurement to measureTitleBar.
+            val centerHeightCandidate = centerMeasurable.maxIntrinsicHeight(scope.constraints.maxWidth)
+            maxSpaceVertically = max(maxSpaceVertically, centerHeightCandidate)
+        }
+
+        return FillCenterTitleBarMeasureResult(
+            heightPx = maxSpaceVertically,
+            startMeasuredPlaceables = startMeasurables,
+            endMeasuredPlaceables = endMeasurables,
+            startOccupied = startOccupied,
+            endOccupied = endOccupied,
+            centerMeasurable = centerMeasurable,
+        )
+    }
+
+    override fun MeasureScope.measureTitleBar(scope: TitleBarPlacementScope): MeasureResult {
+        val result =
+            scope.measureResult as? FillCenterTitleBarMeasureResult
+                ?: error("TitleBarLayoutPolicy.FillCenter requires FillCenterTitleBarMeasureResult")
+
+        val leftInset = scope.contentPadding.calculateLeftPadding(LayoutDirection.Ltr).roundToPx()
+        val rightInset = scope.contentPadding.calculateRightPadding(LayoutDirection.Ltr).roundToPx()
+        val occupiedSpaceHorizontally = result.startOccupied + result.endOccupied + leftInset + rightInset
+        val boxWidth = maxOf(scope.constraints.minWidth, occupiedSpaceHorizontally)
+
+        val contentIsRtl = scope.layoutDirection == LayoutDirection.Rtl
+        val controlsOnRight = scope.controlButtonsDirection == LayoutDirection.Ltr
+
+        var leftUsed = leftInset
+        var rightUsed = rightInset
+
+        result.endMeasuredPlaceables.forEach { measured ->
+            if (controlsOnRight) {
+                rightUsed += measured.placeable.width
+            } else {
+                leftUsed += measured.placeable.width
+            }
+        }
+
+        result.startMeasuredPlaceables.forEach { measured ->
+            if (contentIsRtl) {
+                rightUsed += measured.placeable.width
+            } else {
+                leftUsed += measured.placeable.width
+            }
+        }
+
+        val centerLaneX = leftUsed
+        val centerLaneWidth = maxOf(0, boxWidth - leftUsed - rightUsed)
+        val centerPlaceable =
+            result.centerMeasurable?.measure(
+                Constraints(
+                    minWidth = centerLaneWidth,
+                    maxWidth = centerLaneWidth,
+                    minHeight = 0,
+                    maxHeight = scope.constraints.maxHeight,
+                ),
+            )
+        val boxHeight = max(result.heightPx, centerPlaceable?.height ?: 0)
+
+        return layout(boxWidth, boxHeight) {
+            var leftPlaced = leftInset
+            var rightPlaced = rightInset
+
+            result.endMeasuredPlaceables.forEach { measured ->
+                val placeable = measured.placeable
+                val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
+                if (controlsOnRight) {
+                    placeable.place(boxWidth - rightPlaced - placeable.width, y)
+                    rightPlaced += placeable.width
+                } else {
+                    placeable.place(leftPlaced, y)
+                    leftPlaced += placeable.width
+                }
+            }
+
+            result.startMeasuredPlaceables.forEach { measured ->
+                val placeable = measured.placeable
+                val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
+                if (contentIsRtl) {
+                    placeable.place(boxWidth - rightPlaced - placeable.width, y)
+                    rightPlaced += placeable.width
+                } else {
+                    placeable.place(leftPlaced, y)
+                    leftPlaced += placeable.width
+                }
+            }
+
+            centerPlaceable?.let { placeable ->
+                val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
+                placeable.place(centerLaneX, y)
+            }
+        }
+    }
+}
+
+private data class FillCenterTitleBarMeasureResult(
+    override val heightPx: Int,
+    val startMeasuredPlaceables: List<MeasuredLayoutChild>,
+    val endMeasuredPlaceables: List<MeasuredLayoutChild>,
+    val startOccupied: Int,
+    val endOccupied: Int,
+    val centerMeasurable: Measurable?,
 ) : TitleBarMeasureResult

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarLayoutPolicy.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBarLayoutPolicy.kt
@@ -1,0 +1,310 @@
+package io.github.kdroidfilter.nucleus.window
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.layout.AlignmentLine
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.offset
+import java.awt.Window
+import kotlin.math.max
+
+@Stable
+interface TitleBarLayoutPolicy {
+    fun MeasureScope.prepareMeasure(scope: TitleBarMeasureScope): TitleBarMeasureResult
+
+    fun MeasureScope.measureTitleBar(scope: TitleBarPlacementScope): MeasureResult
+
+    companion object {
+        val Default: TitleBarLayoutPolicy = DefaultTitleBarLayoutPolicy
+    }
+}
+
+@Stable
+interface TitleBarMeasureScope {
+    val children: List<TitleBarLayoutChild>
+    val constraints: Constraints
+    val layoutDirection: LayoutDirection
+    val controlButtonsDirection: LayoutDirection
+}
+
+@Stable
+interface TitleBarPlacementScope {
+    val children: List<TitleBarLayoutChild>
+    val constraints: Constraints
+    val layoutDirection: LayoutDirection
+    val controlButtonsDirection: LayoutDirection
+    val contentPadding: PaddingValues
+    val measureResult: TitleBarMeasureResult
+}
+
+@Stable
+interface TitleBarMeasureResult {
+    val heightPx: Int
+}
+
+@Stable
+interface TitleBarLayoutChild {
+    val measurable: Measurable
+    val alignment: Alignment.Horizontal
+}
+
+@Composable
+fun rememberTitleBarMeasurePolicy(
+    window: Window,
+    state: DecoratedWindowState,
+    applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+    controlButtonsDirection: LayoutDirection,
+    layoutPolicy: TitleBarLayoutPolicy,
+): MeasurePolicy =
+    remember(window, state, applyTitleBar, controlButtonsDirection, layoutPolicy) {
+        TitleBarLayoutAdapterMeasurePolicy(
+            state = state,
+            applyTitleBar = applyTitleBar,
+            controlButtonsDirection = controlButtonsDirection,
+            layoutPolicy = layoutPolicy,
+        )
+    }
+
+@Composable
+fun rememberTitleBarMeasurePolicy(
+    window: Window,
+    state: DecoratedWindowState,
+    applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+    controlButtonsDirection: LayoutDirection = LocalLayoutDirection.current,
+    onPlace: (() -> Unit)? = null,
+): MeasurePolicy =
+    remember(window, state, applyTitleBar, controlButtonsDirection, onPlace) {
+        TitleBarMeasurePolicy(
+            window = window,
+            state = state,
+            applyTitleBar = applyTitleBar,
+            controlButtonsDirection = controlButtonsDirection,
+            onPlace = onPlace,
+        )
+    }
+
+class TitleBarMeasurePolicy(
+    window: Window,
+    private val state: DecoratedWindowState,
+    private val applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+    private val controlButtonsDirection: LayoutDirection,
+    private val onPlace: (() -> Unit)? = null,
+) : MeasurePolicy {
+    private val delegate =
+        TitleBarLayoutAdapterMeasurePolicy(
+            state = state,
+            applyTitleBar = applyTitleBar,
+            controlButtonsDirection = controlButtonsDirection,
+            layoutPolicy = TitleBarLayoutPolicy.Default,
+        )
+
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult {
+        val measureResult = with(delegate) { measure(measurables, constraints) }
+        return object : MeasureResult {
+            override val width: Int = measureResult.width
+            override val height: Int = measureResult.height
+            override val alignmentLines: Map<AlignmentLine, Int> = measureResult.alignmentLines
+
+            override fun placeChildren() {
+                measureResult.placeChildren()
+                onPlace?.invoke()
+            }
+        }
+    }
+}
+
+private class TitleBarLayoutAdapterMeasurePolicy(
+    private val state: DecoratedWindowState,
+    private val applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+    private val controlButtonsDirection: LayoutDirection,
+    private val layoutPolicy: TitleBarLayoutPolicy,
+) : MeasurePolicy {
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult {
+        if (measurables.isEmpty()) {
+            return layout(width = constraints.minWidth, height = constraints.minHeight) {}
+        }
+
+        val children =
+            measurables.map { measurable ->
+                TitleBarLayoutChildImpl(
+                    measurable = measurable,
+                    alignment =
+                        (measurable.parentData as? TitleBarChildDataNode)?.horizontalAlignment
+                            ?: Alignment.CenterHorizontally,
+                )
+            }
+
+        val prepareScope =
+            TitleBarMeasureScopeImpl(
+                children = children,
+                constraints = constraints,
+                layoutDirection = layoutDirection,
+                controlButtonsDirection = controlButtonsDirection,
+            )
+        val measureResult = with(layoutPolicy) { prepareMeasure(prepareScope) }
+        val contentPadding = applyTitleBar(measureResult.heightPx.toDp(), state)
+
+        val placementScope =
+            TitleBarPlacementScopeImpl(
+                children = children,
+                constraints = constraints,
+                layoutDirection = layoutDirection,
+                controlButtonsDirection = controlButtonsDirection,
+                contentPadding = contentPadding,
+                measureResult = measureResult,
+            )
+        return with(layoutPolicy) { measureTitleBar(placementScope) }
+    }
+}
+
+private data class TitleBarLayoutChildImpl(
+    override val measurable: Measurable,
+    override val alignment: Alignment.Horizontal,
+) : TitleBarLayoutChild
+
+private data class TitleBarMeasureScopeImpl(
+    override val children: List<TitleBarLayoutChild>,
+    override val constraints: Constraints,
+    override val layoutDirection: LayoutDirection,
+    override val controlButtonsDirection: LayoutDirection,
+) : TitleBarMeasureScope
+
+private data class TitleBarPlacementScopeImpl(
+    override val children: List<TitleBarLayoutChild>,
+    override val constraints: Constraints,
+    override val layoutDirection: LayoutDirection,
+    override val controlButtonsDirection: LayoutDirection,
+    override val contentPadding: PaddingValues,
+    override val measureResult: TitleBarMeasureResult,
+) : TitleBarPlacementScope
+
+private data class MeasuredLayoutChild(
+    val child: TitleBarLayoutChild,
+    val placeable: Placeable,
+)
+
+private object DefaultTitleBarLayoutPolicy : TitleBarLayoutPolicy {
+    override fun MeasureScope.prepareMeasure(scope: TitleBarMeasureScope): TitleBarMeasureResult {
+        var maxSpaceVertically = scope.constraints.minHeight
+        val contentConstraints = scope.constraints.copy(minWidth = 0, minHeight = 0)
+
+        // Two-pass measurement: End items are measured independently so they
+        // do not reduce the available width for Start/Center items.
+        val endMeasurables = mutableListOf<MeasuredLayoutChild>()
+        val otherMeasurables = mutableListOf<MeasuredLayoutChild>()
+
+        var endOccupied = 0
+        for (child in scope.children) {
+            if (child.alignment != Alignment.End) continue
+            val placeable = child.measurable.measure(contentConstraints.offset(horizontal = -endOccupied))
+            endOccupied += placeable.width
+            maxSpaceVertically = max(maxSpaceVertically, placeable.height)
+            endMeasurables += MeasuredLayoutChild(child, placeable)
+        }
+
+        var otherOccupied = 0
+        @Suppress("LoopWithTooManyJumpStatements")
+        for (child in scope.children) {
+            if (child.alignment == Alignment.End) continue
+            val placeable = child.measurable.measure(contentConstraints.offset(horizontal = -otherOccupied))
+            if (scope.constraints.maxWidth < otherOccupied + placeable.width) break
+            otherOccupied += placeable.width
+            maxSpaceVertically = max(maxSpaceVertically, placeable.height)
+            otherMeasurables += MeasuredLayoutChild(child, placeable)
+        }
+
+        return DefaultTitleBarMeasureResult(
+            heightPx = maxSpaceVertically,
+            measuredPlaceables = endMeasurables + otherMeasurables,
+            endOccupied = endOccupied,
+            otherOccupied = otherOccupied,
+        )
+    }
+
+    override fun MeasureScope.measureTitleBar(scope: TitleBarPlacementScope): MeasureResult {
+        val result =
+            scope.measureResult as? DefaultTitleBarMeasureResult
+                ?: error("TitleBarLayoutPolicy.Default requires DefaultTitleBarMeasureResult")
+
+        val leftInset = scope.contentPadding.calculateLeftPadding(LayoutDirection.Ltr).roundToPx()
+        val rightInset = scope.contentPadding.calculateRightPadding(LayoutDirection.Ltr).roundToPx()
+
+        val occupiedSpaceHorizontally = result.endOccupied + result.otherOccupied + leftInset + rightInset
+        val boxWidth = maxOf(scope.constraints.minWidth, occupiedSpaceHorizontally)
+        val boxHeight = result.heightPx
+
+        return layout(boxWidth, boxHeight) {
+            val placeableGroups = result.measuredPlaceables.groupBy { it.child.alignment }
+
+            val contentIsRtl = scope.layoutDirection == LayoutDirection.Rtl
+            val controlsOnRight = scope.controlButtonsDirection == LayoutDirection.Ltr
+
+            var leftUsed = leftInset
+            var rightUsed = rightInset
+
+            placeableGroups[Alignment.End].orEmpty().forEach { measured ->
+                val placeable = measured.placeable
+                val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
+                if (controlsOnRight) {
+                    placeable.place(boxWidth - rightUsed - placeable.width, y)
+                    rightUsed += placeable.width
+                } else {
+                    placeable.place(leftUsed, y)
+                    leftUsed += placeable.width
+                }
+            }
+
+            placeableGroups[Alignment.Start].orEmpty().forEach { measured ->
+                val placeable = measured.placeable
+                val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
+                if (contentIsRtl) {
+                    placeable.place(boxWidth - rightUsed - placeable.width, y)
+                    rightUsed += placeable.width
+                } else {
+                    placeable.place(leftUsed, y)
+                    leftUsed += placeable.width
+                }
+            }
+
+            val centerPlaceables = placeableGroups[Alignment.CenterHorizontally].orEmpty()
+            val requiredCenterSpace = centerPlaceables.sumOf { it.placeable.width }
+            val minX = leftUsed
+            val maxX = boxWidth - rightUsed - requiredCenterSpace
+            var centerX = (boxWidth - requiredCenterSpace) / 2
+
+            if (minX <= maxX) {
+                centerX = centerX.coerceIn(minX, maxX)
+                centerPlaceables.forEach { measured ->
+                    val placeable = measured.placeable
+                    val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
+                    placeable.place(centerX, y)
+                    centerX += placeable.width
+                }
+            }
+        }
+    }
+}
+
+private data class DefaultTitleBarMeasureResult(
+    override val heightPx: Int,
+    val measuredPlaceables: List<MeasuredLayoutChild>,
+    val endOccupied: Int,
+    val otherOccupied: Int,
+) : TitleBarMeasureResult

--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlsSide.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlsSide.kt
@@ -1,0 +1,11 @@
+package io.github.kdroidfilter.nucleus.window
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+enum class WindowControlsSide {
+    Start,
+    End,
+    Unspecified,
+}
+
+val LocalWindowControlsSide = staticCompositionLocalOf { WindowControlsSide.Unspecified }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
@@ -25,6 +25,7 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
@@ -46,6 +47,7 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
             gradientStartColor = gradientStartColor,
             style = linuxStyle,
             controlButtonsDirection = controlDir,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { _, _ ->
                 val padding =
                     if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
@@ -2,6 +2,7 @@ package io.github.kdroidfilter.nucleus.window
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -9,6 +10,7 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
 import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
@@ -27,29 +29,35 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
     val dialogState = state
+    val controlDir = controlButtonsDirection.resolve()
+    val controlsSide = if (controlDir == LayoutDirection.Rtl) WindowControlsSide.Start else WindowControlsSide.End
 
-    DialogTitleBarImpl(
-        modifier =
-            modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
-                if (
-                    this.currentEvent.button == PointerButton.Primary &&
-                    this.currentEvent.changes.any { changed -> !changed.isConsumed }
-                ) {
-                    JBR.getWindowMove()?.startMovingTogetherWithMouse(window, MouseEvent.BUTTON1)
-                }
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        DialogTitleBarImpl(
+            modifier =
+                modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+                    if (
+                        this.currentEvent.button == PointerButton.Primary &&
+                        this.currentEvent.changes.any { changed -> !changed.isConsumed }
+                    ) {
+                        JBR.getWindowMove()?.startMovingTogetherWithMouse(window, MouseEvent.BUTTON1)
+                    }
+                },
+            gradientStartColor = gradientStartColor,
+            style = linuxStyle,
+            controlButtonsDirection = controlDir,
+            applyTitleBar = { _, _ ->
+                val padding =
+                    if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
+                        PaddingValues(end = 4.dp)
+                    } else {
+                        PaddingValues(0.dp)
+                    }
+                padding
             },
-        gradientStartColor = gradientStartColor,
-        style = linuxStyle,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { _, _ ->
-            if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
-                PaddingValues(end = 4.dp)
-            } else {
-                PaddingValues(0.dp)
-            }
-        },
-    ) { _ ->
-        DialogCloseButton(window, dialogState, linuxStyle)
-        content(dialogState)
+        ) { _ ->
+            DialogCloseButton(window, dialogState, linuxStyle)
+            content(dialogState)
+        }
     }
 }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
@@ -20,6 +20,7 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
@@ -36,6 +37,7 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
             gradientStartColor = gradientStartColor,
             style = style,
             controlButtonsDirection = controlDir,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { height, _ ->
                 titleBar.putProperty("controls.rtl", isRtl)
                 titleBar.height = height.value

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
@@ -2,6 +2,7 @@ package io.github.kdroidfilter.nucleus.window
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,18 +28,21 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
 
     val controlDir = controlButtonsDirection.resolve()
     val isRtl = controlDir == LayoutDirection.Rtl
+    val controlsSide = if (isRtl) WindowControlsSide.Start else WindowControlsSide.End
 
-    DialogTitleBarImpl(
-        modifier = modifier,
-        gradientStartColor = gradientStartColor,
-        style = style,
-        controlButtonsDirection = controlDir,
-        applyTitleBar = { height, _ ->
-            titleBar.putProperty("controls.rtl", isRtl)
-            titleBar.height = height.value
-            JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
-            PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
-        },
-        content = content,
-    )
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        DialogTitleBarImpl(
+            modifier = modifier,
+            gradientStartColor = gradientStartColor,
+            style = style,
+            controlButtonsDirection = controlDir,
+            applyTitleBar = { height, _ ->
+                titleBar.putProperty("controls.rtl", isRtl)
+                titleBar.height = height.value
+                JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
+                PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
+            },
+            content = content,
+        )
+    }
 }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
@@ -23,6 +23,7 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
@@ -39,6 +40,7 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
             gradientStartColor = gradientStartColor,
             style = style,
             controlButtonsDirection = controlDir,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { height, _ ->
                 titleBar.putProperty("controls.rtl", isRtl)
                 titleBar.height = height.value

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -30,24 +31,29 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
 
     val controlDir = controlButtonsDirection.resolve()
     val isRtl = controlDir == LayoutDirection.Rtl
+    val controlsSide = if (isRtl) WindowControlsSide.Start else WindowControlsSide.End
 
-    DialogTitleBarImpl(
-        modifier = modifier,
-        gradientStartColor = gradientStartColor,
-        style = style,
-        controlButtonsDirection = controlDir,
-        applyTitleBar = { height, _ ->
-            titleBar.putProperty("controls.rtl", isRtl)
-            titleBar.height = height.value
-            titleBar.putProperty("controls.dark", style.colors.background.isDark())
-            JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
-            if (isRtl) {
-                PaddingValues(start = titleBar.rightInset.dp, end = titleBar.leftInset.dp)
-            } else {
-                PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
-            }
-        },
-        backgroundContent = { Spacer(modifier = Modifier.fillMaxSize()) },
-        content = content,
-    )
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        DialogTitleBarImpl(
+            modifier = modifier,
+            gradientStartColor = gradientStartColor,
+            style = style,
+            controlButtonsDirection = controlDir,
+            applyTitleBar = { height, _ ->
+                titleBar.putProperty("controls.rtl", isRtl)
+                titleBar.height = height.value
+                titleBar.putProperty("controls.dark", style.colors.background.isDark())
+                JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
+                val padding =
+                    if (isRtl) {
+                        PaddingValues(start = titleBar.rightInset.dp, end = titleBar.leftInset.dp)
+                    } else {
+                        PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
+                    }
+                padding
+            },
+            backgroundContent = { Spacer(modifier = Modifier.fillMaxSize()) },
+            content = content,
+        )
+    }
 }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
@@ -19,6 +19,26 @@ fun DecoratedDialogScope.DialogTitleBar(
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
+    BasicDialogTitleBar(
+        modifier = modifier,
+        gradientStartColor = gradientStartColor,
+        style = style,
+        controlButtonsDirection = controlButtonsDirection,
+        layoutPolicy = TitleBarLayoutPolicy.Default,
+        content = content,
+    )
+}
+
+@Suppress("FunctionNaming")
+@Composable
+fun DecoratedDialogScope.BasicDialogTitleBar(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
+    content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
+) {
     val dialogTitleBarInfo = LocalDialogTitleBarInfo.current
     val titleBarInfo = remember { TitleBarInfo(dialogTitleBarInfo.title, dialogTitleBarInfo.icon) }
     LaunchedEffect(dialogTitleBarInfo.title) { titleBarInfo.title = dialogTitleBarInfo.title }
@@ -28,11 +48,32 @@ fun DecoratedDialogScope.DialogTitleBar(
     ) {
         when (Platform.Current) {
             Platform.Linux ->
-                LinuxDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+                LinuxDialogTitleBar(
+                    modifier,
+                    gradientStartColor,
+                    style,
+                    controlButtonsDirection,
+                    layoutPolicy,
+                    content,
+                )
             Platform.Windows ->
-                WindowsDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+                WindowsDialogTitleBar(
+                    modifier,
+                    gradientStartColor,
+                    style,
+                    controlButtonsDirection,
+                    layoutPolicy,
+                    content,
+                )
             Platform.MacOS ->
-                MacOSDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+                MacOSDialogTitleBar(
+                    modifier,
+                    gradientStartColor,
+                    style,
+                    controlButtonsDirection,
+                    layoutPolicy,
+                    content,
+                )
             Platform.Unknown ->
                 error("DialogTitleBar is not supported on this platform(${System.getProperty("os.name")})")
         }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
@@ -24,6 +24,7 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
@@ -58,6 +59,7 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
             gradientStartColor,
             linuxStyle,
             controlButtonsDirection = controlDir,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { _, _ ->
                 kdePaddingForButtonLayout()
             },

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
@@ -1,6 +1,7 @@
 package io.github.kdroidfilter.nucleus.window
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -11,6 +12,7 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.platform.LocalViewConfiguration
 import com.jetbrains.JBR
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
+import io.github.kdroidfilter.nucleus.window.utils.linux.rememberLinuxButtonLayout
 import java.awt.Frame
 import java.awt.event.MouseEvent
 
@@ -26,38 +28,43 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
+    val controlDir = controlButtonsDirection.resolve()
+    val controlsOnRight = rememberLinuxButtonLayout().controlsOnRight
+    val controlsSide = if (controlsOnRight) WindowControlsSide.End else WindowControlsSide.Start
 
     var lastPress = 0L
     val viewConfig = LocalViewConfiguration.current
-    TitleBarImpl(
-        modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
-            if (
-                this.currentEvent.button == PointerButton.Primary &&
-                this.currentEvent.changes.any { changed -> !changed.isConsumed }
-            ) {
-                JBR.getWindowMove()?.startMovingTogetherWithMouse(window, MouseEvent.BUTTON1)
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        TitleBarImpl(
+            modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
                 if (
-                    System.currentTimeMillis() - lastPress in
-                    viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis
+                    this.currentEvent.button == PointerButton.Primary &&
+                    this.currentEvent.changes.any { changed -> !changed.isConsumed }
                 ) {
-                    if (state.isMaximized) {
-                        window.extendedState = Frame.NORMAL
-                    } else {
-                        window.extendedState = Frame.MAXIMIZED_BOTH
+                    JBR.getWindowMove()?.startMovingTogetherWithMouse(window, MouseEvent.BUTTON1)
+                    if (
+                        System.currentTimeMillis() - lastPress in
+                        viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis
+                    ) {
+                        if (state.isMaximized) {
+                            window.extendedState = Frame.NORMAL
+                        } else {
+                            window.extendedState = Frame.MAXIMIZED_BOTH
+                        }
                     }
+                    lastPress = System.currentTimeMillis()
                 }
-                lastPress = System.currentTimeMillis()
-            }
-        },
-        gradientStartColor,
-        linuxStyle,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { _, _ ->
-            kdePaddingForButtonLayout()
-        },
-        backgroundContent = backgroundContent,
-    ) { currentState ->
-        WindowControlArea(window, currentState, linuxStyle)
-        content(currentState)
+            },
+            gradientStartColor,
+            linuxStyle,
+            controlButtonsDirection = controlDir,
+            applyTitleBar = { _, _ ->
+                kdePaddingForButtonLayout()
+            },
+            backgroundContent = backgroundContent,
+        ) { currentState ->
+            WindowControlArea(window, currentState, linuxStyle)
+            content(currentState)
+        }
     }
 }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -62,6 +62,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
@@ -100,6 +101,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
             gradientStartColor = gradientStartColor,
             style = style,
             controlButtonsDirection = controlDir,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { height, titleBarState ->
                 titleBar.putProperty("controls.rtl", controlIsRtl)
                 titleBar.height = height.value

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -2,6 +2,7 @@ package io.github.kdroidfilter.nucleus.window
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -91,33 +92,38 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
 
     val controlDir = controlButtonsDirection.resolve()
     val controlIsRtl = controlDir == LayoutDirection.Rtl
+    val controlsSide = if (controlIsRtl) WindowControlsSide.Start else WindowControlsSide.End
 
-    TitleBarImpl(
-        modifier = modifier,
-        gradientStartColor = gradientStartColor,
-        style = style,
-        controlButtonsDirection = controlDir,
-        applyTitleBar = { height, titleBarState ->
-            titleBar.putProperty("controls.rtl", controlIsRtl)
-            titleBar.height = height.value
-            JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        TitleBarImpl(
+            modifier = modifier,
+            gradientStartColor = gradientStartColor,
+            style = style,
+            controlButtonsDirection = controlDir,
+            applyTitleBar = { height, titleBarState ->
+                titleBar.putProperty("controls.rtl", controlIsRtl)
+                titleBar.height = height.value
+                JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
 
-            if (titleBarState.isFullscreen && newFullscreenControls) {
-                if (controlIsRtl) {
-                    PaddingValues(end = 80.dp)
-                } else {
-                    PaddingValues(start = 80.dp)
+                val padding =
+                    if (titleBarState.isFullscreen && newFullscreenControls) {
+                        if (controlIsRtl) {
+                            PaddingValues(end = 80.dp)
+                        } else {
+                            PaddingValues(start = 80.dp)
+                        }
+                    } else {
+                        PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
+                    }
+                padding
+            },
+            onPlace = {
+                if (state.isFullscreen) {
+                    MacUtil.updateFullScreenButtons(window)
                 }
-            } else {
-                PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
-            }
-        },
-        onPlace = {
-            if (state.isFullscreen) {
-                MacUtil.updateFullScreenButtons(window)
-            }
-        },
-        backgroundContent = backgroundContent,
-        content = content,
-    )
+            },
+            backgroundContent = backgroundContent,
+            content = content,
+        )
+    }
 }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,23 +32,27 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
 
     val controlDir = controlButtonsDirection.resolve()
     val controlIsRtl = controlDir == LayoutDirection.Rtl
-    TitleBarImpl(
-        modifier = modifier,
-        gradientStartColor = gradientStartColor,
-        style = style,
-        controlButtonsDirection = controlDir,
-        applyTitleBar = { height, _ ->
-            titleBar.putProperty("controls.rtl", controlIsRtl)
-            titleBar.height = height.value
-            titleBar.putProperty("controls.dark", style.colors.background.isDark())
-            JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
-            PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
-        },
-        backgroundContent = {
-            Spacer(modifier = Modifier.fillMaxSize())
-            backgroundContent()
-        },
-    ) { state ->
-        content(state)
+    val controlsSide = if (controlIsRtl) WindowControlsSide.Start else WindowControlsSide.End
+
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        TitleBarImpl(
+            modifier = modifier,
+            gradientStartColor = gradientStartColor,
+            style = style,
+            controlButtonsDirection = controlDir,
+            applyTitleBar = { height, _ ->
+                titleBar.putProperty("controls.rtl", controlIsRtl)
+                titleBar.height = height.value
+                titleBar.putProperty("controls.dark", style.colors.background.isDark())
+                JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
+                PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
+            },
+            backgroundContent = {
+                Spacer(modifier = Modifier.fillMaxSize())
+                backgroundContent()
+            },
+        ) { state ->
+            content(state)
+        }
     }
 }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
@@ -23,6 +23,7 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
@@ -40,6 +41,7 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
             gradientStartColor = gradientStartColor,
             style = style,
             controlButtonsDirection = controlDir,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { height, _ ->
                 titleBar.putProperty("controls.rtl", controlIsRtl)
                 titleBar.height = height.value

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.kt
@@ -25,13 +25,59 @@ fun DecoratedWindowScope.TitleBar(
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
+    BasicTitleBar(
+        modifier = modifier,
+        gradientStartColor = gradientStartColor,
+        style = style,
+        controlButtonsDirection = controlButtonsDirection,
+        layoutPolicy = TitleBarLayoutPolicy.Default,
+        backgroundContent = backgroundContent,
+        content = content,
+    )
+}
+
+@Suppress("FunctionNaming")
+@Composable
+fun DecoratedWindowScope.BasicTitleBar(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
+    backgroundContent: @Composable () -> Unit = {},
+    content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
+) {
     when (Platform.Current) {
         Platform.Linux ->
-            LinuxTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, backgroundContent, content)
+            LinuxTitleBar(
+                modifier,
+                gradientStartColor,
+                style,
+                controlButtonsDirection,
+                layoutPolicy,
+                backgroundContent,
+                content,
+            )
         Platform.Windows ->
-            WindowsTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, backgroundContent, content)
+            WindowsTitleBar(
+                modifier,
+                gradientStartColor,
+                style,
+                controlButtonsDirection,
+                layoutPolicy,
+                backgroundContent,
+                content,
+            )
         Platform.MacOS ->
-            MacOSTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, backgroundContent, content)
+            MacOSTitleBar(
+                modifier,
+                gradientStartColor,
+                style,
+                controlButtonsDirection,
+                layoutPolicy,
+                backgroundContent,
+                content,
+            )
         Platform.Unknown ->
             error("TitleBar is not supported on this platform(${System.getProperty("os.name")})")
     }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
@@ -27,6 +27,7 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val controlDir = controlButtonsDirection.resolve()
@@ -38,6 +39,7 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
             gradientStartColor,
             style,
             controlDir,
+            layoutPolicy,
             controlsSide,
             content,
         )
@@ -47,6 +49,7 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
             gradientStartColor,
             style,
             controlDir,
+            layoutPolicy,
             controlsSide,
             content,
         )
@@ -63,6 +66,7 @@ private fun DecoratedDialogScope.NativeLinuxDialogTitleBar(
     gradientStartColor: Color,
     style: TitleBarStyle,
     controlButtonsDirection: LayoutDirection,
+    layoutPolicy: TitleBarLayoutPolicy,
     controlsSide: WindowControlsSide,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
 ) {
@@ -75,6 +79,7 @@ private fun DecoratedDialogScope.NativeLinuxDialogTitleBar(
             gradientStartColor = gradientStartColor,
             style = linuxStyle,
             controlButtonsDirection = controlButtonsDirection,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { _, _ ->
                 val padding =
                     if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
@@ -124,6 +129,7 @@ private fun DecoratedDialogScope.FallbackLinuxDialogTitleBar(
     gradientStartColor: Color,
     style: TitleBarStyle,
     controlButtonsDirection: LayoutDirection,
+    layoutPolicy: TitleBarLayoutPolicy,
     controlsSide: WindowControlsSide,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
 ) {
@@ -145,6 +151,7 @@ private fun DecoratedDialogScope.FallbackLinuxDialogTitleBar(
             gradientStartColor = gradientStartColor,
             style = linuxStyle,
             controlButtonsDirection = controlButtonsDirection,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { _, _ ->
                 val padding =
                     if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -11,6 +12,7 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
@@ -27,10 +29,27 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
+    val controlDir = controlButtonsDirection.resolve()
+    val controlsSide = if (controlDir == LayoutDirection.Rtl) WindowControlsSide.Start else WindowControlsSide.End
+
     if (JniLinuxWindowBridge.isLoaded) {
-        NativeLinuxDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+        NativeLinuxDialogTitleBar(
+            modifier,
+            gradientStartColor,
+            style,
+            controlDir,
+            controlsSide,
+            content,
+        )
     } else {
-        FallbackLinuxDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+        FallbackLinuxDialogTitleBar(
+            modifier,
+            gradientStartColor,
+            style,
+            controlDir,
+            controlsSide,
+            content,
+        )
     }
 }
 
@@ -43,51 +62,56 @@ private fun DecoratedDialogScope.NativeLinuxDialogTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
-    controlButtonsDirection: ControlButtonsDirection,
+    controlButtonsDirection: LayoutDirection,
+    controlsSide: WindowControlsSide,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
     val dialogState = state
 
-    DialogTitleBarImpl(
-        modifier = modifier,
-        gradientStartColor = gradientStartColor,
-        style = linuxStyle,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { _, _ ->
-            if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
-                PaddingValues(end = 4.dp)
-            } else {
-                PaddingValues(0.dp)
-            }
-        },
-        backgroundContent = {
-            Spacer(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
-                            if (
-                                this.currentEvent.button == PointerButton.Primary &&
-                                this.currentEvent.changes.any { !it.isConsumed }
-                            ) {
-                                // Initiate native WM move
-                                val mouseLocation = MouseInfo.getPointerInfo()?.location
-                                if (mouseLocation != null) {
-                                    JniLinuxWindowBridge.nativeStartWindowMove(
-                                        window,
-                                        mouseLocation.x,
-                                        mouseLocation.y,
-                                        1,
-                                    )
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        DialogTitleBarImpl(
+            modifier = modifier,
+            gradientStartColor = gradientStartColor,
+            style = linuxStyle,
+            controlButtonsDirection = controlButtonsDirection,
+            applyTitleBar = { _, _ ->
+                val padding =
+                    if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
+                        PaddingValues(end = 4.dp)
+                    } else {
+                        PaddingValues(0.dp)
+                    }
+                padding
+            },
+            backgroundContent = {
+                Spacer(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+                                if (
+                                    this.currentEvent.button == PointerButton.Primary &&
+                                    this.currentEvent.changes.any { !it.isConsumed }
+                                ) {
+                                    // Initiate native WM move
+                                    val mouseLocation = MouseInfo.getPointerInfo()?.location
+                                    if (mouseLocation != null) {
+                                        JniLinuxWindowBridge.nativeStartWindowMove(
+                                            window,
+                                            mouseLocation.x,
+                                            mouseLocation.y,
+                                            1,
+                                        )
+                                    }
                                 }
-                            }
-                        },
-            )
-        },
-    ) { _ ->
-        DialogCloseButton(window, dialogState, linuxStyle)
-        content(dialogState)
+                            },
+                )
+            },
+        ) { _ ->
+            DialogCloseButton(window, dialogState, linuxStyle)
+            content(dialogState)
+        }
     }
 }
 
@@ -99,39 +123,43 @@ private fun DecoratedDialogScope.FallbackLinuxDialogTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
-    controlButtonsDirection: ControlButtonsDirection,
+    controlButtonsDirection: LayoutDirection,
+    controlsSide: WindowControlsSide,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
 ) {
     val linuxStyle = createLinuxTitleBarStyle(style)
     val dialogState = state
 
-    DialogTitleBarImpl(
-        modifier =
-            modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
-                // No double-click behavior for dialogs — just consume primary presses
-                // so the drag handler below can start dragging.
-                if (
-                    this.currentEvent.button == PointerButton.Primary &&
-                    this.currentEvent.changes.any { !it.isConsumed }
-                ) {
-                    // Intentional no-op: drag is handled by the background Spacer.
-                }
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        DialogTitleBarImpl(
+            modifier =
+                modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+                    // No double-click behavior for dialogs, drag is handled by the background Spacer.
+                    if (
+                        this.currentEvent.button == PointerButton.Primary &&
+                        this.currentEvent.changes.any { !it.isConsumed }
+                    ) {
+                        // Intentional no-op.
+                    }
+                },
+            gradientStartColor = gradientStartColor,
+            style = linuxStyle,
+            controlButtonsDirection = controlButtonsDirection,
+            applyTitleBar = { _, _ ->
+                val padding =
+                    if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
+                        PaddingValues(end = 4.dp)
+                    } else {
+                        PaddingValues(0.dp)
+                    }
+                padding
             },
-        gradientStartColor = gradientStartColor,
-        style = linuxStyle,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { _, _ ->
-            if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
-                PaddingValues(end = 4.dp)
-            } else {
-                PaddingValues(0.dp)
-            }
-        },
-        backgroundContent = {
-            Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
-        },
-    ) { _ ->
-        DialogCloseButton(window, dialogState, linuxStyle)
-        content(dialogState)
+            backgroundContent = {
+                Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
+            },
+        ) { _ ->
+            DialogCloseButton(window, dialogState, linuxStyle)
+            content(dialogState)
+        }
     }
 }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
@@ -22,6 +24,10 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
+    val controlDir = controlButtonsDirection.resolve()
+    val controlIsRtl = controlDir == LayoutDirection.Rtl
+    val controlsSide = if (controlIsRtl) WindowControlsSide.Start else WindowControlsSide.End
+
     DisposableEffect(window) {
         onDispose {
             val ptr = JniMacWindowUtil.getWindowPtr(window)
@@ -29,29 +35,32 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
         }
     }
 
-    DialogTitleBarImpl(
-        modifier = modifier.titleBarHitTestHandler(window),
-        gradientStartColor = gradientStartColor,
-        style = style,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { height, _ ->
-            JniMacWindowUtil.applyWindowProperties(window)
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        DialogTitleBarImpl(
+            modifier = modifier.titleBarHitTestHandler(window),
+            gradientStartColor = gradientStartColor,
+            style = style,
+            controlButtonsDirection = controlDir,
+            applyTitleBar = { height, _ ->
+                JniMacWindowUtil.applyWindowProperties(window)
 
-            val ptr = JniMacWindowUtil.getWindowPtr(window)
-            val leftInset =
-                if (ptr != 0L && JniMacTitleBarBridge.isLoaded) {
-                    JniMacTitleBarBridge.nativeApplyTitleBar(ptr, height.value)
-                } else {
-                    @Suppress("MagicNumber")
-                    val shrink = minOf(height.value / 28f, 1f)
-                    @Suppress("MagicNumber")
-                    height.value + 2f * shrink * 20f
-                }
-            PaddingValues(start = leftInset.dp)
-        },
-        backgroundContent = {
-            Spacer(modifier = Modifier.fillMaxSize())
-        },
-        content = content,
-    )
+                val ptr = JniMacWindowUtil.getWindowPtr(window)
+                val leftInset =
+                    if (ptr != 0L && JniMacTitleBarBridge.isLoaded) {
+                        JniMacTitleBarBridge.nativeApplyTitleBar(ptr, height.value)
+                    } else {
+                        @Suppress("MagicNumber")
+                        val shrink = minOf(height.value / 28f, 1f)
+                        @Suppress("MagicNumber")
+                        height.value + 2f * shrink * 20f
+                    }
+                val padding = PaddingValues(start = leftInset.dp)
+                padding
+            },
+            backgroundContent = {
+                Spacer(modifier = Modifier.fillMaxSize())
+            },
+            content = content,
+        )
+    }
 }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
@@ -22,6 +22,7 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val controlDir = controlButtonsDirection.resolve()
@@ -41,6 +42,7 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
             gradientStartColor = gradientStartColor,
             style = style,
             controlButtonsDirection = controlDir,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { height, _ ->
                 JniMacWindowUtil.applyWindowProperties(window)
 

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
@@ -4,11 +4,13 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
@@ -24,6 +26,9 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
+    val controlDir = controlButtonsDirection.resolve()
+    val controlsSide = if (controlDir == LayoutDirection.Rtl) WindowControlsSide.Start else WindowControlsSide.End
+
     if (JniWindowsDecorationBridge.isLoaded) {
         DisposableEffect(window) {
             val hwnd = JniWindowsWindowUtil.getHwnd(window)
@@ -43,17 +48,19 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
         }
     }
 
-    DialogTitleBarImpl(
-        modifier = modifier,
-        gradientStartColor = gradientStartColor,
-        style = style,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { _, _ -> PaddingValues(0.dp) },
-        backgroundContent = {
-            Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
-        },
-    ) { dialogState ->
-        WindowsDialogCloseButton(window, dialogState, style)
-        content(dialogState)
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        DialogTitleBarImpl(
+            modifier = modifier,
+            gradientStartColor = gradientStartColor,
+            style = style,
+            controlButtonsDirection = controlDir,
+            applyTitleBar = { _, _ -> PaddingValues(0.dp) },
+            backgroundContent = {
+                Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
+            },
+        ) { dialogState ->
+            WindowsDialogCloseButton(window, dialogState, style)
+            content(dialogState)
+        }
     }
 }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Windows.kt
@@ -24,6 +24,7 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val controlDir = controlButtonsDirection.resolve()
@@ -54,6 +55,7 @@ internal fun DecoratedDialogScope.WindowsDialogTitleBar(
             gradientStartColor = gradientStartColor,
             style = style,
             controlButtonsDirection = controlDir,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { _, _ -> PaddingValues(0.dp) },
             backgroundContent = {
                 Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.kt
@@ -19,6 +19,26 @@ fun DecoratedDialogScope.DialogTitleBar(
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
+    BasicDialogTitleBar(
+        modifier = modifier,
+        gradientStartColor = gradientStartColor,
+        style = style,
+        controlButtonsDirection = controlButtonsDirection,
+        layoutPolicy = TitleBarLayoutPolicy.Default,
+        content = content,
+    )
+}
+
+@Suppress("FunctionNaming")
+@Composable
+fun DecoratedDialogScope.BasicDialogTitleBar(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
+    content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
+) {
     val dialogTitleBarInfo = LocalDialogTitleBarInfo.current
     val titleBarInfo = remember { TitleBarInfo(dialogTitleBarInfo.title, dialogTitleBarInfo.icon) }
     LaunchedEffect(dialogTitleBarInfo.title) { titleBarInfo.title = dialogTitleBarInfo.title }
@@ -28,11 +48,32 @@ fun DecoratedDialogScope.DialogTitleBar(
     ) {
         when (Platform.Current) {
             Platform.Linux ->
-                LinuxDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+                LinuxDialogTitleBar(
+                    modifier,
+                    gradientStartColor,
+                    style,
+                    controlButtonsDirection,
+                    layoutPolicy,
+                    content,
+                )
             Platform.Windows ->
-                WindowsDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+                WindowsDialogTitleBar(
+                    modifier,
+                    gradientStartColor,
+                    style,
+                    controlButtonsDirection,
+                    layoutPolicy,
+                    content,
+                )
             Platform.MacOS ->
-                MacOSDialogTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, content)
+                MacOSDialogTitleBar(
+                    modifier,
+                    gradientStartColor,
+                    style,
+                    controlButtonsDirection,
+                    layoutPolicy,
+                    content,
+                )
             Platform.Unknown ->
                 error("DialogTitleBar is not supported on this platform(${System.getProperty("os.name")})")
         }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -13,9 +14,11 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 import io.github.kdroidfilter.nucleus.window.utils.linux.JniLinuxWindowBridge
+import io.github.kdroidfilter.nucleus.window.utils.linux.rememberLinuxButtonLayout
 import java.awt.Frame
 import java.awt.MouseInfo
 
@@ -30,10 +33,30 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
+    val controlDir = controlButtonsDirection.resolve()
+    val controlsOnRight = rememberLinuxButtonLayout().controlsOnRight
+    val controlsSide = if (controlsOnRight) WindowControlsSide.End else WindowControlsSide.Start
+
     if (JniLinuxWindowBridge.isLoaded) {
-        NativeLinuxTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, backgroundContent, content)
+        NativeLinuxTitleBar(
+            modifier,
+            gradientStartColor,
+            style,
+            controlDir,
+            controlsSide,
+            backgroundContent,
+            content,
+        )
     } else {
-        FallbackLinuxTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, backgroundContent, content)
+        FallbackLinuxTitleBar(
+            modifier,
+            gradientStartColor,
+            style,
+            controlDir,
+            controlsSide,
+            backgroundContent,
+            content,
+        )
     }
 }
 
@@ -47,7 +70,8 @@ private fun DecoratedWindowScope.NativeLinuxTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
-    controlButtonsDirection: ControlButtonsDirection,
+    controlButtonsDirection: LayoutDirection,
+    controlsSide: WindowControlsSide,
     backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
@@ -66,21 +90,23 @@ private fun DecoratedWindowScope.NativeLinuxTitleBar(
             holder.compositionLocalContext = currentCompositionLocalContext
             holder.titleBarHeight = linuxStyle.metrics.height
             holder.content = {
-                TitleBarImpl(
-                    modifier = modifier,
-                    gradientStartColor = gradientStartColor,
-                    style = linuxStyle,
-                    controlButtonsDirection = controlButtonsDirection.resolve(),
-                    applyTitleBar = { _, _ -> PaddingValues(0.dp) },
-                ) { currentState ->
-                    WindowControlArea(
-                        window = window,
-                        state = currentState,
+                CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+                    TitleBarImpl(
+                        modifier = modifier,
+                        gradientStartColor = gradientStartColor,
                         style = linuxStyle,
-                        isFullscreen = true,
-                        onExitFullscreen = onExitFullscreen,
-                    )
-                    content(currentState)
+                        controlButtonsDirection = controlButtonsDirection,
+                        applyTitleBar = { _, _ -> PaddingValues(0.dp) },
+                    ) { currentState ->
+                        WindowControlArea(
+                            window = window,
+                            state = currentState,
+                            style = linuxStyle,
+                            isFullscreen = true,
+                            onExitFullscreen = onExitFullscreen,
+                        )
+                        content(currentState)
+                    }
                 }
             }
         }
@@ -88,60 +114,65 @@ private fun DecoratedWindowScope.NativeLinuxTitleBar(
     }
 
     // ── Normal title bar (or fullscreen without newFullscreenControls) ──
-    TitleBarImpl(
-        modifier = modifier,
-        gradientStartColor = gradientStartColor,
-        style = linuxStyle,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { _, _ ->
-            kdePaddingForButtonLayout()
-        },
-        backgroundContent = {
-            backgroundContent()
-            Spacer(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
-                            if (
-                                this.currentEvent.button == PointerButton.Primary &&
-                                this.currentEvent.changes.any { !it.isConsumed }
-                            ) {
-                                val now = System.currentTimeMillis()
-                                val elapsed = now - lastPressTime
-                                if (elapsed in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
-                                    // Double-click: toggle maximize
-                                    if (state.isMaximized) {
-                                        window.extendedState = Frame.NORMAL
-                                    } else {
-                                        window.extendedState = Frame.MAXIMIZED_BOTH
-                                    }
-                                } else {
-                                    // Single press: initiate native WM move
-                                    val mouseLocation = MouseInfo.getPointerInfo()?.location
-                                    if (mouseLocation != null) {
-                                        JniLinuxWindowBridge.nativeStartWindowMove(
-                                            window,
-                                            mouseLocation.x,
-                                            mouseLocation.y,
-                                            1,
-                                        )
-                                    }
-                                }
-                                lastPressTime = now
-                            }
-                        },
-            )
-        },
-    ) { currentState ->
-        WindowControlArea(
-            window = window,
-            state = currentState,
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        TitleBarImpl(
+            modifier = modifier,
+            gradientStartColor = gradientStartColor,
             style = linuxStyle,
-            isFullscreen = isNativeFullscreen,
-            onExitFullscreen = onExitFullscreen,
-        )
-        content(currentState)
+            controlButtonsDirection = controlButtonsDirection,
+            applyTitleBar = { _, _ ->
+                kdePaddingForButtonLayout()
+            },
+            backgroundContent = {
+                backgroundContent()
+                Spacer(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+                                if (
+                                    this.currentEvent.button == PointerButton.Primary &&
+                                    this.currentEvent.changes.any { !it.isConsumed }
+                                ) {
+                                    val now = System.currentTimeMillis()
+                                    val elapsed = now - lastPressTime
+                                    if (
+                                        elapsed in
+                                        viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis
+                                    ) {
+                                        // Double-click: toggle maximize
+                                        if (state.isMaximized) {
+                                            window.extendedState = Frame.NORMAL
+                                        } else {
+                                            window.extendedState = Frame.MAXIMIZED_BOTH
+                                        }
+                                    } else {
+                                        // Single press: initiate native WM move
+                                        val mouseLocation = MouseInfo.getPointerInfo()?.location
+                                        if (mouseLocation != null) {
+                                            JniLinuxWindowBridge.nativeStartWindowMove(
+                                                window,
+                                                mouseLocation.x,
+                                                mouseLocation.y,
+                                                1,
+                                            )
+                                        }
+                                    }
+                                    lastPressTime = now
+                                }
+                            },
+                )
+            },
+        ) { currentState ->
+            WindowControlArea(
+                window = window,
+                state = currentState,
+                style = linuxStyle,
+                isFullscreen = isNativeFullscreen,
+                onExitFullscreen = onExitFullscreen,
+            )
+            content(currentState)
+        }
     }
 }
 
@@ -153,7 +184,8 @@ private fun DecoratedWindowScope.FallbackLinuxTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
-    controlButtonsDirection: ControlButtonsDirection,
+    controlButtonsDirection: LayoutDirection,
+    controlsSide: WindowControlsSide,
     backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
@@ -162,37 +194,39 @@ private fun DecoratedWindowScope.FallbackLinuxTitleBar(
 
     var lastPress = 0L
 
-    TitleBarImpl(
-        // Detect double-click to maximize/restore on the title bar area
-        modifier =
-            modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
-                if (
-                    this.currentEvent.button == PointerButton.Primary &&
-                    this.currentEvent.changes.any { !it.isConsumed }
-                ) {
-                    val now = System.currentTimeMillis()
-                    if (now - lastPress in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
-                        if (state.isMaximized) {
-                            window.extendedState = Frame.NORMAL
-                        } else {
-                            window.extendedState = Frame.MAXIMIZED_BOTH
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        TitleBarImpl(
+            // Detect double-click to maximize/restore on the title bar area
+            modifier =
+                modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+                    if (
+                        this.currentEvent.button == PointerButton.Primary &&
+                        this.currentEvent.changes.any { !it.isConsumed }
+                    ) {
+                        val now = System.currentTimeMillis()
+                        if (now - lastPress in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
+                            if (state.isMaximized) {
+                                window.extendedState = Frame.NORMAL
+                            } else {
+                                window.extendedState = Frame.MAXIMIZED_BOTH
+                            }
                         }
+                        lastPress = now
                     }
-                    lastPress = now
-                }
+                },
+            gradientStartColor = gradientStartColor,
+            style = linuxStyle,
+            controlButtonsDirection = controlButtonsDirection,
+            applyTitleBar = { _, _ ->
+                kdePaddingForButtonLayout()
             },
-        gradientStartColor = gradientStartColor,
-        style = linuxStyle,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { _, _ ->
-            kdePaddingForButtonLayout()
-        },
-        backgroundContent = {
-            backgroundContent()
-            Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
-        },
-    ) { currentState ->
-        WindowControlArea(window, currentState, linuxStyle)
-        content(currentState)
+            backgroundContent = {
+                backgroundContent()
+                Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
+            },
+        ) { currentState ->
+            WindowControlArea(window, currentState, linuxStyle)
+            content(currentState)
+        }
     }
 }

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Linux.kt
@@ -30,6 +30,7 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
@@ -43,6 +44,7 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
             gradientStartColor,
             style,
             controlDir,
+            layoutPolicy,
             controlsSide,
             backgroundContent,
             content,
@@ -53,6 +55,7 @@ internal fun DecoratedWindowScope.LinuxTitleBar(
             gradientStartColor,
             style,
             controlDir,
+            layoutPolicy,
             controlsSide,
             backgroundContent,
             content,
@@ -71,6 +74,7 @@ private fun DecoratedWindowScope.NativeLinuxTitleBar(
     gradientStartColor: Color,
     style: TitleBarStyle,
     controlButtonsDirection: LayoutDirection,
+    layoutPolicy: TitleBarLayoutPolicy,
     controlsSide: WindowControlsSide,
     backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
@@ -96,6 +100,7 @@ private fun DecoratedWindowScope.NativeLinuxTitleBar(
                         gradientStartColor = gradientStartColor,
                         style = linuxStyle,
                         controlButtonsDirection = controlButtonsDirection,
+                        layoutPolicy = layoutPolicy,
                         applyTitleBar = { _, _ -> PaddingValues(0.dp) },
                     ) { currentState ->
                         WindowControlArea(
@@ -120,6 +125,7 @@ private fun DecoratedWindowScope.NativeLinuxTitleBar(
             gradientStartColor = gradientStartColor,
             style = linuxStyle,
             controlButtonsDirection = controlButtonsDirection,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { _, _ ->
                 kdePaddingForButtonLayout()
             },
@@ -185,6 +191,7 @@ private fun DecoratedWindowScope.FallbackLinuxTitleBar(
     gradientStartColor: Color,
     style: TitleBarStyle,
     controlButtonsDirection: LayoutDirection,
+    layoutPolicy: TitleBarLayoutPolicy,
     controlsSide: WindowControlsSide,
     backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
@@ -217,6 +224,7 @@ private fun DecoratedWindowScope.FallbackLinuxTitleBar(
             gradientStartColor = gradientStartColor,
             style = linuxStyle,
             controlButtonsDirection = controlButtonsDirection,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { _, _ ->
                 kdePaddingForButtonLayout()
             },

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -42,6 +42,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
@@ -181,6 +182,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
             gradientStartColor = gradientStartColor,
             style = style,
             controlButtonsDirection = controlDir,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { height, titleBarState ->
                 JniMacWindowUtil.applyWindowProperties(window)
 

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -95,6 +96,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
     // correct side. Uses the control buttons direction (decoupled from content).
     val controlDir = controlButtonsDirection.resolve()
     val controlIsRtl = controlDir == LayoutDirection.Rtl
+    val controlsSide = if (controlIsRtl) WindowControlsSide.Start else WindowControlsSide.End
     LaunchedEffect(window, controlIsRtl) {
         val ptr = JniMacWindowUtil.getWindowPtr(window)
         if (ptr != 0L && JniMacTitleBarBridge.isLoaded) {
@@ -150,77 +152,83 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
     val viewConfig = LocalViewConfiguration.current
     var lastPress = 0L
 
-    TitleBarImpl(
-        modifier =
-            Modifier
-                .offset(y = menuBarOffset)
-                .zIndex(if (menuBarOffset > 0.dp) 1f else 0f)
-                .then(modifier)
-                .titleBarHitTestHandler(window)
-                .onPointerEvent(PointerEventType.Press, PointerEventPass.Final) {
-                    if (
-                        this.currentEvent.button == PointerButton.Primary &&
-                        this.currentEvent.changes.any { !it.isConsumed }
-                    ) {
-                        val now = System.currentTimeMillis()
-                        if (now - lastPress in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
-                            val p = JniMacWindowUtil.getWindowPtr(window)
-                            if (p != 0L && JniMacTitleBarBridge.isLoaded) {
-                                JniMacTitleBarBridge.nativePerformTitleBarDoubleClickAction(p)
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        TitleBarImpl(
+            modifier =
+                Modifier
+                    .offset(y = menuBarOffset)
+                    .zIndex(if (menuBarOffset > 0.dp) 1f else 0f)
+                    .then(modifier)
+                    .titleBarHitTestHandler(window)
+                    .onPointerEvent(PointerEventType.Press, PointerEventPass.Final) {
+                        if (
+                            this.currentEvent.button == PointerButton.Primary &&
+                            this.currentEvent.changes.any { !it.isConsumed }
+                        ) {
+                            val now = System.currentTimeMillis()
+                            if (
+                                now - lastPress in
+                                viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis
+                            ) {
+                                val p = JniMacWindowUtil.getWindowPtr(window)
+                                if (p != 0L && JniMacTitleBarBridge.isLoaded) {
+                                    JniMacTitleBarBridge.nativePerformTitleBarDoubleClickAction(p)
+                                }
                             }
+                            lastPress = now
                         }
-                        lastPress = now
-                    }
-                },
-        gradientStartColor = gradientStartColor,
-        style = style,
-        controlButtonsDirection = controlDir,
-        applyTitleBar = { height, titleBarState ->
-            JniMacWindowUtil.applyWindowProperties(window)
+                    },
+            gradientStartColor = gradientStartColor,
+            style = style,
+            controlButtonsDirection = controlDir,
+            applyTitleBar = { height, titleBarState ->
+                JniMacWindowUtil.applyWindowProperties(window)
 
-            val p = JniMacWindowUtil.getWindowPtr(window)
-
-            if (titleBarState.isFullscreen) {
-                if (controlIsRtl) {
-                    PaddingValues(end = 80.dp)
-                } else {
-                    PaddingValues(start = 80.dp)
-                }
-            } else {
-                val buttonInset =
-                    if (p != 0L && JniMacTitleBarBridge.isLoaded) {
-                        JniMacTitleBarBridge.nativeApplyTitleBar(p, height.value)
-                    } else {
-                        @Suppress("MagicNumber")
-                        val shrink = minOf(height.value / 28f, 1f)
-
-                        @Suppress("MagicNumber")
-                        val leftMargin = minOf(height.value / 2f, 20f)
-
-                        @Suppress("MagicNumber")
-                        2f * leftMargin + 2f * shrink * 20f
-                    }
-                if (controlIsRtl) {
-                    PaddingValues(end = buttonInset.dp)
-                } else {
-                    PaddingValues(start = buttonInset.dp)
-                }
-            }
-        },
-        onPlace = {
-            if (state.isFullscreen) {
                 val p = JniMacWindowUtil.getWindowPtr(window)
-                if (p != 0L && JniMacTitleBarBridge.isLoaded) {
-                    JniMacTitleBarBridge.nativeUpdateFullScreenButtons(p)
+                val padding =
+                    if (titleBarState.isFullscreen) {
+                        if (controlIsRtl) {
+                            PaddingValues(end = 80.dp)
+                        } else {
+                            PaddingValues(start = 80.dp)
+                        }
+                    } else {
+                        val buttonInset =
+                            if (p != 0L && JniMacTitleBarBridge.isLoaded) {
+                                JniMacTitleBarBridge.nativeApplyTitleBar(p, height.value)
+                            } else {
+                                @Suppress("MagicNumber")
+                                val shrink = minOf(height.value / 28f, 1f)
+
+                                @Suppress("MagicNumber")
+                                val leftMargin = minOf(height.value / 2f, 20f)
+
+                                @Suppress("MagicNumber")
+                                2f * leftMargin + 2f * shrink * 20f
+                            }
+                        if (controlIsRtl) {
+                            PaddingValues(end = buttonInset.dp)
+                        } else {
+                            PaddingValues(start = buttonInset.dp)
+                        }
+                    }
+                padding
+            },
+            onPlace = {
+                if (state.isFullscreen) {
+                    val p = JniMacWindowUtil.getWindowPtr(window)
+                    if (p != 0L && JniMacTitleBarBridge.isLoaded) {
+                        JniMacTitleBarBridge.nativeUpdateFullScreenButtons(p)
+                    }
                 }
-            }
-        },
-        backgroundContent = {
-            Spacer(modifier = Modifier.fillMaxSize())
-            backgroundContent()
-        },
-        content = content,
-    )
+            },
+            backgroundContent = {
+                Spacer(modifier = Modifier.fillMaxSize())
+                backgroundContent()
+            },
+            content = content,
+        )
+    }
 }
 
 /**

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
@@ -34,6 +34,7 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = LocalTitleBarStyle.current,
     controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
@@ -47,6 +48,7 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
             gradientStartColor,
             style,
             controlDir,
+            layoutPolicy,
             controlsSide,
             backgroundContent,
             content,
@@ -57,6 +59,7 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
             gradientStartColor,
             style,
             controlDir,
+            layoutPolicy,
             controlsSide,
             backgroundContent,
             content,
@@ -72,6 +75,7 @@ private fun DecoratedWindowScope.NativeWindowsTitleBar(
     gradientStartColor: Color,
     style: TitleBarStyle,
     controlButtonsDirection: LayoutDirection,
+    layoutPolicy: TitleBarLayoutPolicy,
     controlsSide: WindowControlsSide,
     backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
@@ -133,6 +137,7 @@ private fun DecoratedWindowScope.NativeWindowsTitleBar(
                         gradientStartColor = gradientStartColor,
                         style = style,
                         controlButtonsDirection = controlButtonsDirection,
+                        layoutPolicy = layoutPolicy,
                         applyTitleBar = { _, _ -> PaddingValues(0.dp) },
                     ) { currentState ->
                         WindowsWindowControlArea(
@@ -157,6 +162,7 @@ private fun DecoratedWindowScope.NativeWindowsTitleBar(
             gradientStartColor = gradientStartColor,
             style = style,
             controlButtonsDirection = controlButtonsDirection,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { height, currentState ->
                 val hwnd = JniWindowsWindowUtil.getHwnd(window)
                 if (hwnd != 0L) {
@@ -220,6 +226,7 @@ private fun DecoratedWindowScope.FallbackWindowsTitleBar(
     gradientStartColor: Color,
     style: TitleBarStyle,
     controlButtonsDirection: LayoutDirection,
+    layoutPolicy: TitleBarLayoutPolicy,
     controlsSide: WindowControlsSide,
     backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
@@ -249,6 +256,7 @@ private fun DecoratedWindowScope.FallbackWindowsTitleBar(
             gradientStartColor = gradientStartColor,
             style = style,
             controlButtonsDirection = controlButtonsDirection,
+            layoutPolicy = layoutPolicy,
             applyTitleBar = { _, _ -> PaddingValues(0.dp) },
             backgroundContent = {
                 backgroundContent()

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.Windows.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.currentCompositionLocalContext
@@ -17,6 +18,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.nucleus.window.styling.LocalTitleBarStyle
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
@@ -35,12 +37,17 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
+    val controlDir = controlButtonsDirection.resolve()
+    val controlIsRtl = controlDir == LayoutDirection.Rtl
+    val controlsSide = if (controlIsRtl) WindowControlsSide.Start else WindowControlsSide.End
+
     if (JniWindowsDecorationBridge.isLoaded) {
         NativeWindowsTitleBar(
             modifier,
             gradientStartColor,
             style,
-            controlButtonsDirection,
+            controlDir,
+            controlsSide,
             backgroundContent,
             content,
         )
@@ -49,7 +56,8 @@ internal fun DecoratedWindowScope.WindowsTitleBar(
             modifier,
             gradientStartColor,
             style,
-            controlButtonsDirection,
+            controlDir,
+            controlsSide,
             backgroundContent,
             content,
         )
@@ -63,7 +71,8 @@ private fun DecoratedWindowScope.NativeWindowsTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
-    controlButtonsDirection: ControlButtonsDirection,
+    controlButtonsDirection: LayoutDirection,
+    controlsSide: WindowControlsSide,
     backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
@@ -118,21 +127,23 @@ private fun DecoratedWindowScope.NativeWindowsTitleBar(
             holder.compositionLocalContext = currentCompositionLocalContext
             holder.titleBarHeight = style.metrics.height
             holder.content = {
-                TitleBarImpl(
-                    modifier = modifier,
-                    gradientStartColor = gradientStartColor,
-                    style = style,
-                    controlButtonsDirection = controlButtonsDirection.resolve(),
-                    applyTitleBar = { _, _ -> PaddingValues(0.dp) },
-                ) { currentState ->
-                    WindowsWindowControlArea(
-                        window = window,
-                        state = currentState,
+                CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+                    TitleBarImpl(
+                        modifier = modifier,
+                        gradientStartColor = gradientStartColor,
                         style = style,
-                        isFullscreen = true,
-                        onExitFullscreen = onExitFullscreen,
-                    )
-                    content(currentState)
+                        controlButtonsDirection = controlButtonsDirection,
+                        applyTitleBar = { _, _ -> PaddingValues(0.dp) },
+                    ) { currentState ->
+                        WindowsWindowControlArea(
+                            window = window,
+                            state = currentState,
+                            style = style,
+                            isFullscreen = true,
+                            onExitFullscreen = onExitFullscreen,
+                        )
+                        content(currentState)
+                    }
                 }
             }
         }
@@ -140,58 +151,63 @@ private fun DecoratedWindowScope.NativeWindowsTitleBar(
     }
 
     // ── Normal title bar (or fullscreen without newFullscreenControls) ──
-    TitleBarImpl(
-        modifier = modifier,
-        gradientStartColor = gradientStartColor,
-        style = style,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { height, _ ->
-            val hwnd = JniWindowsWindowUtil.getHwnd(window)
-            if (hwnd != 0L) {
-                val heightPx = with(density) { height.roundToPx() }
-                JniWindowsDecorationBridge.nativeSetTitleBarHeight(hwnd, heightPx)
-            }
-            PaddingValues(0.dp)
-        },
-        backgroundContent = {
-            backgroundContent()
-            Spacer(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
-                            if (
-                                this.currentEvent.button == PointerButton.Primary &&
-                                this.currentEvent.changes.any { !it.isConsumed }
-                            ) {
-                                val now = System.currentTimeMillis()
-                                val elapsed = now - lastPressTime
-                                if (elapsed in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
-                                    if (state.isMaximized) {
-                                        window.extendedState = Frame.NORMAL
-                                    } else {
-                                        window.extendedState = Frame.MAXIMIZED_BOTH
-                                    }
-                                } else {
-                                    val hwnd = JniWindowsWindowUtil.getHwnd(window)
-                                    if (hwnd != 0L) {
-                                        JniWindowsDecorationBridge.nativeStartDrag(hwnd)
-                                    }
-                                }
-                                lastPressTime = now
-                            }
-                        },
-            )
-        },
-    ) { currentState ->
-        WindowsWindowControlArea(
-            window = window,
-            state = currentState,
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        TitleBarImpl(
+            modifier = modifier,
+            gradientStartColor = gradientStartColor,
             style = style,
-            isFullscreen = isNativeFullscreen,
-            onExitFullscreen = onExitFullscreen,
-        )
-        content(currentState)
+            controlButtonsDirection = controlButtonsDirection,
+            applyTitleBar = { height, currentState ->
+                val hwnd = JniWindowsWindowUtil.getHwnd(window)
+                if (hwnd != 0L) {
+                    val heightPx = with(density) { height.roundToPx() }
+                    JniWindowsDecorationBridge.nativeSetTitleBarHeight(hwnd, heightPx)
+                }
+                PaddingValues(0.dp)
+            },
+            backgroundContent = {
+                backgroundContent()
+                Spacer(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+                                if (
+                                    this.currentEvent.button == PointerButton.Primary &&
+                                    this.currentEvent.changes.any { !it.isConsumed }
+                                ) {
+                                    val now = System.currentTimeMillis()
+                                    val elapsed = now - lastPressTime
+                                    if (
+                                        elapsed in
+                                        viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis
+                                    ) {
+                                        if (state.isMaximized) {
+                                            window.extendedState = Frame.NORMAL
+                                        } else {
+                                            window.extendedState = Frame.MAXIMIZED_BOTH
+                                        }
+                                    } else {
+                                        val hwnd = JniWindowsWindowUtil.getHwnd(window)
+                                        if (hwnd != 0L) {
+                                            JniWindowsDecorationBridge.nativeStartDrag(hwnd)
+                                        }
+                                    }
+                                    lastPressTime = now
+                                }
+                            },
+                )
+            },
+        ) { currentState ->
+            WindowsWindowControlArea(
+                window = window,
+                state = currentState,
+                style = style,
+                isFullscreen = isNativeFullscreen,
+                onExitFullscreen = onExitFullscreen,
+            )
+            content(currentState)
+        }
     }
 }
 
@@ -203,42 +219,45 @@ private fun DecoratedWindowScope.FallbackWindowsTitleBar(
     modifier: Modifier,
     gradientStartColor: Color,
     style: TitleBarStyle,
-    controlButtonsDirection: ControlButtonsDirection,
+    controlButtonsDirection: LayoutDirection,
+    controlsSide: WindowControlsSide,
     backgroundContent: @Composable () -> Unit,
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
     val viewConfig = LocalViewConfiguration.current
     var lastPress = 0L
 
-    TitleBarImpl(
-        modifier =
-            modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
-                if (
-                    this.currentEvent.button == PointerButton.Primary &&
-                    this.currentEvent.changes.any { !it.isConsumed }
-                ) {
-                    val now = System.currentTimeMillis()
-                    if (now - lastPress in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
-                        if (state.isMaximized) {
-                            window.extendedState = Frame.NORMAL
-                        } else {
-                            window.extendedState = Frame.MAXIMIZED_BOTH
+    CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
+        TitleBarImpl(
+            modifier =
+                modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+                    if (
+                        this.currentEvent.button == PointerButton.Primary &&
+                        this.currentEvent.changes.any { !it.isConsumed }
+                    ) {
+                        val now = System.currentTimeMillis()
+                        if (now - lastPress in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
+                            if (state.isMaximized) {
+                                window.extendedState = Frame.NORMAL
+                            } else {
+                                window.extendedState = Frame.MAXIMIZED_BOTH
+                            }
                         }
+                        lastPress = now
                     }
-                    lastPress = now
-                }
+                },
+            gradientStartColor = gradientStartColor,
+            style = style,
+            controlButtonsDirection = controlButtonsDirection,
+            applyTitleBar = { _, _ -> PaddingValues(0.dp) },
+            backgroundContent = {
+                backgroundContent()
+                Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
             },
-        gradientStartColor = gradientStartColor,
-        style = style,
-        controlButtonsDirection = controlButtonsDirection.resolve(),
-        applyTitleBar = { _, _ -> PaddingValues(0.dp) },
-        backgroundContent = {
-            backgroundContent()
-            Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
-        },
-    ) { currentState ->
-        WindowsWindowControlArea(window, currentState, style)
-        content(currentState)
+        ) { currentState ->
+            WindowsWindowControlArea(window, currentState, style)
+            content(currentState)
+        }
     }
 }
 

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.kt
@@ -28,13 +28,59 @@ fun DecoratedWindowScope.TitleBar(
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
 ) {
+    BasicTitleBar(
+        modifier = modifier,
+        gradientStartColor = gradientStartColor,
+        style = style,
+        controlButtonsDirection = controlButtonsDirection,
+        layoutPolicy = TitleBarLayoutPolicy.Default,
+        backgroundContent = backgroundContent,
+        content = content,
+    )
+}
+
+@Suppress("FunctionNaming")
+@Composable
+fun DecoratedWindowScope.BasicTitleBar(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = LocalTitleBarStyle.current,
+    controlButtonsDirection: ControlButtonsDirection = ControlButtonsDirection.Auto,
+    layoutPolicy: TitleBarLayoutPolicy = TitleBarLayoutPolicy.Default,
+    backgroundContent: @Composable () -> Unit = {},
+    content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit = {},
+) {
     when (Platform.Current) {
         Platform.Linux ->
-            LinuxTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, backgroundContent, content)
+            LinuxTitleBar(
+                modifier,
+                gradientStartColor,
+                style,
+                controlButtonsDirection,
+                layoutPolicy,
+                backgroundContent,
+                content,
+            )
         Platform.Windows ->
-            WindowsTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, backgroundContent, content)
+            WindowsTitleBar(
+                modifier,
+                gradientStartColor,
+                style,
+                controlButtonsDirection,
+                layoutPolicy,
+                backgroundContent,
+                content,
+            )
         Platform.MacOS ->
-            MacOSTitleBar(modifier, gradientStartColor, style, controlButtonsDirection, backgroundContent, content)
+            MacOSTitleBar(
+                modifier,
+                gradientStartColor,
+                style,
+                controlButtonsDirection,
+                layoutPolicy,
+                backgroundContent,
+                content,
+            )
         Platform.Unknown ->
             error("TitleBar is not supported on this platform(${System.getProperty("os.name")})")
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@
 ### New Features
 
 - **Reactive GNOME titlebar button layout** — Decorated windows on Linux now read `org.gnome.desktop.wm.preferences` → `button-layout` via GSettings (`libgio` dlopen) to determine which buttons to show and on which side. The layout updates reactively when the user changes it in GNOME Tweaks or via `gsettings set`. Falls back to the default layout on KDE and other desktop environments. New `rememberLinuxButtonLayout()` composable for direct access.
+- **Title bar controls-side plumbing (core/JBR/JNI)** — Add non-breaking `WindowControlsSide` + `LocalWindowControlsSide` infrastructure to share platform-resolved window controls side with core layout. This stage is infrastructure only and does not change current title bar layout behavior.
 - **GraalVM reachability metadata for FileKit and dbus-java** — Apps using FileKit on Linux no longer need manual reachability entries for xdg-desktop-portal file dialogs. Includes new dbus-java conditional library metadata and Linux JDK internals (`UnixSystem`, `NativePRNG$NonBlocking`, `CollationData`).
 - **Windows notification shortcut policies** — New `ShortcutPolicy` enum on `WindowsNotificationCenter` for finer control over Start Menu shortcut creation behavior.
 - **`NucleusApp.appName` and `NucleusApp.aumid` properties** — Expose application name and AUMID for better configuration handling.

--- a/docs/runtime/decorated-window.md
+++ b/docs/runtime/decorated-window.md
@@ -301,6 +301,11 @@ Platform-dispatched title bar composable. Provides a `TitleBarScope` with:
 - `icon: Painter?` — the window icon
 - `Modifier.align(alignment: Alignment.Horizontal)` — positions content within the title bar
 
+!!! note "Advanced: internal controls-side channel"
+    `TitleBar` now exposes an internal cross-module channel through `LocalWindowControlsSide`.
+    It carries the platform-resolved side (`Start` / `End` / `Unspecified`) where window controls are located.
+    Most applications should keep using `TitleBar` normally and do not need to read or provide this local.
+
 ```kotlin
 TitleBar { state ->
     // Left-aligned icon

--- a/example/src/main/kotlin/com/example/demo/FillCenterDemoWindow.kt
+++ b/example/src/main/kotlin/com/example/demo/FillCenterDemoWindow.kt
@@ -1,0 +1,246 @@
+package com.example.demo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.rememberWindowState
+import com.example.demo.gallery.GalleryScreen
+import io.github.kdroidfilter.nucleus.core.runtime.Platform
+import io.github.kdroidfilter.nucleus.window.BasicTitleBar
+import io.github.kdroidfilter.nucleus.window.TitleBarLayoutPolicy
+import io.github.kdroidfilter.nucleus.window.macOSLargeCornerRadius
+import io.github.kdroidfilter.nucleus.window.material.MaterialDecoratedWindow
+import io.github.kdroidfilter.nucleus.window.newFullscreenControls
+
+@Composable
+fun FillCenterDemoWindow(
+    visible: Boolean,
+    onCloseRequest: () -> Unit,
+    seedColor: Color,
+) {
+    if (!visible) return
+
+    val fillCenterWindowState =
+        rememberWindowState(
+            position = WindowPosition.Aligned(Alignment.Center),
+            placement = WindowPlacement.Floating,
+            size = DpSize(1340.dp, 480.dp),
+        )
+
+    MaterialDecoratedWindow(
+        state = fillCenterWindowState,
+        onCloseRequest = onCloseRequest,
+        title = "Fill Title",
+    ) {
+        val demoTabs = remember { buildDemoWindowTabs() }
+        var demoSelectedTab by remember { mutableStateOf("Nucleus") }
+
+        BasicTitleBar(
+            modifier = Modifier.newFullscreenControls().macOSLargeCornerRadius(),
+            layoutPolicy = TitleBarLayoutPolicy.FillCenter,
+        ) { _ ->
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.Start)
+                        .padding(horizontal = 12.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.primaryContainer)
+                        .padding(horizontal = 8.dp, vertical = 3.dp),
+            ) {
+                Text(
+                    text = "Start",
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.End)
+                        .padding(horizontal = 12.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(MaterialTheme.colorScheme.tertiaryContainer)
+                        .padding(horizontal = 8.dp, vertical = 3.dp),
+            ) {
+                Text(
+                    text = "End",
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp)
+                        .padding(horizontal = 4.dp, vertical = 2.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                FillTitleTabs(
+                    tabs = demoTabs,
+                    selectedTab = demoSelectedTab,
+                    onSelect = { demoSelectedTab = it },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+
+        DemoWindowTabContent(
+            selectedTab = demoSelectedTab,
+            seedColor = seedColor,
+            window = window,
+        )
+    }
+}
+
+private fun buildDemoWindowTabs(): List<String> =
+    buildList {
+        addAll(listOf("Nucleus", "Gallery", "Taskbar"))
+        add("Notifications (Common)")
+        if (Platform.Current == Platform.MacOS ||
+            Platform.Current == Platform.Linux ||
+            Platform.Current == Platform.Windows
+        ) {
+            add("Notifications")
+        }
+        if (Platform.Current == Platform.Windows ||
+            Platform.Current == Platform.Linux ||
+            Platform.Current == Platform.MacOS
+        ) {
+            add("Launcher")
+        }
+        add("Media Control")
+        add("Auto-Launch")
+        add("Hotkeys")
+        if (Platform.Current == Platform.MacOS) {
+            add("Menu")
+        }
+    }
+
+@Composable
+private fun io.github.kdroidfilter.nucleus.window.TitleBarScope.FillTitleTabs(
+    tabs: List<String>,
+    selectedTab: String?,
+    onSelect: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.height(28.dp),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        tabs.forEach { tabTitle ->
+            val isSelected = tabTitle == selectedTab
+            val hoverInteraction = remember { MutableInteractionSource() }
+            val isHovered by hoverInteraction.collectIsHoveredAsState()
+
+            val backgroundColor =
+                when {
+                    isSelected -> MaterialTheme.colorScheme.surfaceContainerHigh
+                    isHovered -> MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f)
+                    else -> Color.Transparent
+                }
+
+            val textColor =
+                if (isSelected) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                }
+
+            Box(
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(backgroundColor)
+                        .hoverable(hoverInteraction)
+                        .titleBarClickable { onSelect(tabTitle) }
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = tabTitle,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = textColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DemoWindowTabContent(
+    selectedTab: String,
+    seedColor: Color,
+    window: java.awt.Window,
+) {
+    when (selectedTab) {
+        "Nucleus" -> NucleusContent()
+        "Notifications (Common)" -> CommonNotificationsScreen()
+        "Gallery" -> {
+            val currentDensity = LocalDensity.current
+            CompositionLocalProvider(
+                LocalDensity provides
+                    Density(
+                        density = currentDensity.density * 0.75f,
+                        fontScale = currentDensity.fontScale,
+                    ),
+            ) {
+                GalleryScreen(seedColor = seedColor)
+            }
+        }
+        "Taskbar" -> TaskbarProgressScreen(window)
+        "Notifications" -> {
+            when (Platform.Current) {
+                Platform.MacOS -> NotificationsScreen()
+                Platform.Linux -> LinuxNotificationsScreen()
+                Platform.Windows -> WindowsNotificationsScreen()
+                else -> {}
+            }
+        }
+        "Launcher" -> {
+            when (Platform.Current) {
+                Platform.Windows -> WindowsLauncherScreen(window)
+                Platform.MacOS -> MacOsLauncherScreen()
+                Platform.Linux -> LauncherScreen()
+                else -> {}
+            }
+        }
+        "Media Control" -> MediaControlScreen()
+        "Auto-Launch" -> AutoLaunchScreen()
+        "Hotkeys" -> GlobalHotKeyScreen()
+        "Menu" -> MacOsMenuScreen()
+    }
+}

--- a/example/src/main/kotlin/com/example/demo/Main.kt
+++ b/example/src/main/kotlin/com/example/demo/Main.kt
@@ -136,6 +136,7 @@ fun main(args: Array<String>) {
 
     application {
         var isWindowVisible by remember { mutableStateOf(true) }
+        var isFillCenterWindowVisible by remember { mutableStateOf(false) }
         var restoreRequestCount by remember { mutableStateOf(0) }
         var themeMode by remember { mutableStateOf(ThemeMode.System) }
         var showInfoDialog by remember { mutableStateOf(false) }
@@ -191,7 +192,7 @@ fun main(args: Array<String>) {
                     ) {
                         val tabs =
                             buildList {
-                                addAll(listOf("Nucleus", "Gallery", "Taskbar"))
+                                addAll(listOf("Nucleus", "Fill Title", "Gallery", "Taskbar"))
                                 add("Notifications (Common)")
                                 if (Platform.Current == Platform.MacOS ||
                                     Platform.Current == Platform.Linux ||
@@ -207,7 +208,6 @@ fun main(args: Array<String>) {
                                 }
                                 add("Media Control")
                                 add("Auto-Launch")
-
                                 add("Hotkeys")
                                 if (Platform.Current == Platform.MacOS) {
                                     add("Menu")
@@ -324,6 +324,10 @@ fun main(args: Array<String>) {
 
                         when (selectedTab) {
                             "Nucleus" -> NucleusContent()
+                            "Fill Title" ->
+                                FillCenterDemoEntryTab(
+                                    onOpenDemo = { isFillCenterWindowVisible = true },
+                                )
                             "Notifications (Common)" -> CommonNotificationsScreen()
                             "Gallery" -> {
                                 val currentDensity = LocalDensity.current
@@ -395,13 +399,19 @@ fun main(args: Array<String>) {
                         }
                     }
                 }
+
+                FillCenterDemoWindow(
+                    visible = isFillCenterWindowVisible,
+                    onCloseRequest = { isFillCenterWindowVisible = false },
+                    seedColor = seedColor,
+                )
             }
         }
     }
 }
 
 @Composable
-fun NucleusContent() {
+internal fun NucleusContent() {
     val currentDeepLink by deepLinkUri
     // macOS: the kAEOpenApplication AppleEvent is delivered after NSApp.run()
     // starts processing — which is exactly when this composable first runs.
@@ -498,11 +508,11 @@ fun NucleusContent() {
                 )
             }
 
-            if (updater.isUpdateSupported()) {
-                Column(
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
+            Column(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                if (updater.isUpdateSupported()) {
                     Text(
                         text = "Auto-Update",
                         style = MaterialTheme.typography.titleMedium,
@@ -526,6 +536,17 @@ fun NucleusContent() {
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FillCenterDemoEntryTab(onOpenDemo: () -> Unit) {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Button(onClick = onOpenDemo) {
+                Text("Open Fill Title Window")
             }
         }
     }


### PR DESCRIPTION
## 🚀 Description
This PR introduces a new title bar layout customization layer with a built-in fill-center policy and adds dedicated basic title bar APIs for advanced layout scenarios.

Key updates include:
- Added `TitleBarLayoutPolicy` with `Default` (legacy-compatible) and `FillCenter` behavior.
- Added `BasicTitleBar(...)` and `BasicDialogTitleBar(...)` as low-level entry points.
- Kept existing `TitleBar(...)` / `DialogTitleBar(...)` APIs compatible by delegating to `Basic*` + `Default`.
- Wired `layoutPolicy` through core/JBR/JNI title bar paths.
- Added Fill Title demo window in `example` for behavior validation.
- Updated demo tab interactions in title bar to use `titleBarClickable`, improving macOS fullscreen interaction stability.

## 📄 Motivation and Context
Current title bar center content behavior is primarily wrap-content oriented, which makes "center fills remaining space" scenarios (e.g. tab strips) hard to express consistently.

This change provides a framework-native fill-center layout model while preserving existing behavior and API compatibility:
- No breaking changes for existing title bar usage.
- Advanced users can opt into `FillCenter` via `Basic*` APIs.
- Platform integration details remain internal; only content layout policy is exposed.

## 🧪 How Has This Been Tested?
Build/test checks:
- `./gradlew.bat :decorated-window-core:compileKotlin :decorated-window-jbr:compileKotlin :decorated-window-jni:compileKotlin :example:compileKotlin`  
  Result: **BUILD SUCCESSFUL**

Manual validation:
- Verified Fill Title demo behavior in windowed mode and fullscreen mode.
- Confirmed title bar controls and content still render/behave correctly with new policy plumbing.
- Verified macOS fullscreen demo tab switching no longer relies on plain `clickable` in title bar hit-test-sensitive area.

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
