### PR TITLE
feat(menu-macos): searchable native menus via SearchField items

### DIFF
--- a/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativeMenuBar.kt
+++ b/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativeMenuBar.kt
@@ -293,6 +293,24 @@ class NativeMenuScope internal constructor() {
         )
     }
 
+    // ── SearchField ──────────────────────────────────────────────────────
+
+    /**
+     * Adds a search field to the menu (Chrome-History-style): typing filters the menu's other
+     * items natively by title (case/diacritic-insensitive), separators are hidden while a query
+     * is active, and everything resets when the menu closes. The field grabs keyboard focus
+     * when the menu opens.
+     *
+     * @param placeholder Placeholder text shown in the empty field.
+     * @param width Field width in points.
+     */
+    fun SearchField(
+        placeholder: String = "",
+        width: Double = 230.0,
+    ) {
+        entries += MenuItemEntry.SearchFieldEntry(placeholder, width)
+    }
+
     // ── Separator ────────────────────────────────────────────────────────
 
     /** Adds a horizontal separator line. */
@@ -374,6 +392,11 @@ internal sealed class MenuItemEntry {
 
     object SeparatorEntry : MenuItemEntry()
 
+    data class SearchFieldEntry(
+        val placeholder: String,
+        val width: Double,
+    ) : MenuItemEntry()
+
     data class SectionHeaderEntry(
         val title: String,
     ) : MenuItemEntry()
@@ -419,6 +442,11 @@ private fun materializeItems(
                 val header = NsMenuItem.sectionHeader(entry.title)
                 menu.addItem(header)
                 header.close()
+            }
+            is MenuItemEntry.SearchFieldEntry -> {
+                val field = NsMenuItem.searchField(entry.placeholder, entry.width)
+                menu.addItem(field)
+                field.close()
             }
             is MenuItemEntry.SubmenuEntry -> {
                 val menuItem = NsMenuItem(entry.text)

--- a/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativeNsMenuBridge.kt
+++ b/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativeNsMenuBridge.kt
@@ -117,6 +117,12 @@ internal object NativeNsMenuBridge {
 
     @JvmStatic external fun nativeCreateSeparatorItem(): Long
 
+    @JvmStatic
+    external fun nativeCreateSearchFieldItem(
+        placeholder: String,
+        width: Double,
+    ): Long
+
     @JvmStatic external fun nativeCreateSectionHeader(title: String): Long
 
     @JvmStatic external fun nativeRelease(handle: Long)

--- a/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NsMenuItem.kt
+++ b/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NsMenuItem.kt
@@ -32,6 +32,16 @@ internal class NsMenuItem internal constructor(
         /** Creates a section header item (macOS 14+). */
         fun sectionHeader(title: String): NsMenuItem = NsMenuItem(NativeNsMenuBridge.nativeCreateSectionHeader(title))
 
+        /**
+         * Creates a search-field item: an NSSearchField hosted in the item's view that filters
+         * the sibling items of its menu natively as the user types (title contains query,
+         * case/diacritic-insensitive). The filter resets when the menu closes.
+         */
+        fun searchField(
+            placeholder: String,
+            width: Double = 230.0,
+        ): NsMenuItem = NsMenuItem(NativeNsMenuBridge.nativeCreateSearchFieldItem(placeholder, width))
+
         /** Creates a non-owning wrapper for use in callbacks. */
         internal fun borrowed(handle: Long): NsMenuItem = NsMenuItem(handle, owned = false)
     }

--- a/menu-macos/src/main/native/macos/nucleus_menu_macos.m
+++ b/menu-macos/src/main/native/macos/nucleus_menu_macos.m
@@ -389,6 +389,128 @@ JNIEXPORT jlong JNICALL JNI_FN(nativeCreateSectionHeader)(JNIEnv *env, jclass cl
     }
 }
 
+// ============================================================================
+// SECTION: Search-field menu item (native in-menu filtering)
+// ============================================================================
+
+// Filters the sibling items of its enclosing menu as the user types: an item
+// stays visible while its title contains the query (case/diacritic-insensitive).
+// Separators are hidden while a query is active. Everything resets when the
+// menu closes. Filtering is fully native — no JNI round-trip per keystroke.
+@interface NucleusMenuSearchFilter : NSObject <NSSearchFieldDelegate>
+@property (nonatomic, weak) NSSearchField *field;
+@end
+
+@implementation NucleusMenuSearchFilter
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+        [nc addObserver:self selector:@selector(menuDidEndTracking:)
+                   name:NSMenuDidEndTrackingNotification object:nil];
+        [nc addObserver:self selector:@selector(menuDidBeginTracking:)
+                   name:NSMenuDidBeginTrackingNotification object:nil];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (NSMenu *)hostMenu {
+    return self.field.enclosingMenuItem.menu;
+}
+
+- (void)searchChanged:(id)sender {
+    (void)sender;
+    [self applyFilter];
+}
+
+// Fires on every keystroke — `continuous`/target-action alone only fires on
+// Enter or the clear button, which is what made filtering feel non-live.
+- (void)controlTextDidChange:(NSNotification *)notification {
+    (void)notification;
+    [self applyFilter];
+}
+
+- (void)applyFilter {
+    NSSearchField *field = self.field;
+    if (!field) return;
+    NSMenuItem *host = field.enclosingMenuItem;
+    NSMenu *menu = host.menu;
+    if (!menu) return;
+    NSString *query = [field.stringValue stringByTrimmingCharactersInSet:
+                       [NSCharacterSet whitespaceCharacterSet]];
+    BOOL filtering = query.length > 0;
+    for (NSMenuItem *item in menu.itemArray) {
+        if (item == host) continue;
+        if (!filtering) {
+            item.hidden = NO;
+        } else if (item.separatorItem) {
+            item.hidden = YES;
+        } else {
+            NSRange r = [item.title rangeOfString:query
+                                          options:(NSCaseInsensitiveSearch |
+                                                   NSDiacriticInsensitiveSearch |
+                                                   NSWidthInsensitiveSearch)];
+            item.hidden = (r.location == NSNotFound);
+        }
+    }
+}
+
+- (void)menuDidBeginTracking:(NSNotification *)note {
+    if (note.object != [self hostMenu]) return;
+    NSSearchField *field = self.field;
+    // The item view's window only exists once the menu is on screen.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (field.window) [field.window makeFirstResponder:field];
+    });
+}
+
+- (void)menuDidEndTracking:(NSNotification *)note {
+    if (note.object != [self hostMenu]) return;
+    self.field.stringValue = @"";
+    [self applyFilter];
+}
+
+@end
+
+static char kNucleusSearchFilterKey;
+
+JNIEXPORT jlong JNICALL JNI_FN(nativeCreateSearchFieldItem)(JNIEnv *env, jclass clazz,
+                                                            jstring jPlaceholder, jdouble width) {
+    (void)clazz;
+    @autoreleasepool {
+        NSString *placeholder = toNSString(env, jPlaceholder) ?: @"";
+        __block jlong result = 0;
+        runOnMain(^{
+            CGFloat w = width > 0 ? (CGFloat)width : 230.0;
+            NSMenuItem *item = [[NSMenuItem alloc] initWithTitle:@"" action:nil keyEquivalent:@""];
+            NSView *container = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, w, 28)];
+            NSSearchField *field =
+                [[NSSearchField alloc] initWithFrame:NSMakeRect(10, 3, w - 20, 22)];
+            field.placeholderString = placeholder;
+            field.autoresizingMask = NSViewWidthSizable;
+
+            NucleusMenuSearchFilter *filter = [NucleusMenuSearchFilter new];
+            filter.field = field;
+            field.delegate = filter; // controlTextDidChange: → per-keystroke filtering
+            field.target = filter;
+            field.action = @selector(searchChanged:);
+            // Tie the filter's lifetime to the menu item
+            objc_setAssociatedObject(item, &kNucleusSearchFilterKey, filter,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+            [container addSubview:field];
+            container.autoresizingMask = NSViewWidthSizable;
+            item.view = container;
+            result = retainToHandle(item);
+        });
+        return result;
+    }
+}
+
 JNIEXPORT void JNICALL JNI_FN(nativeRelease)(JNIEnv *env, jclass clazz, jlong handle) {
     (void)env; (void)clazz;
     releaseHandle(handle);


### PR DESCRIPTION
## What

New `NativeMenuScope.SearchField(placeholder, width)` DSL entry for native macOS menus: an `NSSearchField` hosted in a menu item's view that **filters the menu's other items live as the user types**.

- Title matching is case/diacritic/width-insensitive (Hebrew-friendly: `NSDiacriticInsensitiveSearch`).
- Separators are hidden while a query is active; everything resets when the menu closes.
- The field grabs keyboard focus when the menu opens (`NSMenuDidBeginTrackingNotification`).
- Filtering is entirely native — per-keystroke via `NSSearchFieldDelegate controlTextDidChange:` (target/action alone only fires on Enter, which made the first iteration feel non-live). No JNI round-trips while typing, so the open menu updates instantly.

## Implementation

- `nucleus_menu_macos.m`: `NucleusMenuSearchFilter` (delegate + begin/end-tracking observers) and `nativeCreateSearchFieldItem`, lifetime tied to the item via associated object.
- Kotlin: bridge external, `NsMenuItem.searchField()`, `MenuItemEntry.SearchFieldEntry` + materialization.
- Prebuilt dylibs are gitignored; CI rebuilds them at tag time as usual.

## Usage

```kotlin
Menu(historyTitle) {
    SearchField(placeholder = searchPlaceholder)
    Item(showFullHistory, shortcut = NativeKeyShortcut("y")) { … }
    SectionHeader(recentlyVisited)
    visits.forEach { Item(it.title, icon = NsMenuItemImage.SystemSymbol("book.closed")) { … } }
}
```

## Validation

Exercised end-to-end by Zayit's Chrome-style History menu on macOS (Hebrew titles): live filtering per keystroke, reset on close. `ktlintCheck` + `detekt` green on `menu-macos`.