### PR TITLE
fix(appimage): drop injected --no-sandbox in the Linux launcher wrapper

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -1357,6 +1357,15 @@ abstract class AbstractElectronBuilderPackageTask
                   esac
                 done
                 DIR="$(cd "$(dirname "$SCRIPT")" && pwd)"
+                # electron-builder's AppImage AppRun injects --no-sandbox when unprivileged user
+                # namespaces are unavailable (the Ubuntu 24.04+ default), on the assumption the
+                # binary is Chromium/Electron. This is a JVM/native app with no such sandbox, and
+                # its launcher may abort on the unknown option, so drop the flag before delegating.
+                for arg in "$@"; do
+                  shift
+                  [ "$arg" = "--no-sandbox" ] && continue
+                  set -- "$@" "$arg"
+                done
                 exec "$DIR/$$relativePath" "$@"
                 """.trimIndent() + "\n"
 


### PR DESCRIPTION
## Problem

AppImages built by Nucleus fail to launch on Ubuntu 24.04+ (and any host where unprivileged user namespaces are restricted):

```
$ ./MyApp.AppImage
Error: no such option --no-sandbox
```

Fixes #266.

## Root cause

Nucleus packages the AppImage via electron-builder. electron-builder's generated `AppRun` prepends `--no-sandbox` to the launched binary when `unshare -Ur true` fails (i.e. unprivileged user namespaces are unavailable, the Ubuntu 24.04+ default), on the assumption the binary is Chromium/Electron:

```bash
if [ $HAVE_NO_SANDBOX -eq 0 ] && ! unshare -Ur true 2>/dev/null ; then
  NO_SANDBOX=(--no-sandbox)
fi
...
exec "$BIN" "${NO_SANDBOX[@]}" "${EXECUTABLE_ARGS[@]}" "${args[@]}"
```

But Nucleus packages JVM / GraalVM-native apps, which have no Chromium sandbox and whose launchers may abort on the unknown option.

There is no electron-builder configuration to disable this: the injection is hardcoded in `generateAppRunScript`, the `AppRun` is rewritten on every build, and `linux.executableArgs` can only *add* arguments (it cannot remove `--no-sandbox`).

## Fix

`AppRun` execs `"$APPDIR/<executableName>"`, which is the launcher wrapper Nucleus already generates in `ensureLinuxExecutableAlias` (it resolves symlinks and delegates to the real `bin/<launcher>`). This drops `--no-sandbox` in that wrapper before delegating:

```sh
for arg in "$@"; do
  shift
  [ "$arg" = "--no-sandbox" ] && continue
  set -- "$@" "$arg"
done
exec "$DIR/<relativePath>" "$@"
```

Chosen here because it:

- needs no AppImage repackaging and no extra tooling;
- leaves electron-builder's artifact bytes, `sha512`, and `.blockmap` untouched, so auto-update metadata stays valid;
- covers both jpackage and GraalVM launchers, which both route through this wrapper;
- is independent of which electron-builder version a build resolves.

## Alternatives considered

- **Post-processing the built `.AppImage`** to rewrite `AppRun`: requires extract + repackage tooling and would invalidate the auto-update `sha512`/`.blockmap` electron-builder just generated.
- **Upstream electron-builder change** to skip the injection for non-Electron targets: the cleaner long-term fix, but not something Nucleus can do locally.

## Testing

The POSIX `sh` rebuild idiom preserves argument order and arguments containing spaces; only exact `--no-sandbox` tokens are removed.
