### PR TITLE
fix(graalvm): add D3D and IME metadata for Windows native-image

### DIFF
--- a/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/windows-reachability-metadata.json
+++ b/plugin-build/plugin/src/main/resources/nucleus/graalvm/platform-metadata/windows-reachability-metadata.json
@@ -2598,6 +2598,94 @@
                     "parameterTypes": []
                 }
             ]
+        },
+        {
+            "type": "sun.awt.windows.WInputMethod",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "inquireCandidatePosition",
+                    "parameterTypes": []
+                },
+                {
+                    "name": "sendInputMethodEvent",
+                    "parameterTypes": [
+                        "int",
+                        "long",
+                        "java.lang.String",
+                        "int[]",
+                        "java.lang.String[]",
+                        "int[]",
+                        "byte[]",
+                        "int",
+                        "int",
+                        "int"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "sun.awt.windows.WInputMethodDescriptor",
+            "jniAccessible": true
+        },
+        {
+            "type": "sun.java2d.d3d.D3DGraphicsDevice$1",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "run",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "sun.java2d.d3d.D3DRenderQueue$1",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "run",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "sun.java2d.d3d.D3DSurfaceData",
+            "jniAccessible": true,
+            "fields": [
+                {
+                    "name": "nativeHeight"
+                },
+                {
+                    "name": "nativeWidth"
+                }
+            ],
+            "methods": [
+                {
+                    "name": "dispose",
+                    "parameterTypes": [
+                        "long"
+                    ]
+                },
+                {
+                    "name": "setSurfaceLost",
+                    "parameterTypes": [
+                        "boolean"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "sun.java2d.d3d.D3DSurfaceData$1",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "run",
+                    "parameterTypes": []
+                }
+            ]
+        },
+        {
+            "type": "sun.java2d.d3d.D3DSurfaceData$D3DWindowSurfaceData"
         }
     ],
     "resources": [
@@ -2606,6 +2694,9 @@
         },
         {
             "bundle": "com.sun.java.swing.plaf.windows.resources.windows"
+        },
+        {
+            "glob": "META-INF/services/java.awt.im.spi.InputMethodDescriptor"
         }
     ]
 }


### PR DESCRIPTION
## 🚀 Description

Adds minimal GraalVM native-image reachability metadata to fix Windows IME (Input Method Editor) input failure — required for Chinese, Japanese, and Korean text input.

Three independent GraalVM metadata gaps are addressed:

1. **D3D anonymous inner classes** — `D3DRenderQueue$1`, `D3DGraphicsDevice$1`, `D3DSurfaceData$1` implement `Runnable` and are invoked by the AWT-Windows thread at runtime. Without explicit reachability metadata, GraalVM native-image omits their `run()` methods, causing `NoSuchMethodError` that crashes the AWT event loop and prevents IME from initializing.

2. **Windows IME JNI callbacks** — `WInputMethod.inquireCandidatePosition()` and `WInputMethod.sendInputMethodEvent(...)` are native-to-Java upcalls from the Windows IME system. `WInputMethodDescriptor` must also be registered as JNI-accessible.

3. **IME ServiceLoader resource** — `META-INF/services/java.awt.im.spi.InputMethodDescriptor` is required for GraalVM native-image's ServiceLoader to discover `WInputMethodDescriptor`, the Windows IME service provider. Without it, the IME subsystem never starts.

## 📄 Motivation and Context

Fixes Windows IME being completely non-functional in GraalVM native-image builds. The issue affected all window types — both plain `Window()` and `DecoratedWindow` — because the root causes operate at the AWT layer, below any decoration abstraction.

## 🧪 How Has This Been Tested?

Controlled A/B experiment with three builds:

| Build | IME Status |
|-------|-----------|
| JVM (baseline) | ✅ Works |
| `main` native-image (no fix) | ❌ Broken — `AWT-Windows` `NoSuchMethodError`, IME candidates never appear |
| **This fix native-image** | ✅ **Works** — identical to JVM baseline |

Metadata was collected via GraalVM `native-image-agent` during a JVM session with active IME interaction, then distilled to only the minimal entries required for the fix.

## 📦 Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.