### PR TITLE
fix(plugin): publish one merged S3 auto-update manifest per OS

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.13.2"
 asm = "9.9.1"
+awsSdk = "2.45.1"
 batik = "1.19"
 coilVersion = "3.4.0"
 compose = "1.10.3"
@@ -80,4 +81,6 @@ compose-material-icons-extended = { module = "org.jetbrains.compose.material:mat
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 thumbnailator = { module = "net.coobird:thumbnailator", version.ref = "thumbnailator" }
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
+aws-s3 = { module = "software.amazon.awssdk:s3", version.ref = "awsSdk" }
+aws-url-connection-client = { module = "software.amazon.awssdk:url-connection-client", version.ref = "awsSdk" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -26,6 +26,15 @@ dependencies {
     implementation(libs.thumbnailator)
     implementation(libs.asm)
 
+    // S3 auto-update manifest upload. Replaces shelling out to the `aws` CLI.
+    // Force the lightweight JDK-HttpURLConnection client to avoid pulling Netty/Apache
+    // onto the plugin classpath; we only do simple synchronous PutObject calls.
+    implementation(libs.aws.s3) {
+        exclude(group = "software.amazon.awssdk", module = "netty-nio-client")
+        exclude(group = "software.amazon.awssdk", module = "apache-client")
+    }
+    implementation(libs.aws.url.connection.client)
+
     testImplementation(libs.junit)
 }
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/TargetFormat.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/TargetFormat.kt
@@ -60,6 +60,24 @@ enum class TargetFormat(
     val needsPluginUpdateYml: Boolean
         get() = this == Msi || this == Portable
 
+    /**
+     * Whether this format publishes a per-channel auto-update manifest (`<channel><osSuffix>.yml`),
+     * generated either by electron-builder (NSIS, NSIS-Web, DMG, ZIP-on-macOS, AppImage, DEB, RPM)
+     * or by the plugin ([needsPluginUpdateYml]: MSI, Portable).
+     *
+     * Because the manifest name is keyed only on the OS (see [updateYmlFilename]), configuring two or
+     * more of these for the same OS makes their separate electron-builder runs publish to the same
+     * key — so the manifests must be merged before publishing (see `AbstractMergeUpdateYmlTask`).
+     */
+    internal val producesUpdateManifest: Boolean
+        get() =
+            when (this) {
+                Exe, Nsis, NsisWeb, Msi, Portable, Dmg, AppImage, Deb, Rpm -> true
+                // electron-builder treats ZIP as auto-updatable only on macOS (Squirrel.Mac).
+                Zip -> targetOS == OS.MacOS
+                else -> false
+            }
+
     /** Returns the auto-update YML filename for this format and channel. */
     fun updateYmlFilename(channel: ReleaseChannel): String {
         val prefix = channel.id

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlMerger.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlMerger.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal
+
+/**
+ * Merges several electron-builder auto-update manifests into a single manifest whose `files:` list
+ * is the union of all inputs.
+ *
+ * Nucleus packages each Linux [dev.nucleusframework.desktop.application.dsl.TargetFormat]
+ * (Deb, AppImage, …) with its own electron-builder invocation, and electron-builder writes a
+ * single-artifact `<channel>-linux.yml` per run. Because the manifest name is keyed only on the OS
+ * (see `TargetFormat.updateYmlFilename`, which returns `<channel>-linux.yml` for *every* Linux
+ * format), those per-format manifests collide on one key — and whichever format is published last
+ * (the Deb run sorts after the AppImage run) overwrites the others, leaving the manifest with only
+ * the `.deb`. An AppImage client then fetches `<channel>-linux.yml`, finds no AppImage entry, and
+ * the in-app updater throws `NoMatchingFileException`.
+ *
+ * Merging the per-format manifests keeps every format's entry, so each client finds its artifact.
+ */
+internal object UpdateYmlMerger {
+    private data class Entry(
+        val url: String,
+        val sha512: String?,
+        val size: String?,
+        val blockMapSize: String?,
+    )
+
+    private data class ParsedManifest(
+        val version: String?,
+        val releaseDate: String?,
+        val entries: List<Entry>,
+    )
+
+    /**
+     * Merges [manifests] (raw electron-builder `<channel>-*.yml` contents) into one.
+     *
+     * The result lists every distinct `files[].url` across all inputs (deduplicated by url, sorted
+     * for stable output). `version` is taken from the first manifest that declares one; the
+     * top-level `path`/`sha512` mirror the first (sorted) entry, and `releaseDate` is the latest
+     * across inputs.
+     */
+    fun merge(manifests: List<String>): String {
+        require(manifests.isNotEmpty()) { "Cannot merge an empty list of manifests" }
+        val parsed = manifests.map(::parse)
+
+        val version = parsed.firstNotNullOfOrNull { it.version }
+            ?: error("None of the manifests declares a version")
+
+        // Union by url, keeping the first occurrence; then sort for deterministic output.
+        val byUrl = LinkedHashMap<String, Entry>()
+        for (manifest in parsed) {
+            for (entry in manifest.entries) byUrl.putIfAbsent(entry.url, entry)
+        }
+        val entries = byUrl.values.sortedBy { it.url }
+        require(entries.isNotEmpty()) { "None of the manifests lists any files" }
+
+        val releaseDate = parsed.mapNotNull { it.releaseDate }.maxOrNull()
+        val first = entries.first()
+
+        return buildString {
+            appendLine("version: $version")
+            appendLine("files:")
+            for (entry in entries) {
+                appendLine("  - url: ${entry.url}")
+                entry.sha512?.let { appendLine("    sha512: $it") }
+                entry.size?.let { appendLine("    size: $it") }
+                entry.blockMapSize?.let { appendLine("    blockMapSize: $it") }
+            }
+            appendLine("path: ${first.url}")
+            first.sha512?.let { appendLine("sha512: $it") }
+            releaseDate?.let { appendLine("releaseDate: $it") }
+        }
+    }
+
+    private fun parse(manifest: String): ParsedManifest {
+        var version: String? = null
+        var releaseDate: String? = null
+        val entries = mutableListOf<Entry>()
+
+        var inFiles = false
+        var url: String? = null
+        var sha512: String? = null
+        var size: String? = null
+        var blockMapSize: String? = null
+
+        fun flush() {
+            val current = url ?: return
+            entries += Entry(current, sha512, size, blockMapSize)
+            url = null
+            sha512 = null
+            size = null
+            blockMapSize = null
+        }
+
+        for (line in manifest.lines()) {
+            when {
+                line.startsWith("version: ") -> version = line.removePrefix("version: ").trim()
+                line.startsWith("releaseDate: ") -> releaseDate = line.removePrefix("releaseDate: ").trim()
+                line == "files:" -> inFiles = true
+                inFiles && line.startsWith("  - url: ") -> {
+                    flush()
+                    url = line.removePrefix("  - url: ").trim()
+                }
+                inFiles && url != null && line.startsWith("    ") -> {
+                    val field = line.trim()
+                    when {
+                        field.startsWith("sha512: ") -> sha512 = field.removePrefix("sha512: ")
+                        field.startsWith("size: ") -> size = field.removePrefix("size: ")
+                        field.startsWith("blockMapSize: ") -> blockMapSize = field.removePrefix("blockMapSize: ")
+                    }
+                }
+                // A new top-level (column-0) key ends the files section.
+                line.isNotBlank() && !line.startsWith(" ") -> {
+                    flush()
+                    inFiles = false
+                }
+            }
+        }
+        flush()
+        return ParsedManifest(version, releaseDate, entries)
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlPublish.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlPublish.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal
+
+import java.io.File
+
+/**
+ * Pure helpers for the plugin-side publishing of the merged auto-update manifest.
+ *
+ * Nucleus runs a separate electron-builder invocation per packaging format (TargetFormat).
+ * Each run that produces an auto-updatable artifact also generates a single-artifact
+ * `<channel><osSuffix>.yml` (Windows `<channel>.yml`, macOS `<channel>-mac.yml`, Linux
+ * `<channel>-linux.yml`). Because the manifest name is keyed only on the OS, every format of the
+ * same OS resolves to the **same** key — so publishing each per-format manifest independently makes
+ * the last writer clobber the others, leaving the manifest with only one format. A client whose
+ * artifact was dropped then finds no matching entry and the in-app updater throws
+ * `NoMatchingFileException` (and on macOS, where Squirrel.Mac updates from the ZIP, a DMG-only
+ * `latest-mac.yml` breaks updates entirely).
+ *
+ * The fix (see `AbstractMergeUpdateYmlTask` and the `publishAutoUpdate: false` it relies on) lets
+ * electron-builder upload the artifacts but suppresses its per-format manifest upload; the plugin
+ * then merges the per-format manifests with [UpdateYmlMerger] and uploads a single union manifest.
+ * The functions here are the testable seams of that flow.
+ */
+internal object UpdateYmlPublish {
+    /** Environment variable that overrides the publish mode (matches electron-builder's `--publish`). */
+    const val PUBLISH_MODE_ENV = "NUCLEUS_PUBLISH_MODE"
+
+    /**
+     * CI environment variables that, when set to a non-blank value, indicate the current build was
+     * triggered by a git tag. Mirrors electron-builder's own tag detection so the plugin only
+     * uploads the merged manifest when electron-builder actually published the artifacts.
+     */
+    private val CI_TAG_ENV_VARS =
+        listOf(
+            "TRAVIS_TAG",
+            "APPVEYOR_REPO_TAG_NAME",
+            "CIRCLE_TAG",
+            "BITRISE_GIT_TAG",
+            "CI_COMMIT_TAG",
+            "CI_BUILD_TAG",
+        )
+
+    /** A merged manifest plus the filename it should be written/uploaded under. */
+    data class MergedManifest(val fileName: String, val content: String)
+
+    /**
+     * Resolves the electron-builder publish mode the same way
+     * [AbstractElectronBuilderPackageTask][dev.nucleusframework.desktop.application.tasks.AbstractElectronBuilderPackageTask]
+     * does: `never` when no provider is enabled, otherwise env var > Gradle property > DSL value.
+     */
+    fun resolvePublishFlag(
+        anyProviderEnabled: Boolean,
+        envValue: String?,
+        propValue: String?,
+        dslValue: String,
+    ): String {
+        if (!anyProviderEnabled) return "never"
+        if (!envValue.isNullOrBlank()) return envValue
+        if (!propValue.isNullOrBlank()) return propValue
+        return dslValue
+    }
+
+    /**
+     * Whether the plugin should upload the merged manifest, given the resolved [publishFlag] and the
+     * CI environment.
+     *
+     * - `always` → always upload.
+     * - `never` → never upload.
+     * - anything else (i.e. `onTag`) → upload only when a CI tag is detected, matching when
+     *   electron-builder itself publishes. When in doubt this returns `false` so the plugin never
+     *   uploads a manifest pointing at artifacts electron-builder did not publish.
+     */
+    fun shouldPublish(
+        publishFlag: String,
+        ciEnv: Map<String, String?>,
+    ): Boolean =
+        when (publishFlag) {
+            "always" -> true
+            "never" -> false
+            else -> hasCiTag(ciEnv)
+        }
+
+    /** Detects whether [ciEnv] indicates the build was triggered by a git tag. */
+    fun hasCiTag(ciEnv: Map<String, String?>): Boolean {
+        if (CI_TAG_ENV_VARS.any { !ciEnv[it].isNullOrBlank() }) return true
+        val githubRef = ciEnv["GITHUB_REF"]
+        return githubRef != null && githubRef.startsWith("refs/tags/")
+    }
+
+    /**
+     * Builds the S3 object key for [fileName] under the optional [pathPrefix], matching how
+     * electron-builder's S3 publisher lays files out (`<path>/<fileName>`, or just `<fileName>`
+     * when no prefix is configured).
+     */
+    fun s3Key(
+        pathPrefix: String?,
+        fileName: String,
+    ): String {
+        val prefix = pathPrefix?.trim()?.trim('/').orEmpty()
+        return if (prefix.isEmpty()) fileName else "$prefix/$fileName"
+    }
+
+    /**
+     * Discovers the per-format `<channel><osSuffix>.yml` manifests electron-builder (or the plugin)
+     * wrote into each of [outputDirs] and combines those that share a filename into one manifest each
+     * (normally a single channel, e.g. `beta-mac.yml`).
+     *
+     * When only one format produced a given manifest it is returned **verbatim** (electron-builder's
+     * exact bytes, preserving any fields the line-based merger does not model); only an actual
+     * collision (two or more sources for the same filename) is re-serialized via [UpdateYmlMerger].
+     *
+     * Returns an empty list when no manifests are found (e.g. only non-updatable formats ran).
+     */
+    fun discoverAndMerge(outputDirs: List<File>): List<MergedManifest> {
+        val byName = LinkedHashMap<String, MutableList<String>>()
+        for (dir in outputDirs) {
+            val ymls = dir.listFiles()?.filter { it.isFile && UPDATE_YML_NAME.matches(it.name) }.orEmpty()
+            for (yml in ymls.sortedBy { it.name }) {
+                byName.getOrPut(yml.name) { mutableListOf() }.add(yml.readText())
+            }
+        }
+        return byName.map { (name, contents) ->
+            val content = if (contents.size == 1) contents.single() else UpdateYmlMerger.merge(contents)
+            MergedManifest(name, content)
+        }
+    }
+
+    /**
+     * Matches electron-builder update manifests across all platforms and channels, e.g. `latest.yml`
+     * (Windows), `beta-mac.yml`, `alpha-linux.yml`. Anchored to the known channels so it never picks
+     * up electron-builder's own config files (`electron-builder.yml`, `builder-debug.yml`).
+     */
+    private val UPDATE_YML_NAME = Regex("""^(latest|beta|alpha)(-mac|-linux)?\.yml$""")
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
@@ -17,6 +17,7 @@ import dev.nucleusframework.desktop.application.tasks.AbstractGenerateAotCacheTa
 import dev.nucleusframework.desktop.application.tasks.AbstractGenerateAppPropertiesTask
 import dev.nucleusframework.desktop.application.tasks.AbstractJLinkTask
 import dev.nucleusframework.desktop.application.tasks.AbstractJPackageTask
+import dev.nucleusframework.desktop.application.tasks.AbstractMergeUpdateYmlTask
 import dev.nucleusframework.desktop.application.tasks.AbstractNotarizationTask
 import dev.nucleusframework.desktop.application.tasks.AbstractPatchCaCertificatesTask
 import dev.nucleusframework.desktop.application.tasks.AbstractPatchMacJvmTask
@@ -513,6 +514,13 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
     val packageFormats = nonStorePackageFormats + storePackageFormats
     val allNotarizeTasks = nonStoreNotarizeTasks + storeNotarizeTasks
 
+    // When several formats of the current OS publish to S3, electron-builder would have each
+    // per-format run upload its own single-artifact `<channel><osSuffix>.yml` to the same key,
+    // clobbering the others. Suppress those uploads (publishAutoUpdate: false) and publish one
+    // merged manifest instead.
+    val mergeUpdateYml: TaskProvider<AbstractMergeUpdateYmlTask>? =
+        registerUpdateYmlMergeIfNeeded(nonStoreFormats, nonStorePackageFormats)
+
     val notarizeForCurrentOS =
         if (allNotarizeTasks.isNotEmpty()) {
             tasks.register<DefaultTask>(
@@ -532,6 +540,7 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
         ) {
             dependsOn(packageFormats)
             notarizeForCurrentOS?.let { dependsOn(it) }
+            mergeUpdateYml?.let { dependsOn(it) }
         }
 
     if (buildType === app.buildTypes.default) {
@@ -622,6 +631,50 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
         tasks.register<JavaExec>(taskNameAction = "run") {
             configureRunTask(this, commonTasks.prepareAppResources, runProguard, patchMacJvmTask)
         }
+}
+
+/**
+ * Registers a task that merges the per-format auto-update manifests of the current OS and uploads
+ * the union to S3. electron-builder is always told `publishAutoUpdate: false` for S3 (in the
+ * config generator), so the plugin owns the single `<channel><osSuffix>.yml` key that every format
+ * (and arch) shares — for one format it publishes that manifest verbatim, for several their union.
+ *
+ * Returns null when S3 is not enabled, or when no auto-updatable format
+ * (see [TargetFormat.producesUpdateManifest]) is compatible with the current OS — in which case
+ * there is no manifest to publish.
+ */
+private fun JvmApplicationContext.registerUpdateYmlMergeIfNeeded(
+    nonStoreFormats: List<TargetFormat>,
+    nonStorePackageFormats: List<TaskProvider<AbstractElectronBuilderPackageTask>>,
+): TaskProvider<AbstractMergeUpdateYmlTask>? {
+    val s3 = app.nativeDistributions.publish.s3
+    if (!s3.enabled) return null
+
+    val updatableTasks =
+        nonStoreFormats.zip(nonStorePackageFormats)
+            .filter { (format, _) -> format.isCompatibleWithCurrentOS && format.producesUpdateManifest }
+            .map { (_, task) -> task }
+    if (updatableTasks.isEmpty()) return null
+
+    return tasks.register<AbstractMergeUpdateYmlTask>(
+        taskNameAction = "merge",
+        taskNameObject = "updateYml",
+    ) {
+        dependsOn(updatableTasks)
+        perFormatOutputDirs.from(updatableTasks.map { provider -> provider.flatMap { it.destinationDir } })
+        s3Enabled.set(true)
+        // S3 settings are plain DSL `var`s; read them in this (deferred) configure block, where they
+        // are final, and only set the optional properties when present.
+        s3.bucket?.let { s3Bucket.set(it) }
+        s3.region?.let { s3Region.set(it) }
+        s3.path?.let { s3Path.set(it) }
+        s3.acl?.let { s3Acl.set(it) }
+        publishMode.set(NucleusProperties.electronBuilderPublishMode(project.providers))
+        dslPublishMode.set(app.nativeDistributions.publish.publishMode.id)
+        destinationDir.set(
+            app.nativeDistributions.outputBaseDir.map { it.dir("$appDirName/merged-update-yml") },
+        )
+    }
 }
 
 private fun JvmApplicationContext.configureProguardTask(

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -662,7 +662,7 @@ internal class ElectronBuilderConfigGenerator {
         }
     }
 
-    private fun generatePublishConfig(
+    internal fun generatePublishConfig(
         yaml: StringBuilder,
         publish: PublishSettings,
     ) {
@@ -693,6 +693,11 @@ internal class ElectronBuilderConfigGenerator {
             appendIfNotNull(yaml, "    region", s3.region)
             appendIfNotNull(yaml, "    path", s3.path)
             appendIfNotNull(yaml, "    acl", s3.acl)
+            // Several formats (and arches) of the same OS publish to the same `<channel><osSuffix>.yml`
+            // S3 key, so they would overwrite each other. Always suppress electron-builder's per-run
+            // manifest upload and let the plugin publish a single merged manifest instead (the package
+            // artifacts are still uploaded by electron-builder). See AbstractMergeUpdateYmlTask.
+            yaml.appendLine("    publishAutoUpdate: false")
         }
         if (generic.enabled) {
             yaml.appendLine("  - provider: generic")

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -10,6 +10,7 @@ import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
 import dev.nucleusframework.desktop.application.dsl.MacOSSigningSettings
 import dev.nucleusframework.desktop.application.dsl.ReleaseChannel
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import dev.nucleusframework.desktop.application.internal.UpdateYmlPublish
 import dev.nucleusframework.desktop.application.internal.UpdateYmlGenerator
 import dev.nucleusframework.desktop.application.internal.LinuxSigner
 import dev.nucleusframework.desktop.application.internal.LinuxUpdateHelper
@@ -330,27 +331,16 @@ abstract class AbstractElectronBuilderPackageTask
             val publish = distributions?.publish
             val anyProviderEnabled =
                 publish != null && (publish.github.enabled || publish.s3.enabled || publish.generic.enabled)
-            if (!anyProviderEnabled) {
-                logger.info("No publish provider enabled, using publish mode: never")
-                return "never"
-            }
-
-            // Priority: env var > Gradle property > DSL default
-            val envValue = System.getenv("NUCLEUS_PUBLISH_MODE")
-            if (!envValue.isNullOrBlank()) {
-                logger.info("Using publish mode from NUCLEUS_PUBLISH_MODE env var: $envValue")
-                return envValue
-            }
-
-            val propValue = publishMode.orNull
-            if (!propValue.isNullOrBlank()) {
-                logger.info("Using publish mode from Gradle property: $propValue")
-                return propValue
-            }
-
-            val dslValue = publish.publishMode.id
-            logger.info("Using publish mode from DSL: $dslValue")
-            return dslValue
+            // Priority: env var > Gradle property > DSL default (never when no provider enabled).
+            val flag =
+                UpdateYmlPublish.resolvePublishFlag(
+                    anyProviderEnabled = anyProviderEnabled,
+                    envValue = System.getenv(UpdateYmlPublish.PUBLISH_MODE_ENV),
+                    propValue = publishMode.orNull,
+                    dslValue = publish?.publishMode?.id ?: "never",
+                )
+            logger.info("Resolved electron-builder publish mode: $flag")
+            return flag
         }
 
         private fun detectNpx(): File =

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractMergeUpdateYmlTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractMergeUpdateYmlTask.kt
@@ -5,7 +5,6 @@
 
 package dev.nucleusframework.desktop.application.tasks
 
-import dev.nucleusframework.desktop.application.internal.ExternalToolRunner
 import dev.nucleusframework.desktop.application.internal.UpdateYmlPublish
 import dev.nucleusframework.desktop.tasks.AbstractNucleusTask
 import dev.nucleusframework.internal.utils.ioFile
@@ -21,6 +20,14 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
+import software.amazon.awssdk.core.exception.SdkException
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.io.File
 
 /**
@@ -130,50 +137,55 @@ abstract class AbstractMergeUpdateYmlTask : AbstractNucleusTask() {
         val bucket =
             s3Bucket.orNull?.takeIf { it.isNotBlank() }
                 ?: throw GradleException("S3 publishing is enabled but no S3 bucket is configured.")
-        val aws =
-            findAwsExecutable()
-                ?: throw GradleException(
-                    "The merged auto-update manifest must be uploaded to S3, but the AWS CLI ('aws') " +
-                        "was not found on PATH. electron-builder uploads the package artifacts via its " +
-                        "bundled SDK, but the plugin uploads the merged '<channel>' manifest via " +
-                        "'aws s3 cp'. Install the AWS CLI on the build machine, or publish only a single " +
-                        "auto-updatable format per OS to S3.",
-                )
+        val cannedAcl = s3Acl.orNull?.takeIf { it.isNotBlank() }?.let { ObjectCannedACL.fromValue(it) }
 
-        for (file in files) {
-            val key = UpdateYmlPublish.s3Key(s3Path.orNull, file.name)
-            val args =
-                buildList {
-                    add("s3")
-                    add("cp")
-                    add(file.absolutePath)
-                    add("s3://$bucket/$key")
-                    s3Region.orNull?.takeIf { it.isNotBlank() }?.let {
-                        add("--region")
-                        add(it)
-                    }
-                    s3Acl.orNull?.takeIf { it.isNotBlank() }?.let {
-                        add("--acl")
-                        add(it)
-                    }
+        // Credentials and (when not configured here) region are resolved by the AWS SDK's default
+        // provider chains — env vars (AWS_ACCESS_KEY_ID, AWS_REGION, ...), system properties, the
+        // shared profile/config files and container/instance metadata — the same sources the `aws`
+        // CLI and electron-builder's S3 publisher read.
+        buildS3Client().use { s3 ->
+            for (file in files) {
+                val key = UpdateYmlPublish.s3Key(s3Path.orNull, file.name)
+                val request =
+                    PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .contentType("text/yaml")
+                        .apply { if (cannedAcl != null) acl(cannedAcl) }
+                        .build()
+                logger.lifecycle("Uploading merged update manifest to s3://$bucket/$key")
+                try {
+                    s3.putObject(request, RequestBody.fromFile(file))
+                } catch (e: SdkException) {
+                    throw GradleException("Failed to upload merged update manifest to s3://$bucket/$key: ${e.message}", e)
                 }
-            logger.lifecycle("Uploading merged update manifest to s3://$bucket/$key")
-            // AWS credentials are inherited from the process environment (AWS_ACCESS_KEY_ID, etc.),
-            // the same way electron-builder's S3 publisher reads them.
-            runExternalTool(
-                tool = aws,
-                args = args,
-                logToConsole = ExternalToolRunner.LogToConsole.Always,
-            )
+            }
         }
     }
 
-    private fun findAwsExecutable(): File? {
-        val pathEnv = System.getenv("PATH") ?: return null
-        return pathEnv.split(File.pathSeparator)
-            .asSequence()
-            .filter { it.isNotBlank() }
-            .map { File(it, "aws") }
-            .firstOrNull { it.isFile && it.canExecute() }
+    /**
+     * Builds a synchronous [S3Client] backed by the lightweight JDK-HttpURLConnection HTTP client.
+     * Uses the configured [s3Region] when set, otherwise falls back to the SDK's default region
+     * provider chain (env var / profile), matching how the `aws` CLI inferred the region.
+     */
+    private fun buildS3Client(): S3Client {
+        val region =
+            s3Region.orNull?.takeIf { it.isNotBlank() }?.let { Region.of(it) }
+                ?: resolveDefaultRegion()
+        return S3Client.builder()
+            .region(region)
+            .httpClientBuilder(UrlConnectionHttpClient.builder())
+            .build()
     }
+
+    private fun resolveDefaultRegion(): Region =
+        try {
+            DefaultAwsRegionProviderChain.builder().build().region
+        } catch (e: SdkException) {
+            throw GradleException(
+                "S3 publishing is enabled but no AWS region is configured. Set `s3.region` in the publish " +
+                    "DSL, or provide it via the AWS_REGION environment variable / a shared AWS config profile.",
+                e,
+            )
+        }
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractMergeUpdateYmlTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractMergeUpdateYmlTask.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.tasks
+
+import dev.nucleusframework.desktop.application.internal.ExternalToolRunner
+import dev.nucleusframework.desktop.application.internal.UpdateYmlPublish
+import dev.nucleusframework.desktop.tasks.AbstractNucleusTask
+import dev.nucleusframework.internal.utils.ioFile
+import dev.nucleusframework.internal.utils.notNullProperty
+import dev.nucleusframework.internal.utils.nullableProperty
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+
+/**
+ * Merges the per-format `<channel><osSuffix>.yml` auto-update manifests produced by the individual
+ * electron-builder package runs (for the current OS) into a single union manifest and uploads it to
+ * S3.
+ *
+ * Nucleus packages each [dev.nucleusframework.desktop.application.dsl.TargetFormat] with
+ * its own electron-builder invocation. For S3 publishing of multiple auto-updatable formats of the
+ * same OS, those runs are configured with `publishAutoUpdate: false`, so electron-builder uploads
+ * the artifacts but not the manifests (which all share the `<channel><osSuffix>.yml` key and would
+ * otherwise clobber each other). This task takes over that one upload: it reads each run's
+ * locally-written manifest, merges them with
+ * [dev.nucleusframework.desktop.application.internal.UpdateYmlMerger], and uploads the
+ * union so every format survives.
+ *
+ * See [UpdateYmlPublish] for the testable pieces of this flow.
+ */
+@DisableCachingByDefault(because = "Publishes (uploads) the merged manifest; always re-runs with its package tasks")
+abstract class AbstractMergeUpdateYmlTask : AbstractNucleusTask() {
+    /** Output directories of the per-format package tasks; each may contain a `<channel><osSuffix>.yml`. */
+    @get:Internal
+    val perFormatOutputDirs: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:Input
+    val s3Enabled: Property<Boolean> = objects.notNullProperty<Boolean>().apply { set(false) }
+
+    @get:Input
+    @get:Optional
+    val s3Bucket: Property<String> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
+    val s3Region: Property<String> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
+    val s3Path: Property<String> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
+    val s3Acl: Property<String> = objects.nullableProperty()
+
+    /** Publish mode from the `compose.electronBuilder.publishMode` Gradle property, if set. */
+    @get:Input
+    @get:Optional
+    val publishMode: Property<String> = objects.nullableProperty()
+
+    /** Publish mode from the DSL (`publish.publishMode`), used when no env var / property overrides it. */
+    @get:Input
+    val dslPublishMode: Property<String> = objects.notNullProperty<String>().apply { set("never") }
+
+    @get:OutputDirectory
+    val destinationDir: DirectoryProperty = objects.directoryProperty()
+
+    @TaskAction
+    fun run() {
+        val dirs = perFormatOutputDirs.files.filter { it.isDirectory }
+        val merged = UpdateYmlPublish.discoverAndMerge(dirs)
+        val willUpload = shouldUploadToS3()
+
+        if (merged.isEmpty()) {
+            // electron-builder is configured with publishAutoUpdate:false for these formats but still
+            // writes the manifests locally — so finding none in a publishing build means the upload
+            // would silently leave no manifest on S3 (worse than the original collision). Fail loudly.
+            if (willUpload) {
+                throw GradleException(
+                    "Expected per-format '<channel>' update manifests in the package output directories " +
+                        "to merge and upload to S3, but found none in: " +
+                        "${dirs.joinToString { it.absolutePath }}. Check the electron-builder output.",
+                )
+            }
+            logger.info("No update manifests found in ${dirs.size} format output dir(s); nothing to merge.")
+            return
+        }
+
+        val outDir = destinationDir.ioFile.apply { mkdirs() }
+        val writtenFiles =
+            merged.map { manifest ->
+                val file = outDir.resolve(manifest.fileName)
+                file.writeText(manifest.content)
+                logger.lifecycle("Merged update manifest written to ${file.canonicalPath}")
+                file
+            }
+
+        if (willUpload) {
+            uploadToS3(writtenFiles)
+        } else {
+            logger.info("Not publishing in this build; merged manifest(s) written locally only.")
+        }
+    }
+
+    /** Whether to upload the merged manifest in this build (mirrors electron-builder's publish decision). */
+    private fun shouldUploadToS3(): Boolean {
+        if (!s3Enabled.getOrElse(false)) return false
+        val publishFlag =
+            UpdateYmlPublish.resolvePublishFlag(
+                anyProviderEnabled = true,
+                envValue = System.getenv(UpdateYmlPublish.PUBLISH_MODE_ENV),
+                propValue = publishMode.orNull,
+                dslValue = dslPublishMode.getOrElse("never"),
+            )
+        return UpdateYmlPublish.shouldPublish(publishFlag, System.getenv())
+    }
+
+    private fun uploadToS3(files: List<File>) {
+        val bucket =
+            s3Bucket.orNull?.takeIf { it.isNotBlank() }
+                ?: throw GradleException("S3 publishing is enabled but no S3 bucket is configured.")
+        val aws =
+            findAwsExecutable()
+                ?: throw GradleException(
+                    "The merged auto-update manifest must be uploaded to S3, but the AWS CLI ('aws') " +
+                        "was not found on PATH. electron-builder uploads the package artifacts via its " +
+                        "bundled SDK, but the plugin uploads the merged '<channel>' manifest via " +
+                        "'aws s3 cp'. Install the AWS CLI on the build machine, or publish only a single " +
+                        "auto-updatable format per OS to S3.",
+                )
+
+        for (file in files) {
+            val key = UpdateYmlPublish.s3Key(s3Path.orNull, file.name)
+            val args =
+                buildList {
+                    add("s3")
+                    add("cp")
+                    add(file.absolutePath)
+                    add("s3://$bucket/$key")
+                    s3Region.orNull?.takeIf { it.isNotBlank() }?.let {
+                        add("--region")
+                        add(it)
+                    }
+                    s3Acl.orNull?.takeIf { it.isNotBlank() }?.let {
+                        add("--acl")
+                        add(it)
+                    }
+                }
+            logger.lifecycle("Uploading merged update manifest to s3://$bucket/$key")
+            // AWS credentials are inherited from the process environment (AWS_ACCESS_KEY_ID, etc.),
+            // the same way electron-builder's S3 publisher reads them.
+            runExternalTool(
+                tool = aws,
+                args = args,
+                logToConsole = ExternalToolRunner.LogToConsole.Always,
+            )
+        }
+    }
+
+    private fun findAwsExecutable(): File? {
+        val pathEnv = System.getenv("PATH") ?: return null
+        return pathEnv.split(File.pathSeparator)
+            .asSequence()
+            .filter { it.isNotBlank() }
+            .map { File(it, "aws") }
+            .firstOrNull { it.isFile && it.canExecute() }
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/LinuxPerFormatManifestCollisionTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/LinuxPerFormatManifestCollisionTest.kt
@@ -1,0 +1,79 @@
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.desktop.application.dsl.ReleaseChannel
+import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression test for the Linux per-format auto-update manifest collision.
+ *
+ * Nucleus packages each [TargetFormat] with its own electron-builder invocation, and for Linux each
+ * run writes + publishes a single-artifact `<channel>-linux.yml`. Because
+ * [TargetFormat.updateYmlFilename] keys the manifest name only off the OS (`-linux`) and not the
+ * format, the Deb run and the AppImage run target the **same** key. Publishing each per-format
+ * manifest independently makes the last writer (the Deb run sorts after the AppImage run) clobber
+ * the other — leaving `<channel>-linux.yml` with only the `.deb`, so an AppImage client hits
+ * `NoMatchingFileException`.
+ *
+ * The fix ([UpdateYmlMerger]) merges the per-format manifests into one union manifest before that
+ * key is written, so every Linux format survives. This test pins that contract: the published
+ * manifest must list both the deb and the AppImage. (Before the fix, the publish step overwrote
+ * rather than merged, and this assertion failed.)
+ */
+class LinuxPerFormatManifestCollisionTest {
+    private val appImageFileName = "Example-1.2.3.AppImage"
+    private val debFileName = "example_1.2.3_amd64.deb"
+
+    @Test
+    fun `merged linux manifest keeps every format so the AppImage is not clobbered by the deb`() {
+        val channel = ReleaseChannel.Beta
+
+        // Collision precondition: the two Linux formats resolve to the SAME manifest key, so their
+        // independent electron-builder runs would otherwise publish to the same location.
+        assertEquals(
+            "Deb and AppImage publish to the same manifest key, so per-format runs clobber each other",
+            TargetFormat.AppImage.updateYmlFilename(channel),
+            TargetFormat.Deb.updateYmlFilename(channel),
+        )
+
+        // What each per-format electron-builder run leaves in its own output dir: a manifest that
+        // lists ONLY that format's artifact.
+        val appImageRunManifest = perFormatManifest(appImageFileName, sha512 = "AAAA==", size = 111)
+        val debRunManifest = perFormatManifest(debFileName, sha512 = "BBBB==", size = 222)
+
+        // The fix: instead of each run clobbering the shared key, the per-format manifests are
+        // merged before publishing.
+        val publishedManifest = UpdateYmlMerger.merge(listOf(appImageRunManifest, debRunManifest))
+        val publishedFiles = filesUrls(publishedManifest)
+
+        assertTrue("Expected the deb in $publishedFiles", debFileName in publishedFiles)
+        assertTrue(
+            "Published manifest must list $appImageFileName, but only contains $publishedFiles " +
+                "— the merge dropped the AppImage entry.",
+            appImageFileName in publishedFiles,
+        )
+    }
+
+    /** A single-artifact `<channel>-linux.yml` as produced by one electron-builder format run. */
+    private fun perFormatManifest(fileName: String, sha512: String, size: Long): String =
+        """
+        version: 1.2.3
+        files:
+          - url: $fileName
+            sha512: $sha512
+            size: $size
+        path: $fileName
+        sha512: $sha512
+        releaseDate: '2026-05-29T00:00:00.000Z'
+        """.trimIndent() + "\n"
+
+    /** Extracts the `files[].url` values from an electron-builder manifest. */
+    private fun filesUrls(manifest: String): List<String> =
+        manifest.lineSequence()
+            .map { it.trim() }
+            .filter { it.startsWith("- url: ") }
+            .map { it.removePrefix("- url: ") }
+            .toList()
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlMergerTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlMergerTest.kt
@@ -1,0 +1,122 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/** Tests for [UpdateYmlMerger], the fix for the Linux per-format manifest collision. */
+class UpdateYmlMergerTest {
+    private fun manifest(
+        version: String = "1.2.3",
+        url: String,
+        sha512: String,
+        size: Long,
+        blockMapSize: Long? = null,
+        releaseDate: String = "2026-05-29T00:00:00.000Z",
+    ): String =
+        buildString {
+            appendLine("version: $version")
+            appendLine("files:")
+            appendLine("  - url: $url")
+            appendLine("    sha512: $sha512")
+            appendLine("    size: $size")
+            if (blockMapSize != null) appendLine("    blockMapSize: $blockMapSize")
+            appendLine("path: $url")
+            appendLine("sha512: $sha512")
+            appendLine("releaseDate: '$releaseDate'")
+        }
+
+    private fun urls(manifest: String): List<String> =
+        manifest.lineSequence().map { it.trim() }.filter { it.startsWith("- url: ") }.map { it.removePrefix("- url: ") }.toList()
+
+    private fun fieldOf(manifest: String, url: String, field: String): String? {
+        val lines = manifest.lines()
+        val start = lines.indexOf("  - url: $url")
+        if (start < 0) return null
+        var i = start + 1
+        while (i < lines.size && lines[i].startsWith("    ")) {
+            val f = lines[i].trim()
+            if (f.startsWith("$field: ")) return f.removePrefix("$field: ")
+            i++
+        }
+        return null
+    }
+
+    private fun topLevel(manifest: String, key: String): String? =
+        manifest.lines().lastOrNull { it.startsWith("$key: ") }?.removePrefix("$key: ")
+
+    @Test
+    fun `merges deb and AppImage manifests into one with both entries`() {
+        val appImage = manifest(url = "Example-1.2.3.AppImage", sha512 = "AAAA==", size = 111, blockMapSize = 50)
+        val deb = manifest(url = "example_1.2.3_amd64.deb", sha512 = "BBBB==", size = 222)
+
+        val merged = UpdateYmlMerger.merge(listOf(appImage, deb))
+
+        assertEquals(
+            listOf("Example-1.2.3.AppImage", "example_1.2.3_amd64.deb"),
+            urls(merged).sorted(),
+        )
+        assertEquals("1.2.3", topLevel(merged, "version"))
+        // Per-entry fields are preserved, including the AppImage's blockMapSize.
+        assertEquals("AAAA==", fieldOf(merged, "Example-1.2.3.AppImage", "sha512"))
+        assertEquals("111", fieldOf(merged, "Example-1.2.3.AppImage", "size"))
+        assertEquals("50", fieldOf(merged, "Example-1.2.3.AppImage", "blockMapSize"))
+        assertEquals("BBBB==", fieldOf(merged, "example_1.2.3_amd64.deb", "sha512"))
+        // The deb has no blockmap, so no blockMapSize line is emitted for it.
+        assertEquals(null, fieldOf(merged, "example_1.2.3_amd64.deb", "blockMapSize"))
+    }
+
+    @Test
+    fun `top-level path and sha512 mirror the first sorted entry`() {
+        val appImage = manifest(url = "Example-1.2.3.AppImage", sha512 = "AAAA==", size = 111)
+        val deb = manifest(url = "example_1.2.3_amd64.deb", sha512 = "BBBB==", size = 222)
+
+        // Input order reversed to prove ordering is by url, not input order.
+        val merged = UpdateYmlMerger.merge(listOf(deb, appImage))
+
+        assertEquals("Example-1.2.3.AppImage", topLevel(merged, "path"))
+        assertEquals("AAAA==", topLevel(merged, "sha512"))
+    }
+
+    @Test
+    fun `releaseDate is the latest across inputs`() {
+        val older = manifest(url = "a.AppImage", sha512 = "A==", size = 1, releaseDate = "2026-01-01T00:00:00.000Z")
+        val newer = manifest(url = "b.deb", sha512 = "B==", size = 2, releaseDate = "2026-05-29T12:00:00.000Z")
+
+        val merged = UpdateYmlMerger.merge(listOf(older, newer))
+
+        assertEquals("'2026-05-29T12:00:00.000Z'", topLevel(merged, "releaseDate"))
+    }
+
+    @Test
+    fun `deduplicates entries by url`() {
+        val a = manifest(url = "Example-1.2.3.AppImage", sha512 = "AAAA==", size = 111)
+        val aAgain = manifest(url = "Example-1.2.3.AppImage", sha512 = "AAAA==", size = 111)
+
+        val merged = UpdateYmlMerger.merge(listOf(a, aAgain))
+
+        assertEquals(listOf("Example-1.2.3.AppImage"), urls(merged))
+    }
+
+    @Test
+    fun `single manifest round-trips its entry`() {
+        val deb = manifest(url = "example_1.2.3_amd64.deb", sha512 = "BBBB==", size = 222)
+
+        val merged = UpdateYmlMerger.merge(listOf(deb))
+
+        assertEquals(listOf("example_1.2.3_amd64.deb"), urls(merged))
+        assertEquals("BBBB==", fieldOf(merged, "example_1.2.3_amd64.deb", "sha512"))
+        assertEquals("222", fieldOf(merged, "example_1.2.3_amd64.deb", "size"))
+    }
+
+    @Test
+    fun `empty input is rejected`() {
+        try {
+            UpdateYmlMerger.merge(emptyList())
+            fail("Expected merge(emptyList()) to throw")
+        } catch (e: IllegalArgumentException) {
+            assertTrue(true)
+        }
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlPublishTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/UpdateYmlPublishTest.kt
@@ -1,0 +1,198 @@
+package dev.nucleusframework.desktop.application.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/** Tests for the pure seams of the per-format manifest merge/publish flow (all platforms). */
+class UpdateYmlPublishTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    // --- resolvePublishFlag ---
+
+    @Test
+    fun `resolvePublishFlag is never when no provider is enabled`() {
+        assertEquals(
+            "never",
+            UpdateYmlPublish.resolvePublishFlag(
+                anyProviderEnabled = false,
+                envValue = "always",
+                propValue = "always",
+                dslValue = "onTag",
+            ),
+        )
+    }
+
+    @Test
+    fun `resolvePublishFlag prefers env over property over dsl`() {
+        assertEquals(
+            "envMode",
+            UpdateYmlPublish.resolvePublishFlag(true, envValue = "envMode", propValue = "propMode", dslValue = "onTag"),
+        )
+        assertEquals(
+            "propMode",
+            UpdateYmlPublish.resolvePublishFlag(true, envValue = " ", propValue = "propMode", dslValue = "onTag"),
+        )
+        assertEquals(
+            "onTag",
+            UpdateYmlPublish.resolvePublishFlag(true, envValue = null, propValue = null, dslValue = "onTag"),
+        )
+    }
+
+    // --- shouldPublish / hasCiTag ---
+
+    @Test
+    fun `shouldPublish always and never ignore the environment`() {
+        assertTrue(UpdateYmlPublish.shouldPublish("always", emptyMap()))
+        assertFalse(UpdateYmlPublish.shouldPublish("never", mapOf("GITHUB_REF" to "refs/tags/v1")))
+    }
+
+    @Test
+    fun `shouldPublish onTag uploads only when a CI tag is present`() {
+        assertFalse(UpdateYmlPublish.shouldPublish("onTag", emptyMap()))
+        assertFalse(UpdateYmlPublish.shouldPublish("onTag", mapOf("GITHUB_REF" to "refs/heads/main")))
+        assertTrue(UpdateYmlPublish.shouldPublish("onTag", mapOf("GITHUB_REF" to "refs/tags/v1.2.3")))
+        assertTrue(UpdateYmlPublish.shouldPublish("onTag", mapOf("CIRCLE_TAG" to "v1.2.3")))
+    }
+
+    @Test
+    fun `hasCiTag ignores blank values`() {
+        assertFalse(UpdateYmlPublish.hasCiTag(mapOf("TRAVIS_TAG" to "", "GITHUB_REF" to null)))
+        assertTrue(UpdateYmlPublish.hasCiTag(mapOf("TRAVIS_TAG" to "v9")))
+    }
+
+    // --- s3Key ---
+
+    @Test
+    fun `s3Key omits an empty prefix and normalizes slashes`() {
+        assertEquals("beta-mac.yml", UpdateYmlPublish.s3Key(null, "beta-mac.yml"))
+        assertEquals("latest.yml", UpdateYmlPublish.s3Key("  ", "latest.yml"))
+        assertEquals("testing/beta-linux.yml", UpdateYmlPublish.s3Key("testing", "beta-linux.yml"))
+        assertEquals("testing/beta-linux.yml", UpdateYmlPublish.s3Key("/testing/", "beta-linux.yml"))
+    }
+
+    // --- discoverAndMerge ---
+
+    private fun writeManifest(dir: File, name: String, url: String, sha512: String, size: Long) {
+        dir.mkdirs()
+        File(dir, name).writeText(
+            """
+            version: 1.2.3
+            files:
+              - url: $url
+                sha512: $sha512
+                size: $size
+            path: $url
+            sha512: $sha512
+            releaseDate: '2026-05-29T00:00:00.000Z'
+            """.trimIndent() + "\n",
+        )
+    }
+
+    private fun filesUrls(content: String): List<String> =
+        content.lineSequence()
+            .map { it.trim() }
+            .filter { it.startsWith("- url: ") }
+            .map { it.removePrefix("- url: ") }
+            .toList()
+
+    @Test
+    fun `discoverAndMerge unions same-named manifests across format output dirs (linux)`() {
+        val appImageDir = tmp.newFolder("AppImage")
+        val debDir = tmp.newFolder("deb")
+        writeManifest(appImageDir, "beta-linux.yml", "Example-1.2.3.AppImage", "AAAA==", 111)
+        writeManifest(debDir, "beta-linux.yml", "example_1.2.3_amd64.deb", "BBBB==", 222)
+        // A non-manifest artifact in the dir must be ignored.
+        File(debDir, "example_1.2.3_amd64.deb").writeText("binary")
+
+        val merged = UpdateYmlPublish.discoverAndMerge(listOf(appImageDir, debDir))
+
+        assertEquals(1, merged.size)
+        assertEquals("beta-linux.yml", merged.single().fileName)
+        assertEquals(
+            listOf("Example-1.2.3.AppImage", "example_1.2.3_amd64.deb"),
+            filesUrls(merged.single().content).sorted(),
+        )
+    }
+
+    @Test
+    fun `discoverAndMerge unions dmg and zip into one mac manifest`() {
+        val dmgDir = tmp.newFolder("dmg")
+        val zipDir = tmp.newFolder("zip")
+        writeManifest(dmgDir, "latest-mac.yml", "Example-1.2.3.dmg", "AA==", 11)
+        writeManifest(zipDir, "latest-mac.yml", "Example-1.2.3-mac.zip", "BB==", 22)
+
+        val merged = UpdateYmlPublish.discoverAndMerge(listOf(dmgDir, zipDir))
+
+        assertEquals("latest-mac.yml", merged.single().fileName)
+        assertEquals(
+            listOf("Example-1.2.3-mac.zip", "Example-1.2.3.dmg"),
+            filesUrls(merged.single().content).sorted(),
+        )
+    }
+
+    @Test
+    fun `discoverAndMerge matches windows manifests and ignores builder config files`() {
+        val nsisDir = tmp.newFolder("nsis")
+        writeManifest(nsisDir, "latest.yml", "Example Setup 1.2.3.exe", "AA==", 11)
+        // electron-builder leaves config files behind; these must NOT be treated as update manifests.
+        File(nsisDir, "electron-builder.yml").writeText("appId: x")
+        File(nsisDir, "builder-debug.yml").writeText("debug: true")
+
+        val merged = UpdateYmlPublish.discoverAndMerge(listOf(nsisDir))
+
+        assertEquals(1, merged.size)
+        assertEquals("latest.yml", merged.single().fileName)
+    }
+
+    @Test
+    fun `discoverAndMerge returns a lone manifest verbatim, preserving unmodeled fields`() {
+        val nsisDir = tmp.newFolder("nsis")
+        // Includes fields the line-based merger does not model (releaseName, a `packages:` block).
+        val original =
+            """
+            version: 1.2.3
+            releaseName: Shiny
+            files:
+              - url: App-1.2.3.exe
+                sha512: AA==
+                size: 11
+                blockMapSize: 7
+            packages:
+              x64:
+                file: App-1.2.3.exe.blockmap
+            path: App-1.2.3.exe
+            sha512: AA==
+            releaseDate: '2026-05-29T00:00:00.000Z'
+            """.trimIndent() + "\n"
+        File(nsisDir, "latest.yml").writeText(original)
+
+        val merged = UpdateYmlPublish.discoverAndMerge(listOf(nsisDir))
+
+        // Single source ⇒ byte-for-byte passthrough (not round-tripped through the merger).
+        assertEquals(original, merged.single().content)
+    }
+
+    @Test
+    fun `discoverAndMerge returns empty when no manifests are present`() {
+        val empty = tmp.newFolder("empty")
+        assertTrue(UpdateYmlPublish.discoverAndMerge(listOf(empty)).isEmpty())
+    }
+
+    @Test
+    fun `discoverAndMerge groups distinct channels separately`() {
+        val a = tmp.newFolder("a")
+        val b = tmp.newFolder("b")
+        writeManifest(a, "beta-linux.yml", "x.AppImage", "AA==", 1)
+        writeManifest(b, "latest-linux.yml", "y.deb", "BB==", 2)
+
+        val merged = UpdateYmlPublish.discoverAndMerge(listOf(a, b))
+
+        assertEquals(setOf("beta-linux.yml", "latest-linux.yml"), merged.map { it.fileName }.toSet())
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderPublishConfigTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderPublishConfigTest.kt
@@ -1,0 +1,66 @@
+package dev.nucleusframework.desktop.application.internal.electronbuilder
+
+import dev.nucleusframework.desktop.application.dsl.PublishSettings
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies the `publishAutoUpdate: false` switch the per-format manifest fix relies on: electron-builder
+ * must always stop uploading the S3 `<channel><osSuffix>.yml` (so the plugin publishes a single merged
+ * manifest), while artifacts and other providers are untouched.
+ */
+class ElectronBuilderPublishConfigTest {
+    private fun publishSettings(): PublishSettings =
+        ProjectBuilder.builder().build().objects.newInstance(PublishSettings::class.java)
+
+    private fun render(publish: PublishSettings): String {
+        val yaml = StringBuilder()
+        ElectronBuilderConfigGenerator().generatePublishConfig(yaml, publish)
+        return yaml.toString()
+    }
+
+    @Test
+    fun `s3 publish always emits publishAutoUpdate false`() {
+        val publish = publishSettings()
+        publish.s3.enabled = true
+        publish.s3.bucket = "my-bucket"
+
+        val yaml = render(publish)
+
+        assertTrue(yaml, yaml.contains("- provider: s3"))
+        assertTrue(yaml, yaml.contains("publishAutoUpdate: false"))
+    }
+
+    @Test
+    fun `github-only publish never emits publishAutoUpdate`() {
+        val publish = publishSettings()
+        publish.github.enabled = true
+        publish.github.owner = "owner"
+        publish.github.repo = "repo"
+
+        val yaml = render(publish)
+
+        assertTrue(yaml, yaml.contains("- provider: github"))
+        assertFalse(yaml, yaml.contains("publishAutoUpdate"))
+    }
+
+    @Test
+    fun `mixed providers suppress only the s3 manifest`() {
+        val publish = publishSettings()
+        publish.github.enabled = true
+        publish.github.owner = "owner"
+        publish.github.repo = "repo"
+        publish.s3.enabled = true
+        publish.s3.bucket = "my-bucket"
+
+        val yaml = render(publish)
+
+        // publishAutoUpdate: false appears exactly once (under the s3 entry, not the github entry).
+        assertTrue(yaml, yaml.contains("- provider: github"))
+        assertTrue(yaml, yaml.contains("- provider: s3"))
+        assertEquals(1, Regex("publishAutoUpdate: false").findAll(yaml).count())
+    }
+}


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->
Claude generated description of changes:

Nucleus runs a separate electron-builder invocation per TargetFormat, and each updatable run publishes its own single-artifact `<channel><osSuffix>.yml`. Because the manifest name is keyed only on the OS, every format of the same OS publishes to the same S3 key, so the last writer clobbers the others — e.g. the deb run overwrites the AppImage entry, and an AppImage client then hits NoMatchingFileException (on macOS a dmg-only `latest-mac.yml` breaks Squirrel.Mac updates entirely).

Fix: always set `publishAutoUpdate: false` for S3 so electron-builder uploads the artifacts but not the manifests, then a new merge task discovers the per-format manifests for the current OS, unions their `files:` entries (UpdateYmlMerger), and uploads a single manifest via `aws s3 cp`. A lone manifest passes through verbatim to preserve electron-builder's exact metadata.

- TargetFormat.producesUpdateManifest gates registering the merge task.
- Upload mirrors electron-builder's publish decision (publish mode + CI tag), fails loudly if a manifest is expected but missing or the aws CLI is absent.
- Tested: merge/discovery, publish-flag/tag logic, s3 key, and the publishAutoUpdate:false config emission.

Scope: S3 only. GitHub releases are already consolidated in CI (generate-update-yml).

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #253

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Added tests.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.