### PR TITLE
feat(window): screen bounds + undecorated windows for cross-window drag & drop

### DIFF
--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
@@ -85,6 +85,8 @@ fun NucleusApplicationScope.JewelDecoratedWindow(
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    // Fully borderless window (no macOS traffic lights) — for overlay/ghost windows.
+    undecorated: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -111,6 +113,7 @@ fun NucleusApplicationScope.JewelDecoratedWindow(
             enabled = enabled,
             focusable = focusable,
             alwaysOnTop = alwaysOnTop,
+            undecorated = undecorated,
             minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -101,6 +101,9 @@ internal fun ApplicationScope.openDecoratedWindow(
     alwaysOnTop: Boolean = false,
     maximized: Boolean = false,
     isDialog: Boolean = false,
+    // Fully borderless window: no native chrome at all — on macOS this drops the
+    // traffic-light buttons too. For overlay/ghost windows (drag previews, HUDs).
+    undecorated: Boolean = false,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     macOSStyle: MacOSStyle = MacOSStyle.Classic,
@@ -121,7 +124,8 @@ internal fun ApplicationScope.openDecoratedWindow(
             // On Windows + Linux we drop them — we draw the close/min/max buttons
             // ourselves via [WindowControlsWindows] / [WindowControlsLinux] inside
             // the user's [TitleBar] composable, mirroring decorated-window-jni.
-            decorations = Platform.Current == Platform.MacOS,
+            // `undecorated` opts out entirely (borderless, no traffic lights).
+            decorations = !undecorated && Platform.Current == Platform.MacOS,
             resizable = resizable,
             visible = false, // we show after first paint
             // Pass `maximized` to the builder so Tao sets it BEFORE the window

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -60,6 +60,8 @@ fun ApplicationScope.DecoratedWindow(
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
     isDialog: Boolean = false,
+    /** Fully borderless window (no traffic lights on macOS) — for overlays/ghosts. */
+    undecorated: Boolean = false,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     macOSStyle: MacOSStyle = MacOSStyle.Classic,
@@ -128,6 +130,7 @@ fun ApplicationScope.DecoratedWindow(
                     // monitor handle which we don't have yet).
                     maximized = state.placement == WindowPlacement.Maximized,
                     isDialog = isDialog,
+                    undecorated = undecorated,
                     onPreviewKeyEvent = { latestPreview(it) },
                     onKeyEvent = { latestKey(it) },
                     macOSStyle = macOSStyle,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -329,6 +329,41 @@ class TaoWindow internal constructor(
         get() = NativeTaoBridge.nativeIsMaximized(handle)
 
     /**
+     * Outer (decoration-inclusive) window bounds as `[x, y, width, height]` in
+     * physical screen pixels with a top-left origin, or `null` while the native
+     * window isn't realized / the platform bridge is unavailable. All three
+     * platform bridges share the Win32 `GetWindowRect` convention.
+     */
+    fun outerBoundsPx(): LongArray? =
+        when (Platform.Current) {
+            Platform.Windows -> {
+                if (!NativeTaoWindowsDecoBridge.isLoaded) {
+                    null
+                } else {
+                    NativeTaoBridge
+                        .nativeHwndHandle(handle)
+                        .takeIf { it != 0L }
+                        ?.let { NativeTaoWindowsDecoBridge.nativeGetWindowRect(it) }
+                }
+            }
+            Platform.MacOS -> {
+                if (!NativeTaoMacOsDecoBridge.isLoaded) {
+                    null
+                } else {
+                    nativeHandle
+                        .takeIf { it != 0L }
+                        ?.let { NativeTaoMacOsDecoBridge.nativeGetWindowRect(it) }
+                }
+            }
+            Platform.Linux -> NativeTaoBridge.nativeLinuxGetWindowRect(handle)
+            else -> null
+        }
+
+    /** The window's current monitor scale factor (1.0 on non-HiDPI displays). */
+    val scaleFactor: Float
+        get() = NativeTaoBridge.nativeScaleFactor(handle).coerceAtLeast(1) / 1000f
+
+    /**
      * Linux/GTK only: true when the compositor has tiled/snapped the window to a
      * screen edge (Aero Snap). Always `false` on Windows/macOS (the native lib
      * returns `false` outside the GTK backend). Used to drop the Compose-drawn

--- a/docs/migration-2.0.md
+++ b/docs/migration-2.0.md
@@ -462,6 +462,137 @@ No ordered init list. No `SingleInstanceManager` plumbing. No restore counter an
 
 ---
 
+## Field Notes — Multi-Window & Cross-Window Drag on the Tao Backend
+
+Everything below was learned migrating a real app (Zayit) to Chrome-style multi-window with
+cross-window tab drag & drop on the Tao backend. If your 1.x code leaned on AWT for anything
+window- or pointer-related, read this section before porting.
+
+### AWT is absent on Tao — and it fails *silently*
+
+The Tao backend never creates AWT windows. Every AWT API still compiles, still runs, and does
+**nothing**: no events, no windows, `null` handles. There is no exception to catch — features
+just go dead. Grep your app for these and replace them:
+
+| 1.x / AWT pattern | Symptom on Tao | 2.0 replacement |
+|---|---|---|
+| `Toolkit.addAWTEventListener(…)` (global mouse/key tracking) | Listener never fires | Observe the Compose pointer stream in `PointerEventPass.Initial` (see drag recipe below) |
+| `KeyboardFocusManager.addKeyEventDispatcher(…)` | Dispatcher never fires | `onPreviewKeyEvent` / `onKeyEvent` on the window |
+| `nucleusWindow.unsafe.awtWindow` | Always `null` | `nucleusWindow.boundsOnScreen()`, `toFront()`, `requestFocus()`, … |
+| `window.locationOnScreen`, `MouseInfo.getPointerInfo()` | N/A (no AWT window) | `NucleusWindow.boundsOnScreen()` + pointer positions from Compose |
+| `JWindow` / `JDialog` overlays (drag ghosts, HUDs) | Window never shows (or AWT headless) | `JewelDecoratedWindow(undecorated = true, focusable = false, alwaysOnTop = true)` |
+| `GraphicsEnvironment.getScreenDevices()` (multi-monitor math) | May throw `HeadlessException` | Guard with `runCatching`; work-area natives exist per-platform if needed |
+
+Rule of thumb: portable code goes through `NucleusWindow`; anything reached via `unsafe.*` is a
+deliberate opt-out that must handle the other backend returning `null`.
+
+### New portable APIs (added 2026-07)
+
+```kotlin
+// Backend-agnostic outer window bounds, logical (dp) screen coordinates, top-left origin.
+// AWT reads user-space coords directly; Tao converts the physical rect through the window's
+// scale factor. Null while the native window isn't realized yet.
+val bounds: NucleusWindowBounds? = nucleusWindow.boundsOnScreen()
+
+// Tao-level primitives behind it (unsafe tier):
+val rectPx: LongArray? = taoWindow.outerBoundsPx() // [x, y, w, h] physical px, Win32 GetWindowRect convention on all 3 OSes
+val scale: Float = taoWindow.scaleFactor
+
+// Fully borderless windows — on macOS this is the only way to get rid of the traffic lights,
+// which are NATIVE and present on every decorated Tao window:
+JewelDecoratedWindow(
+    onCloseRequest = {},
+    undecorated = true,     // ← new; honoured by Tao, ignored by AWT
+    focusable = false,      // never becomes key — no focus flicker while it follows the pointer
+    alwaysOnTop = true,
+    resizable = false,
+    state = ghostWindowState,
+) { /* chip content */ }
+```
+
+### Coordinate systems cheat sheet
+
+Mixing these up produces hit-tests that are off by exactly one scale factor — on a Retina
+display everything lands at half the expected distance.
+
+| Value | Unit | Origin | Notes |
+|---|---|---|---|
+| Compose scene coords (`boundsInWindow`, pointer positions) | **physical px** | window top-left | divide by `LocalDensity.current.density` to get dp |
+| `WindowState.position` / `.size` | logical dp | screen top-left | bidirectionally synced with the native window |
+| `TaoWindow.outerBoundsPx()`, work-area natives | **physical px** | primary-screen top-left | macOS Y is already flipped from AppKit's bottom-left |
+| `NucleusWindow.boundsOnScreen()` | logical dp | screen top-left | the one to use in app code |
+
+Conversion used for cross-window hit-testing:
+`screenDp = window.boundsOnScreen() + positionInWindowPx / density`.
+
+### `WindowState` sync semantics — two traps
+
+1. **`state.position` is only `Absolute` after a native move event.** A window created with
+   `WindowPosition.Aligned(Center)` keeps `Aligned` in its state — the realized coordinates are
+   never written back. Don't derive screen positions from `WindowState`; use
+   `boundsOnScreen()`.
+2. **Placement is applied at builder time.** A window created `Maximized` and mutated to
+   `Floating` a moment later visibly flashes maximized first. If you restore window geometry
+   from disk, read it *before* creating the window and construct the `WindowState` with the
+   final placement/size/position — don't create-then-mutate.
+
+### Multiple windows
+
+`JewelDecoratedWindow` is a plain composable on the application scope — call it N times for N
+windows, keyed by a stable id:
+
+```kotlin
+nucleusApplication(args) {
+    val windows by windowManager.windows.collectAsState()
+    windows.forEach { w ->
+        key(w.id) {
+            JewelDecoratedWindow(state = w.windowState, …) { … }
+        }
+    }
+}
+```
+
+Focus tracking comes from `nucleusWindow.focusFlow`; bring-to-front is
+`toFront()` + `requestFocus()` (works on Tao via `nativeFocus`).
+
+### Cross-window drag & drop recipe (no OS DnD involved)
+
+The platform captures the pointer during a button-held drag: the **source window keeps
+receiving move events even when the cursor is outside its bounds** (macOS `mouseDragged`,
+Win32 `SetCapture`, X11 implicit grab). That capture is the whole trick — it replaces the
+global AWT listener an AWT implementation would use (IntelliJ's `DockManagerImpl` pattern):
+
+1. Observe the drag in the source window with a non-consuming `pointerInput` in
+   `PointerEventPass.Initial` — the gesture owner (e.g. a reorderable row) is unaffected.
+2. Convert to logical screen coords with `boundsOnScreen()` + `position / density`.
+3. Hit-test the other windows' registered drop areas in screen space. Make drop targets
+   generous (a whole title-bar strip, not just the tabs row — with one tab the row is a
+   ~180 dp target users will miss).
+4. Show a ghost: a small `undecorated + focusable=false + alwaysOnTop` window following the
+   pointer via `WindowState.position` mutations. Create it once per drag session and hide it
+   with `visible=false` instead of disposing — recreating a native window mid-drag stutters.
+5. On release: mutate your model (move the tab / spawn a window). A window spawned "under the
+   cursor" should be `Floating` at a **reduced** size — deriving it from a maximized source
+   window otherwise reproduces a maximized footprint.
+
+Two things that do **not** work for the ghost:
+
+- **Compose `Popup`**: on Tao, popups are real native panels (`NSPanel` / child HWND), but they
+  are positioned and clamped **within the parent window** — a popup cannot float outside the
+  window bounds.
+- **A decorated window**: on macOS every decorated Tao window carries native traffic lights.
+  A ghost following the cursor puts them right under the pointer, hover-glowing. That is what
+  `undecorated = true` is for.
+
+### Wayland caveat
+
+Native Wayland (xdg-shell) forbids clients from positioning toplevels: `setOuterPosition` is a
+no-op, so ghost placement, cascading, and "spawn under the cursor" degrade to
+compositor-decided placement. Nucleus logs a one-shot warning; `NUCLEUS_TAO_LINUX_RENDERER=x11`
+falls back to XWayland when precise positioning matters.
+
+---
+
 ## Troubleshooting
 
 **My imports won't resolve after the rename.**
@@ -507,3 +638,38 @@ The IntelliJ snapshots repo is missing. Add `maven("https://www.jetbrains.com/in
 
 **`Dependency resolution is looking for a library compatible with JVM runtime version 11`.**
 Bump the toolchain — Nucleus 2.0 requires JDK 25 for the Jewel stack and JDK 17 for `nucleus-application`. See [Prerequisites](#prerequisites).
+
+**My global `AWTEventListener` / `KeyEventDispatcher` never fires on Tao.**
+Expected — the Tao backend creates no AWT windows, so no AWT events exist. There is no error;
+the listener is simply never called. Replace with Compose-level observation (a non-consuming
+`pointerInput` in `PointerEventPass.Initial`, or the window's `onPreviewKeyEvent`). See
+[Field Notes → AWT is absent on Tao](#awt-is-absent-on-tao--and-it-fails-silently).
+
+**My floating overlay window shows macOS traffic lights (and they highlight under the cursor).**
+Every decorated Tao window keeps the native buttons on macOS. Pass `undecorated = true` (plus
+`focusable = false`, `alwaysOnTop = true` for overlays) — see
+[Field Notes → New portable APIs](#new-portable-apis-added-2026-07).
+
+**A Compose `Popup` won't render outside the window.**
+By design: Tao popups are native panels, but positioned and clamped within the parent window's
+bounds. Anything that must float beyond the window (drag ghost, tear-off preview) needs a real
+window with `undecorated = true`.
+
+**Cross-window hit-testing is off by ~2× on Retina / HiDPI displays.**
+You mixed physical px and logical dp. Compose scene coordinates (`boundsInWindow`, pointer
+positions) are physical px on Tao — divide by `LocalDensity`; `boundsOnScreen()` and
+`WindowState` are logical. See [Field Notes → Coordinate systems](#coordinate-systems-cheat-sheet).
+
+**A restored window flashes maximized before jumping to its saved floating frame.**
+Placement is applied at window-builder time. Read the persisted geometry *before* composing the
+window and build the initial `WindowState` from it, instead of creating the window with a
+default state and mutating it once your restore logic runs.
+
+**`WindowState.position` says `Aligned` even though the window is clearly somewhere on screen.**
+Also by design: the realized coordinates of an `Aligned` position are not written back into the
+state (only native move events produce `Absolute`). Use `NucleusWindow.boundsOnScreen()` for
+real screen coordinates.
+
+**Windows opened programmatically stack exactly on top of each other on Wayland.**
+Native Wayland forbids client-side toplevel positioning; cascading/`setOuterPosition` are
+no-ops. Set `NUCLEUS_TAO_LINUX_RENDERER=x11` to fall back to XWayland if placement matters.

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/AwtDialogNucleusWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/AwtDialogNucleusWindow.kt
@@ -41,6 +41,18 @@ internal class AwtDialogNucleusWindow(
     override val isMaximized: Boolean get() = false
     override val isFullscreen: Boolean get() = false
 
+    override fun boundsOnScreen(): NucleusWindowBounds? =
+        runCatching {
+            if (!composeDialog.isShowing) return null
+            val location = composeDialog.locationOnScreen
+            NucleusWindowBounds(
+                x = location.x.toFloat(),
+                y = location.y.toFloat(),
+                width = composeDialog.width.toFloat(),
+                height = composeDialog.height.toFloat(),
+            )
+        }.getOrNull()
+
     override fun show() = onEdt { composeDialog.isVisible = true }
 
     override fun hide() = onEdt { composeDialog.isVisible = false }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/AwtNucleusWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/AwtNucleusWindow.kt
@@ -65,6 +65,18 @@ internal class AwtNucleusWindow(
     override val isMaximized: Boolean get() = state.placement == WindowPlacement.Maximized
     override val isFullscreen: Boolean get() = state.placement == WindowPlacement.Fullscreen
 
+    override fun boundsOnScreen(): NucleusWindowBounds? =
+        runCatching {
+            if (!composeWindow.isShowing) return null
+            val location = composeWindow.locationOnScreen
+            NucleusWindowBounds(
+                x = location.x.toFloat(),
+                y = location.y.toFloat(),
+                width = composeWindow.width.toFloat(),
+                height = composeWindow.height.toFloat(),
+            )
+        }.getOrNull()
+
     override fun show() = onEdt { composeWindow.isVisible = true }
 
     override fun hide() = onEdt { composeWindow.isVisible = false }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -30,6 +30,9 @@ fun NucleusApplicationScope.DecoratedWindow(
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    // Fully borderless window (no macOS traffic lights) — for overlay/ghost windows.
+    // Honoured by the Tao backend; the AWT backend currently ignores it.
+    undecorated: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -81,6 +84,7 @@ fun NucleusApplicationScope.DecoratedWindow(
                 enabled = enabled,
                 focusable = focusable,
                 alwaysOnTop = alwaysOnTop,
+                undecorated = undecorated,
                 minimumSize = minimumSize,
                 onPreviewKeyEvent = onPreviewKeyEvent,
                 onKeyEvent = onKeyEvent,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusWindow.kt
@@ -10,18 +10,39 @@ import dev.nucleusframework.window.DecoratedWindowScope
 import kotlinx.coroutines.flow.StateFlow
 
 /**
+ * Outer window bounds in logical (dp) screen coordinates, top-left origin.
+ * The unit matches Compose's `WindowState` values on both backends.
+ */
+data class NucleusWindowBounds(
+    val x: Float,
+    val y: Float,
+    val width: Float,
+    val height: Float,
+)
+
+/**
  * Backend-agnostic handle to a window opened by [DecoratedWindow]. Mirrors the
  * intersection of `ComposeWindow` and `TaoWindow`.
  *
  * Backend-specific bridges live behind [unsafe] — using them is an explicit
  * opt-out of the portable contract.
  */
+@Suppress("TooManyFunctions")
 @Stable
 interface NucleusWindow {
     val isFocused: Boolean
     val isMinimized: Boolean
     val isMaximized: Boolean
     val isFullscreen: Boolean
+
+    /**
+     * Outer (decoration-inclusive) window bounds in logical screen coordinates,
+     * or `null` while the native window isn't realized yet. Backend-agnostic:
+     * AWT reads user-space coordinates directly; Tao converts the physical
+     * window rect through the window's scale factor. Intended for cross-window
+     * features (drag & drop hit-testing, window placement).
+     */
+    fun boundsOnScreen(): NucleusWindowBounds? = null
 
     fun show()
 

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/TaoNucleusWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/TaoNucleusWindow.kt
@@ -46,6 +46,18 @@ internal class TaoNucleusWindow(
     override val isMaximized: Boolean get() = taoWindow.isMaximized
     override val isFullscreen: Boolean get() = taoWindow.isFullscreen
 
+    override fun boundsOnScreen(): NucleusWindowBounds? {
+        val rect = taoWindow.outerBoundsPx() ?: return null
+        if (rect.size != RECT_ARRAY_SIZE) return null
+        val scale = taoWindow.scaleFactor.takeIf { it > 0f } ?: 1f
+        return NucleusWindowBounds(
+            x = rect[0] / scale,
+            y = rect[1] / scale,
+            width = rect[2] / scale,
+            height = rect[3] / scale,
+        )
+    }
+
     override fun show() = taoWindow.show()
 
     override fun hide() = taoWindow.hide()
@@ -103,4 +115,9 @@ internal class TaoNucleusWindow(
             override val taoWindow: TaoWindow = this@TaoNucleusWindow.taoWindow
             override val taoHandle: Long = this@TaoNucleusWindow.taoWindow.handle
         }
+
+    private companion object {
+        /** Native window rects arrive as `[x, y, width, height]`. */
+        const val RECT_ARRAY_SIZE = 4
+    }
 }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -42,6 +42,7 @@ internal object TaoDecoratedWindowAdapter {
         enabled: Boolean,
         focusable: Boolean,
         alwaysOnTop: Boolean,
+        undecorated: Boolean,
         minimumSize: DpSize?,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
@@ -66,6 +67,7 @@ internal object TaoDecoratedWindowAdapter {
                 enabled = enabled,
                 focusable = focusable,
                 alwaysOnTop = alwaysOnTop,
+                undecorated = undecorated,
                 onPreviewKeyEvent = onPreviewKeyEvent,
                 onKeyEvent = onKeyEvent,
             ) {


### PR DESCRIPTION
## What

Two portable additions to the window API, plus migration-guide field notes. Motivated by a real migration: Chrome-style multi-window with cross-window tab drag & drop in Zayit, on the Tao backend.

### `NucleusWindow.boundsOnScreen(): NucleusWindowBounds?`

Outer window bounds in logical (dp) screen coordinates, top-left origin, on both backends:

- **AWT**: `locationOnScreen` + size (user-space, already logical).
- **Tao**: new `TaoWindow.outerBoundsPx()` — dispatches to the existing per-platform `nativeGetWindowRect` bridges (macOS NSView, Windows HWND, Linux GTK; all follow the Win32 `GetWindowRect` convention, physical px, top-left) — divided by the new `TaoWindow.scaleFactor`.

**No new natives**: everything reuses JNI entry points already shipped in the prebuilt libraries.

This is the missing primitive for cross-window hit-testing: `WindowState.position` is not a substitute because an `Aligned` position is never written back as `Absolute` (only native move events do that).

### `undecorated: Boolean` through the DecoratedWindow chain

`JewelDecoratedWindow` → `NucleusApplicationScope.DecoratedWindow` → `tao.DecoratedWindow` → `openDecoratedWindow`. Creates a fully borderless window — on macOS this also removes the native traffic-light buttons, which are otherwise present on every decorated Tao window (an always-on-top drag ghost following the pointer ends up with hover-glowing window controls right under the cursor without this). Honoured by the Tao backend; AWT ignores it for now.

Typical use, a drag-preview ghost:

```kotlin
JewelDecoratedWindow(
    onCloseRequest = {},
    state = ghostState,
    undecorated = true,
    focusable = false,
    alwaysOnTop = true,
    resizable = false,
) { /* chip */ }
```

### Docs

`docs/migration-2.0.md` gains a *Field Notes — Multi-Window & Cross-Window Drag on the Tao Backend* section (silent AWT failure table, coordinate-system cheat sheet, WindowState sync traps, drag & drop recipe, why Popup/decorated windows don't work as ghosts, Wayland caveat) and eight matching troubleshooting entries.

## Validation

- Exercised end-to-end by Zayit's cross-window tab DnD on macOS/Tao (drop hit-testing, ghost window, detach placement, boot-time geometry restore).
- `ktlintCheck` + `detekt` green on the touched modules. Pre-existing detekt findings in `TaoMainDispatcher.kt` / `TaoComposeSceneHostWindows.kt` (untouched files) are unchanged.