### PR TITLE
build(appimage): pin electron-builder for reproducible packaging

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderToolManager.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderToolManager.kt
@@ -37,6 +37,14 @@ internal class ElectronBuilderToolManager(
 ) {
     companion object {
         private const val ELECTRON_BUILDER_PACKAGE = "electron-builder"
+
+        // Pin electron-builder so the packaged output (and the generated AppImage AppRun) is
+        // reproducible across builds. Left unpinned, `npx electron-builder` resolves whatever
+        // version is latest at build time, so the same plugin + sources can produce different
+        // artifacts on different days. See #266.
+        private const val ELECTRON_BUILDER_VERSION = "26.15.5"
+        private const val ELECTRON_BUILDER_SPEC = "$ELECTRON_BUILDER_PACKAGE@$ELECTRON_BUILDER_VERSION"
+
         private const val PREPACKAGED_ELECTRON_VERSION = "33.0.0"
     }
 
@@ -58,7 +66,7 @@ internal class ElectronBuilderToolManager(
         val args =
             buildList {
                 add("--yes")
-                add(ELECTRON_BUILDER_PACKAGE)
+                add(ELECTRON_BUILDER_SPEC)
                 add("--prepackaged")
                 add(invocation.prepackagedDir.absolutePath)
                 add("--config")
@@ -156,7 +164,7 @@ internal class ElectronBuilderToolManager(
             val result =
                 execOperations.exec { spec ->
                     spec.executable = npx.absolutePath
-                    spec.args = listOf("--yes", ELECTRON_BUILDER_PACKAGE, "--version")
+                    spec.args = listOf("--yes", ELECTRON_BUILDER_SPEC, "--version")
                     spec.isIgnoreExitValue = true
                     spec.standardOutput = ByteArrayOutputStream()
                     spec.errorOutput = ByteArrayOutputStream()


### PR DESCRIPTION
## Problem

Nucleus packages the AppImage (and other Linux/Windows targets) by invoking electron-builder, but the invocation is unpinned:

```kotlin
private const val ELECTRON_BUILDER_PACKAGE = "electron-builder"
...
add("--yes")
add(ELECTRON_BUILDER_PACKAGE)   // -> `npx electron-builder`, resolves "latest" at build time
```

On a fresh CI runner `npx electron-builder` resolves to whatever is latest on npm at that moment. With an unchanged plugin version and unchanged project sources, two builds on different days can therefore produce different artifacts.

This isn't hypothetical: it's the mechanism behind #266. A consumer's AppImage gained electron-builder's `--no-sandbox` AppRun injection between two builds two weeks apart, purely because the resolved electron-builder version crossed a release boundary. Same plugin, same sources, different output.

## Fix

Pin electron-builder to a fixed version and use it at every call site:

```kotlin
private const val ELECTRON_BUILDER_VERSION = "26.15.5"
private const val ELECTRON_BUILDER_SPEC = "$ELECTRON_BUILDER_PACKAGE@$ELECTRON_BUILDER_VERSION"
```

`npx electron-builder@26.15.5` now resolves deterministically, so packaging output is reproducible across builds and machines.

## Notes

- This is about **reproducibility only**. It does not by itself address the `--no-sandbox` AppRun injection from #266 (26.15.5 post-dates that change); the launcher-wrapper fix in #267 handles that. The two changes are complementary.
- 26.15.5 is the latest stable at time of writing. Bumping the pin is a one-line change. If you'd prefer it overridable (Gradle property / DSL) rather than a hard constant, happy to adjust.
