### PR TITLE
fix(window): correct macOS controls side and Linux dialog close button

### DIFF
--- a/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlArea.kt
+++ b/decorated-window-core/src/main/kotlin/io/github/kdroidfilter/nucleus/window/WindowControlArea.kt
@@ -141,6 +141,8 @@ fun TitleBarScope.DialogCloseButton(
 ) {
     CompositionLocalProvider(LocalLayoutDirection provides LocalControlButtonsDirection.current) {
         val icons = linuxTitleBarIcons()
+        val layout = rememberLinuxButtonLayout()
+        val buttonAlignment = if (layout.controlsOnRight) Alignment.End else Alignment.Start
         val windowState = state.toDecoratedWindowState()
         val closeHover = if (windowState.isActive) icons.closeHoverFocused else icons.closeHover
         val closePressed = if (windowState.isActive) icons.closePressedFocused else icons.closePressed
@@ -153,6 +155,7 @@ fun TitleBarScope.DialogCloseButton(
             iconPressed = closePressed,
             contentDescription = "Close",
             style = style,
+            alignment = buttonAlignment,
             isCloseButton = true,
         )
     }

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
@@ -1,6 +1,5 @@
 package io.github.kdroidfilter.nucleus.window
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -10,11 +9,9 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
 import com.jetbrains.JBR
-import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
+import io.github.kdroidfilter.nucleus.window.utils.linux.rememberLinuxButtonLayout
 import java.awt.event.MouseEvent
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -31,7 +28,8 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
     val linuxStyle = createLinuxTitleBarStyle(style)
     val dialogState = state
     val controlDir = controlButtonsDirection.resolve()
-    val controlsSide = if (controlDir == LayoutDirection.Rtl) WindowControlsSide.Start else WindowControlsSide.End
+    val controlsOnRight = rememberLinuxButtonLayout().controlsOnRight
+    val controlsSide = if (controlsOnRight) WindowControlsSide.End else WindowControlsSide.Start
 
     CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
         DialogTitleBarImpl(
@@ -48,15 +46,7 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
             style = linuxStyle,
             controlButtonsDirection = controlDir,
             layoutPolicy = layoutPolicy,
-            applyTitleBar = { _, _ ->
-                val padding =
-                    if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
-                        PaddingValues(end = 4.dp)
-                    } else {
-                        PaddingValues(0.dp)
-                    }
-                padding
-            },
+            applyTitleBar = { _, _ -> kdePaddingForButtonLayout() },
         ) { _ ->
             DialogCloseButton(window, dialogState, linuxStyle)
             content(dialogState)

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
@@ -29,7 +29,7 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
 
     val controlDir = controlButtonsDirection.resolve()
     val isRtl = controlDir == LayoutDirection.Rtl
-    val controlsSide = if (isRtl) WindowControlsSide.Start else WindowControlsSide.End
+    val controlsSide = if (isRtl) WindowControlsSide.End else WindowControlsSide.Start
 
     CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
         DialogTitleBarImpl(

--- a/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jbr/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -93,7 +93,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
 
     val controlDir = controlButtonsDirection.resolve()
     val controlIsRtl = controlDir == LayoutDirection.Rtl
-    val controlsSide = if (controlIsRtl) WindowControlsSide.Start else WindowControlsSide.End
+    val controlsSide = if (controlIsRtl) WindowControlsSide.End else WindowControlsSide.Start
 
     CompositionLocalProvider(LocalWindowControlsSide provides controlsSide) {
         TitleBarImpl(

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.Linux.kt
@@ -1,6 +1,5 @@
 package io.github.kdroidfilter.nucleus.window
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -13,10 +12,9 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
-import io.github.kdroidfilter.nucleus.core.runtime.LinuxDesktopEnvironment
 import io.github.kdroidfilter.nucleus.window.styling.TitleBarStyle
 import io.github.kdroidfilter.nucleus.window.utils.linux.JniLinuxWindowBridge
+import io.github.kdroidfilter.nucleus.window.utils.linux.rememberLinuxButtonLayout
 import java.awt.MouseInfo
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -31,7 +29,8 @@ internal fun DecoratedDialogScope.LinuxDialogTitleBar(
     content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit = {},
 ) {
     val controlDir = controlButtonsDirection.resolve()
-    val controlsSide = if (controlDir == LayoutDirection.Rtl) WindowControlsSide.Start else WindowControlsSide.End
+    val controlsOnRight = rememberLinuxButtonLayout().controlsOnRight
+    val controlsSide = if (controlsOnRight) WindowControlsSide.End else WindowControlsSide.Start
 
     if (JniLinuxWindowBridge.isLoaded) {
         NativeLinuxDialogTitleBar(
@@ -80,15 +79,7 @@ private fun DecoratedDialogScope.NativeLinuxDialogTitleBar(
             style = linuxStyle,
             controlButtonsDirection = controlButtonsDirection,
             layoutPolicy = layoutPolicy,
-            applyTitleBar = { _, _ ->
-                val padding =
-                    if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
-                        PaddingValues(end = 4.dp)
-                    } else {
-                        PaddingValues(0.dp)
-                    }
-                padding
-            },
+            applyTitleBar = { _, _ -> kdePaddingForButtonLayout() },
             backgroundContent = {
                 Spacer(
                     modifier =
@@ -152,15 +143,7 @@ private fun DecoratedDialogScope.FallbackLinuxDialogTitleBar(
             style = linuxStyle,
             controlButtonsDirection = controlButtonsDirection,
             layoutPolicy = layoutPolicy,
-            applyTitleBar = { _, _ ->
-                val padding =
-                    if (LinuxDesktopEnvironment.Current == LinuxDesktopEnvironment.KDE) {
-                        PaddingValues(end = 4.dp)
-                    } else {
-                        PaddingValues(0.dp)
-                    }
-                padding
-            },
+            applyTitleBar = { _, _ -> kdePaddingForButtonLayout() },
             backgroundContent = {
                 Spacer(modifier = Modifier.fillMaxSize().windowDragHandler(window))
             },

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/DialogTitleBar.MacOS.kt
@@ -27,7 +27,7 @@ internal fun DecoratedDialogScope.MacOSDialogTitleBar(
 ) {
     val controlDir = controlButtonsDirection.resolve()
     val controlIsRtl = controlDir == LayoutDirection.Rtl
-    val controlsSide = if (controlIsRtl) WindowControlsSide.Start else WindowControlsSide.End
+    val controlsSide = if (controlIsRtl) WindowControlsSide.End else WindowControlsSide.Start
 
     DisposableEffect(window) {
         onDispose {

--- a/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
+++ b/decorated-window-jni/src/main/kotlin/io/github/kdroidfilter/nucleus/window/TitleBar.MacOS.kt
@@ -97,7 +97,7 @@ internal fun DecoratedWindowScope.MacOSTitleBar(
     // correct side. Uses the control buttons direction (decoupled from content).
     val controlDir = controlButtonsDirection.resolve()
     val controlIsRtl = controlDir == LayoutDirection.Rtl
-    val controlsSide = if (controlIsRtl) WindowControlsSide.Start else WindowControlsSide.End
+    val controlsSide = if (controlIsRtl) WindowControlsSide.End else WindowControlsSide.Start
     LaunchedEffect(window, controlIsRtl) {
         val ptr = JniMacWindowUtil.getWindowPtr(window)
         if (ptr != 0L && JniMacTitleBarBridge.isLoaded) {


### PR DESCRIPTION

## 🚀 Description
Fix title bar control placement on macOS and Linux dialogs.

This PR:
- corrects `windowControlsSide` on macOS
- makes Linux dialog close buttons follow the system button layout

## 📄 Motivation and Context
`windowControlsSide` was resolved incorrectly on macOS, reporting the controls on the wrong side.

While fixing that, we also found that Linux dialog close buttons were not using the existing system button layout logic, which could place them on the wrong side.

## 🧪 How Has This Been Tested?
Ran:

```powershell
./gradlew :decorated-window-core:compileKotlin :decorated-window-jbr:compileKotlin :decorated-window-jni:compileKotlin :decorated-window-core:ktlintCheck :decorated-window-jbr:ktlintCheck :decorated-window-jni:ktlintCheck
```

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
