### PR TITLE
fix(global-hotkey): correct Wayland portal preferred_trigger format

### DIFF
--- a/global-hotkey/src/main/kotlin/dev/nucleusframework/globalhotkey/GlobalHotKeyManager.kt
+++ b/global-hotkey/src/main/kotlin/dev/nucleusframework/globalhotkey/GlobalHotKeyManager.kt
@@ -96,12 +96,16 @@ object GlobalHotKeyManager {
      * @param keyCode AWT virtual key code (e.g., [java.awt.event.KeyEvent.VK_F12]).
      * @param modifiers bitmask of [HotKeyModifier] values (e.g., `HotKeyModifier.CONTROL + HotKeyModifier.ALT`).
      *                  Use 0 for no modifiers.
+     * @param description user-readable description of what the shortcut does (e.g. "Play/Pause").
+     *                    Shown in the system shortcut dialog on Linux/Wayland (portal backend); ignored
+     *                    on other platforms. When null, the key combination is used as a fallback.
      * @param listener callback invoked when the hotkey is pressed.
      * @return a registration handle for [unregister], or -1 on failure.
      */
     fun register(
         keyCode: Int,
         modifiers: Int = 0,
+        description: String? = null,
         listener: HotKeyListener,
     ): Long {
         if (!ensureReady()) return -1
@@ -109,7 +113,7 @@ object GlobalHotKeyManager {
         return when (Platform.Current) {
             Platform.Windows -> registerWindows(keyCode, modifiers, listener)
             Platform.MacOS -> registerMacOs(keyCode, modifiers, listener)
-            Platform.Linux -> registerLinux(keyCode, modifiers, listener)
+            Platform.Linux -> registerLinux(keyCode, modifiers, description, listener)
             else -> -1
         }
     }
@@ -134,7 +138,7 @@ object GlobalHotKeyManager {
                 logger.warning(lastError)
                 -1
             }
-            Platform.Linux -> registerLinux(mediaKey.nativeCode, 0, listener)
+            Platform.Linux -> registerLinux(mediaKey.nativeCode, 0, mediaKey.name, listener)
             else -> -1
         }
     }
@@ -252,10 +256,11 @@ object GlobalHotKeyManager {
     private fun registerLinux(
         keyCode: Int,
         modifiers: Int,
+        description: String?,
         listener: HotKeyListener,
     ): Long {
         val id = NativeLinuxHotKeyBridge.registerListener(listener)
-        val error = NativeLinuxHotKeyBridge.nativeRegister(id, modifiers, keyCode)
+        val error = NativeLinuxHotKeyBridge.nativeRegister(id, modifiers, keyCode, description)
         if (error != null) {
             NativeLinuxHotKeyBridge.removeListener(id)
             lastError = error

--- a/global-hotkey/src/main/kotlin/dev/nucleusframework/globalhotkey/linux/NativeLinuxHotKeyBridge.kt
+++ b/global-hotkey/src/main/kotlin/dev/nucleusframework/globalhotkey/linux/NativeLinuxHotKeyBridge.kt
@@ -22,6 +22,7 @@ internal object NativeLinuxHotKeyBridge {
         id: Long,
         modifiers: Int,
         keyCode: Int,
+        description: String?,
     ): String?
 
     @JvmStatic

--- a/global-hotkey/src/main/native/linux/nucleus_global_hotkey_linux.c
+++ b/global-hotkey/src/main/native/linux/nucleus_global_hotkey_linux.c
@@ -25,16 +25,13 @@
 
 #include <gio/gio.h>
 
+#include "nucleus_hotkey_keys.h"
+
 /* ------------------------------------------------------------------ */
 /* Constants                                                           */
 /* ------------------------------------------------------------------ */
 
 #define MAX_HOTKEYS 256
-
-#define MOD_ALT     0x0001
-#define MOD_CONTROL 0x0002
-#define MOD_SHIFT   0x0004
-#define MOD_META    0x0008
 
 typedef enum { BACKEND_NONE = 0, BACKEND_X11, BACKEND_PORTAL } BackendType;
 
@@ -51,6 +48,7 @@ typedef struct {
     unsigned int x11_modifiers;
     /* Portal */
     char shortcut_id[32];
+    char description[256];   /* user-readable action label for the portal dialog */
 } HotKeyEntry;
 
 /* ------------------------------------------------------------------ */
@@ -133,82 +131,8 @@ static void fireHotKeyPortal(jlong id, jint keyCode, jint modifiers) {
         (*g_portal_env)->ExceptionClear(g_portal_env);
 }
 
-/* ================================================================== */
-/* AWT VK_* → X11 KeySym                                              */
-/* ================================================================== */
-
-static KeySym awtToKeySym(int vk) {
-    if (vk >= 0x41 && vk <= 0x5A) return XK_a + (vk - 0x41);
-    if (vk >= 0x30 && vk <= 0x39) return XK_0 + (vk - 0x30);
-    if (vk >= 0x70 && vk <= 0x7B) return XK_F1 + (vk - 0x70);
-    if (vk >= 0x60 && vk <= 0x69) return XK_KP_0 + (vk - 0x60);
-    switch (vk) {
-        case 0x0A: return XK_Return;      case 0x1B: return XK_Escape;
-        case 0x08: return XK_BackSpace;    case 0x09: return XK_Tab;
-        case 0x20: return XK_space;        case 0x7F: return XK_Delete;
-        case 0x14: return XK_Caps_Lock;
-        case 0x26: return XK_Up;           case 0x28: return XK_Down;
-        case 0x25: return XK_Left;         case 0x27: return XK_Right;
-        case 0x24: return XK_Home;         case 0x23: return XK_End;
-        case 0x21: return XK_Page_Up;      case 0x22: return XK_Page_Down;
-        case 0x9B: return XK_Insert;
-        case 0xC0: return XK_grave;        case 0x2D: return XK_minus;
-        case 0x3D: return XK_equal;        case 0x5B: return XK_bracketleft;
-        case 0x5D: return XK_bracketright; case 0x5C: return XK_backslash;
-        case 0x3B: return XK_semicolon;    case 0xDE: return XK_apostrophe;
-        case 0x2C: return XK_comma;        case 0x2E: return XK_period;
-        case 0x2F: return XK_slash;
-        case 0x6A: return XK_KP_Multiply;  case 0x6B: return XK_KP_Add;
-        case 0x6D: return XK_KP_Subtract;  case 0x6E: return XK_KP_Decimal;
-        case 0x6F: return XK_KP_Divide;
-        case 0xB3: return 0x1008FF14;      case 0xB2: return 0x1008FF15;
-        case 0xB0: return 0x1008FF17;      case 0xB1: return 0x1008FF16;
-        default:   return NoSymbol;
-    }
-}
-
-/* ================================================================== */
-/* AWT VK_* → GTK accelerator key name (for preferred_trigger)        */
-/* ================================================================== */
-
-static const char *awtToKeyName(int vk) {
-    if (vk >= 0x41 && vk <= 0x5A) {
-        static const char *L[] = {"a","b","c","d","e","f","g","h","i","j","k","l","m",
-                                   "n","o","p","q","r","s","t","u","v","w","x","y","z"};
-        return L[vk - 0x41];
-    }
-    if (vk >= 0x30 && vk <= 0x39) {
-        static const char *D[] = {"0","1","2","3","4","5","6","7","8","9"};
-        return D[vk - 0x30];
-    }
-    if (vk >= 0x70 && vk <= 0x7B) {
-        static const char *F[] = {"F1","F2","F3","F4","F5","F6","F7","F8","F9","F10","F11","F12"};
-        return F[vk - 0x70];
-    }
-    switch (vk) {
-        case 0x0A: return "Return";    case 0x1B: return "Escape";
-        case 0x08: return "BackSpace";  case 0x09: return "Tab";
-        case 0x20: return "space";      case 0x7F: return "Delete";
-        case 0x26: return "Up";         case 0x28: return "Down";
-        case 0x25: return "Left";       case 0x27: return "Right";
-        case 0x24: return "Home";       case 0x23: return "End";
-        case 0x21: return "Page_Up";    case 0x22: return "Page_Down";
-        case 0x9B: return "Insert";
-        case 0xB3: return "XF86AudioPlay";  case 0xB2: return "XF86AudioStop";
-        case 0xB0: return "XF86AudioNext";  case 0xB1: return "XF86AudioPrev";
-        default:   return NULL;
-    }
-}
-
-static void buildTrigger(char *buf, int sz, int mods, int vk) {
-    buf[0] = '\0';
-    if (mods & MOD_CONTROL) strncat(buf, "<Control>", sz - strlen(buf) - 1);
-    if (mods & MOD_ALT)     strncat(buf, "<Alt>", sz - strlen(buf) - 1);
-    if (mods & MOD_SHIFT)   strncat(buf, "<Shift>", sz - strlen(buf) - 1);
-    if (mods & MOD_META)    strncat(buf, "<Super>", sz - strlen(buf) - 1);
-    const char *n = awtToKeyName(vk);
-    if (n) strncat(buf, n, sz - strlen(buf) - 1);
-}
+/* awtToKeySym() and buildTrigger() live in nucleus_hotkey_keys.h so the
+ * native unit test can exercise the trigger format directly. */
 
 /* ================================================================== */
 /* X11 backend                                                         */
@@ -442,9 +366,16 @@ static int portal_bind(char *err_buf, int err_sz) {
     for (int i = 0; i < g_hotkeyCount; i++) {
         GVariantBuilder props;
         g_variant_builder_init(&props, G_VARIANT_TYPE("a{sv}"));
+
         char trigger[128];
         buildTrigger(trigger, sizeof(trigger), g_hotkeys[i].modifiers, g_hotkeys[i].keyCode);
-        g_variant_builder_add(&props, "{sv}", "description", g_variant_new_string(trigger));
+
+        /* description is a user-readable action label, NOT the key combination
+         * (Freedesktop Shortcuts spec). Fall back to the trigger only when the
+         * caller did not supply one, so the portal still has a non-empty label. */
+        const char *desc = g_hotkeys[i].description[0] ? g_hotkeys[i].description
+                                                       : (trigger[0] ? trigger : "Shortcut");
+        g_variant_builder_add(&props, "{sv}", "description", g_variant_new_string(desc));
         if (trigger[0])
             g_variant_builder_add(&props, "{sv}", "preferred_trigger", g_variant_new_string(trigger));
         g_variant_builder_add(&shortcuts, "(sa{sv})", g_hotkeys[i].shortcut_id, &props);
@@ -657,7 +588,7 @@ Java_dev_nucleusframework_globalhotkey_linux_NativeLinuxHotKeyBridge_nativeInit(
 
 JNIEXPORT jstring JNICALL
 Java_dev_nucleusframework_globalhotkey_linux_NativeLinuxHotKeyBridge_nativeRegister(
-    JNIEnv *env, jclass clazz, jlong id, jint modifiers, jint keyCode) {
+    JNIEnv *env, jclass clazz, jlong id, jint modifiers, jint keyCode, jstring description) {
     (void)clazz;
     if (!g_running) return (*env)->NewStringUTF(env, "Not initialized");
 
@@ -671,6 +602,15 @@ Java_dev_nucleusframework_globalhotkey_linux_NativeLinuxHotKeyBridge_nativeRegis
     e->id = id; e->keyCode = keyCode; e->modifiers = modifiers;
     e->x11_keycode = 0; e->x11_modifiers = 0;
     snprintf(e->shortcut_id, sizeof(e->shortcut_id), "nucleus_%ld", (long)id);
+
+    e->description[0] = '\0';
+    if (description) {
+        const char *d = (*env)->GetStringUTFChars(env, description, NULL);
+        if (d) {
+            snprintf(e->description, sizeof(e->description), "%s", d);
+            (*env)->ReleaseStringUTFChars(env, description, d);
+        }
+    }
 
     if (g_backend == BACKEND_X11) {
         KeySym ks = awtToKeySym(keyCode);

--- a/global-hotkey/src/main/native/linux/nucleus_hotkey_keys.h
+++ b/global-hotkey/src/main/native/linux/nucleus_hotkey_keys.h
@@ -1,0 +1,94 @@
+/**
+ * Shared key/modifier mapping for the Linux global hotkey backends.
+ *
+ * Kept header-only (static inline) so the JNI implementation and the native
+ * unit test can share a single source of truth for the trigger-string format.
+ *
+ * Depends only on X11 keysym definitions and XKeysymToString(), which is a pure
+ * lookup that needs no open Display — safe to use from the Wayland/portal path.
+ */
+
+#ifndef NUCLEUS_HOTKEY_KEYS_H
+#define NUCLEUS_HOTKEY_KEYS_H
+
+#include <string.h>
+
+#include <X11/Xlib.h>
+#include <X11/keysym.h>
+
+#define MOD_ALT     0x0001
+#define MOD_CONTROL 0x0002
+#define MOD_SHIFT   0x0004
+#define MOD_META    0x0008
+
+/* AWT VK_* → X11 KeySym. The X11 keysym names returned by XKeysymToString()
+ * are identical to the xkbcommon-keysyms.h identifiers (minus XKB_KEY_) that
+ * the Freedesktop Shortcuts spec requires, so this single table also drives
+ * the portal preferred_trigger key names. */
+static inline KeySym awtToKeySym(int vk) {
+    if (vk >= 0x41 && vk <= 0x5A) return XK_a + (vk - 0x41);
+    if (vk >= 0x30 && vk <= 0x39) return XK_0 + (vk - 0x30);
+    if (vk >= 0x70 && vk <= 0x7B) return XK_F1 + (vk - 0x70);
+    if (vk >= 0x60 && vk <= 0x69) return XK_KP_0 + (vk - 0x60);
+    switch (vk) {
+        case 0x0A: return XK_Return;      case 0x1B: return XK_Escape;
+        case 0x08: return XK_BackSpace;    case 0x09: return XK_Tab;
+        case 0x20: return XK_space;        case 0x7F: return XK_Delete;
+        case 0x14: return XK_Caps_Lock;
+        case 0x26: return XK_Up;           case 0x28: return XK_Down;
+        case 0x25: return XK_Left;         case 0x27: return XK_Right;
+        case 0x24: return XK_Home;         case 0x23: return XK_End;
+        case 0x21: return XK_Page_Up;      case 0x22: return XK_Page_Down;
+        case 0x9B: return XK_Insert;
+        case 0xC0: return XK_grave;        case 0x2D: return XK_minus;
+        case 0x3D: return XK_equal;        case 0x5B: return XK_bracketleft;
+        case 0x5D: return XK_bracketright; case 0x5C: return XK_backslash;
+        case 0x3B: return XK_semicolon;    case 0xDE: return XK_apostrophe;
+        case 0x2C: return XK_comma;        case 0x2E: return XK_period;
+        case 0x2F: return XK_slash;
+        case 0x6A: return XK_KP_Multiply;  case 0x6B: return XK_KP_Add;
+        case 0x6D: return XK_KP_Subtract;  case 0x6E: return XK_KP_Decimal;
+        case 0x6F: return XK_KP_Divide;
+        case 0xB3: return 0x1008FF14;      case 0xB2: return 0x1008FF15;
+        case 0xB0: return 0x1008FF17;      case 0xB1: return 0x1008FF16;
+        default:   return NoSymbol;
+    }
+}
+
+/* AWT modifier bit → Freedesktop Shortcuts spec modifier name. */
+static inline const char *modName(int mod) {
+    switch (mod) {
+        case MOD_CONTROL: return "CTRL";
+        case MOD_ALT:     return "ALT";
+        case MOD_SHIFT:   return "SHIFT";
+        case MOD_META:    return "LOGO";
+        default:          return NULL;
+    }
+}
+
+/* Build a preferred_trigger string in Freedesktop Shortcuts spec syntax:
+ *   modifiers and key joined with '+', e.g. "CTRL+ALT+a", "CTRL+SHIFT+bracketleft".
+ * Modifier names: CTRL, ALT, SHIFT, LOGO. Key names come from XKeysymToString()
+ * (xkbcommon identifier without the XKB_KEY_ prefix).
+ *
+ * Writes an empty string if the key has no known keysym. */
+static inline void buildTrigger(char *buf, int sz, int mods, int vk) {
+    static const int ORDER[] = { MOD_CONTROL, MOD_ALT, MOD_SHIFT, MOD_META };
+
+    buf[0] = '\0';
+    KeySym ks = awtToKeySym(vk);
+    if (ks == NoSymbol) return;
+
+    const char *keyName = XKeysymToString(ks);
+    if (!keyName) return;
+
+    for (unsigned i = 0; i < sizeof(ORDER) / sizeof(ORDER[0]); i++) {
+        if (mods & ORDER[i]) {
+            strncat(buf, modName(ORDER[i]), sz - strlen(buf) - 1);
+            strncat(buf, "+", sz - strlen(buf) - 1);
+        }
+    }
+    strncat(buf, keyName, sz - strlen(buf) - 1);
+}
+
+#endif /* NUCLEUS_HOTKEY_KEYS_H */

--- a/global-hotkey/src/test/native/linux/nucleus_hotkey_keys_test.c
+++ b/global-hotkey/src/test/native/linux/nucleus_hotkey_keys_test.c
@@ -1,0 +1,68 @@
+/**
+ * Regression test for the Linux portal preferred_trigger format.
+ *
+ * Covers issue #264: triggers were emitted in GTK accelerator syntax
+ * ("<Control><Alt>a") instead of the Freedesktop Shortcuts spec syntax
+ * ("CTRL+ALT+a"), and punctuation/bracket/numpad keys produced a malformed
+ * trigger with no key name because awtToKeyName() returned NULL for them.
+ *
+ * Build & run (Linux, requires libX11):
+ *   cc -I src/main/native/linux \
+ *      src/test/native/linux/nucleus_hotkey_keys_test.c -lX11 -o /tmp/hk_test \
+ *   && /tmp/hk_test
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "nucleus_hotkey_keys.h"
+
+/* AWT VK_* codes referenced by the test cases. */
+#define VK_A           0x41
+#define VK_F1          0x70
+#define VK_BRACKETLEFT 0x5B
+#define VK_BRACKETRIGHT 0x5D
+#define VK_SEMICOLON   0x3B
+#define VK_KP0         0x60
+#define VK_PLAY        0xB3
+
+static int failures = 0;
+
+static void expect(int mods, int vk, const char *want) {
+    char got[128];
+    buildTrigger(got, sizeof(got), mods, vk);
+    if (strcmp(got, want) != 0) {
+        fprintf(stderr, "FAIL: buildTrigger(mods=0x%x, vk=0x%x) = \"%s\", want \"%s\"\n",
+                mods, vk, got, want);
+        failures++;
+    } else {
+        printf("ok: \"%s\"\n", got);
+    }
+}
+
+int main(void) {
+    /* Spec format: modifiers and key joined with '+'. */
+    expect(MOD_CONTROL | MOD_ALT, VK_A, "CTRL+ALT+a");
+    expect(MOD_CONTROL | MOD_SHIFT, VK_A, "CTRL+SHIFT+a");
+    expect(MOD_META, VK_A, "LOGO+a");
+    expect(0, VK_F1, "F1");
+
+    /* Punctuation / bracket keys previously yielded a key-less trigger. */
+    expect(MOD_CONTROL | MOD_SHIFT, VK_BRACKETLEFT, "CTRL+SHIFT+bracketleft");
+    expect(MOD_CONTROL, VK_BRACKETRIGHT, "CTRL+bracketright");
+    expect(MOD_CONTROL, VK_SEMICOLON, "CTRL+semicolon");
+
+    /* Numpad and media keys. */
+    expect(MOD_CONTROL, VK_KP0, "CTRL+KP_0");
+    expect(0, VK_PLAY, "XF86AudioPlay");
+
+    /* Canonical modifier ordering regardless of input bit order. */
+    expect(MOD_SHIFT | MOD_CONTROL | MOD_ALT, VK_A, "CTRL+ALT+SHIFT+a");
+
+    if (failures) {
+        fprintf(stderr, "%d test(s) failed\n", failures);
+        return 1;
+    }
+    printf("all trigger-format tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes the Linux Wayland/portal `GlobalShortcuts` backend so the system shortcut dialog opens with the correct, pre-filled key combination and a meaningful description.

- `BindShortcuts.preferred_trigger` now follows the **Freedesktop Shortcuts spec** (`CTRL+ALT+a`) instead of GTK accelerator syntax (`<Control><Alt>a`).
- Key names are derived from `XKeysymToString()`, making `awtToKeySym()` the single source of truth — every mapped key (brackets, punctuation, numpad, media) is now covered. Previously these returned `NULL`, producing malformed key-less triggers like `<Control>`.
- `description` is now a user-readable action label (per spec) rather than the key combination. An optional `description` parameter is threaded through `GlobalHotKeyManager.register(...)` to the portal, falling back to the trigger when none is supplied.
- Shared key/trigger logic moved into `nucleus_hotkey_keys.h`.

## Test plan

- [x] New native regression test `nucleus_hotkey_keys_test.c` fails on the old logic (malformed/key-less triggers) and passes on the new logic.
- [x] `nucleus_global_hotkey_linux.c` builds clean via `build.sh` and passes `-Wall -Wextra`.
- [x] Existing `register()` call sites remain source-compatible (new `description` param defaults to `null`).

Closes #264