### PR TITLE
fix(tao-linux): positionable overlay windows on Wayland + drag/hide fixes

### DIFF
--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import dev.nucleusframework.application.NucleusApplicationScope
+import dev.nucleusframework.application.NucleusWindow
 import dev.nucleusframework.application.NucleusDecoratedWindowScope
 import dev.nucleusframework.window.AwtDecoratedWindowScope
 import dev.nucleusframework.window.DecoratedWindow
@@ -87,6 +88,10 @@ fun NucleusApplicationScope.JewelDecoratedWindow(
     alwaysOnTop: Boolean = false,
     // Fully borderless window (no macOS traffic lights) — for overlay/ghost windows.
     undecorated: Boolean = false,
+    // Linux/Tao only: popup overlay of [popupFor] — on Wayland a wl_subsurface
+    // of the parent, the only client-positionable window kind under xdg-shell
+    // (parent-relative coordinates). For drag ghosts. Ignored elsewhere.
+    popupFor: NucleusWindow? = null,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -114,6 +119,7 @@ fun NucleusApplicationScope.JewelDecoratedWindow(
             focusable = focusable,
             alwaysOnTop = alwaysOnTop,
             undecorated = undecorated,
+            popupFor = popupFor,
             minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -104,6 +104,11 @@ internal fun ApplicationScope.openDecoratedWindow(
     // Fully borderless window: no native chrome at all — on macOS this drops the
     // traffic-light buttons too. For overlay/ghost windows (drag previews, HUDs).
     undecorated: Boolean = false,
+    // Linux only: make this window a popup overlay of [popupFor]
+    // (GTK_WINDOW_POPUP transient → wl_subsurface on Wayland, the only
+    // client-positionable window kind under xdg-shell). Positions are
+    // parent-relative on Wayland. Ignored on other platforms.
+    popupFor: TaoWindow? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     macOSStyle: MacOSStyle = MacOSStyle.Classic,
@@ -134,6 +139,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             // produces a one-frame glitch where the window flashes at its
             // requested logical size before snapping to maximized.
             maximized = maximized,
+            popupOf = popupFor,
         )
 
     if (Platform.Current == Platform.Windows) {
@@ -427,6 +433,12 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     val fullscreenHolder = FullscreenTitleBarHolder()
 
     val linuxDe = LinuxDesktopEnvironment.Current
+    // Wayland: GTK destroys the window's `wl_surface` on hide and creates a
+    // fresh one on show. Suspend the EGL attachment before the hide (a swap
+    // racing the surface destruction is a fatal Wayland protocol error) and
+    // rebuild it once the new surface exists. No-ops on X11.
+    window.onWillHide { host.suspendGpu() }
+    window.onShown { host.resumeGpu() }
     window.onWindowReady { w, h ->
         host.attach()
         // Bring the AccessKit adapter up before we hand the SemanticsOwnerListener

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -62,6 +62,11 @@ fun ApplicationScope.DecoratedWindow(
     isDialog: Boolean = false,
     /** Fully borderless window (no traffic lights on macOS) — for overlays/ghosts. */
     undecorated: Boolean = false,
+    /**
+     * Linux only: popup overlay of another window (wl_subsurface on Wayland —
+     * client-positionable; parent-relative coordinates). Ignored elsewhere.
+     */
+    popupFor: TaoWindow? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     macOSStyle: MacOSStyle = MacOSStyle.Classic,
@@ -131,6 +136,7 @@ fun ApplicationScope.DecoratedWindow(
                     maximized = state.placement == WindowPlacement.Maximized,
                     isDialog = isDialog,
                     undecorated = undecorated,
+                    popupFor = popupFor,
                     onPreviewKeyEvent = { latestPreview(it) },
                     onKeyEvent = { latestKey(it) },
                     macOSStyle = macOSStyle,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoBridge.kt
@@ -119,6 +119,11 @@ internal object NativeTaoBridge {
         resizable: Boolean,
         visible: Boolean,
         maximized: Boolean,
+        // Linux only: non-zero = handle of the window this one is a popup
+        // overlay of (GTK_WINDOW_POPUP transient; wl_subsurface on Wayland —
+        // the only client-positionable window kind under xdg-shell). Ignored
+        // on other platforms.
+        popupOf: Long,
     )
 
     @JvmStatic
@@ -664,6 +669,20 @@ object TaoEventCode {
 
     /** `a` carries the current [TaoModifierMask] bitset. */
     const val MODIFIERS_CHANGED: Int = 22
+
+    /**
+     * Linux only. Dispatched synchronously right BEFORE the GTK window is
+     * hidden, so the host can suspend EGL rendering first — on Wayland the
+     * hide destroys the parent `wl_surface` and a racing swap on the owned
+     * subsurface is a fatal protocol error (GDK "Error 71").
+     */
+    const val WILL_HIDE: Int = 23
+
+    /**
+     * Linux only. Dispatched synchronously right AFTER the GTK window is
+     * shown again (GDK surface re-created) so the host can re-attach EGL.
+     */
+    const val SHOWN: Int = 24
 }
 
 /** Trackpad gesture kind reported by [NativeTaoBridge.EventCallback.onTrackpadGesture]. */

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -67,6 +67,11 @@ object TaoApplication {
         resizable: Boolean = true,
         visible: Boolean = true,
         maximized: Boolean = false,
+        // Linux only: make this window a popup overlay of [popupOf]
+        // (GTK_WINDOW_POPUP transient → wl_subsurface on Wayland, the only
+        // client-positionable window kind under xdg-shell). For
+        // cursor-following overlays such as drag ghosts. Ignored elsewhere.
+        popupOf: TaoWindow? = null,
     ): TaoWindow {
         val handle = handleSeq.getAndIncrement()
         val window = TaoWindow(handle, isResizable = resizable)
@@ -80,6 +85,7 @@ object TaoApplication {
             resizable,
             visible,
             maximized,
+            popupOf?.handle ?: 0L,
         )
         return window
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -74,6 +74,8 @@ class TaoWindow internal constructor(
     private val focusListeners = CopyOnWriteArrayList<(Boolean) -> Unit>()
 
     @Volatile
+    private var willHideListener: (() -> Unit)? = null
+    private var shownListener: (() -> Unit)? = null
     private var pointerMoveListener: ((Int, Int) -> Unit)? = null
 
     @Volatile
@@ -544,6 +546,23 @@ class TaoWindow internal constructor(
         minimizedListeners += block
     }
 
+    /**
+     * Linux only. Fires synchronously on the event-loop thread right before
+     * the GTK window is hidden — the host must suspend EGL rendering before
+     * Wayland's parent `wl_surface` is destroyed (see [TaoEventCode.WILL_HIDE]).
+     */
+    fun onWillHide(block: () -> Unit) {
+        willHideListener = block
+    }
+
+    /**
+     * Linux only. Fires synchronously right after the GTK window is shown
+     * again, once the GDK surface exists — the host may re-attach EGL.
+     */
+    fun onShown(block: () -> Unit) {
+        shownListener = block
+    }
+
     fun onPointerMoved(block: (xFixed: Int, yFixed: Int) -> Unit) {
         pointerMoveListener = block
     }
@@ -672,6 +691,8 @@ class TaoWindow internal constructor(
             TaoEventCode.MOUSE_DOWN -> pointerButtonListener?.invoke(a, true)
             TaoEventCode.MOUSE_UP -> pointerButtonListener?.invoke(a, false)
             TaoEventCode.MODIFIERS_CHANGED -> modifierState = a
+            TaoEventCode.WILL_HIDE -> willHideListener?.invoke()
+            TaoEventCode.SHOWN -> shownListener?.invoke()
             TaoEventCode.SCROLL_LINE -> {
                 // AWT sends the wheel rotation as scrollDelta and leaves the
                 // platform line-count policy in MouseWheelEvent.scrollAmount.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ResizeFrameDecoration.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ResizeFrameDecoration.kt
@@ -72,6 +72,10 @@ internal class ResizeFrameDecoration(
         forTouch: Boolean = false,
     ): Direction? {
         if (widthLogical <= 0 || heightLogical <= 0) return null
+        // A pointer OUTSIDE the window (delivered during a button-held drag by
+        // the platform grab) is not on a resize handle — without this guard
+        // `x < edge` / `x >= width - edge` match every out-of-bounds position.
+        if (x < 0f || y < 0f || x >= widthLogical || y >= heightLogical) return null
         val edge = if (forTouch) touchEdgeThicknessLogical else edgeThicknessLogical
         val nearLeft = x < edge
         val nearRight = x >= widthLogical - edge

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
@@ -200,6 +200,14 @@ internal class TaoComposeSceneHostLinux(
     private var lastPointerY: Float = 0f
 
     /**
+     * Number of currently-pressed mouse buttons. While non-zero a drag is in
+     * flight: pointer positions may legitimately be OUTSIDE the window (the
+     * platform grab keeps delivering them) and must reach Compose — the
+     * resize-band hit-test must not swallow them.
+     */
+    private var pressedButtons: Int = 0
+
+    /**
      * Captured at the first composition via [setContent]. Exposes the
      * standard `FocusManager.clearFocus(force = true)` API which the
      * scene-level [androidx.compose.ui.scene.ComposeSceneFocusManager]
@@ -222,7 +230,67 @@ internal class TaoComposeSceneHostLinux(
             else -> 0
         }
 
+    /** Backend kind of the current EGL attachment: 1 = X11, 2 = Wayland. */
+    private var attachedKind: Int = 0
+
+    /** True while the EGL attachment is torn down because the window is hidden. */
+    private var gpuSuspended: Boolean = false
+
     fun attach() {
+        attachGpu()
+
+        @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+        val dndManager =
+            dev.nucleusframework.window.tao.TaoDragAndDropManager(
+                getRootNode = { scene!!.rootDragAndDropNode },
+                outboundLauncher = ::launchLinuxOutboundDrag,
+            )
+        scene =
+            CanvasLayersComposeScene(
+                density = Density(scale),
+                layoutDirection = GlobalLayoutDirection,
+                coroutineContext = coroutineContext + frameClock + flushingDispatcher,
+                platformContext =
+                    LinuxTaoPlatformContext(
+                        windowHandle = window.handle,
+                        // The custom CSD title bar is drawn inside the same Compose
+                        // scene as the rest of the content, so it shares the (0, 0)
+                        // origin with everything else. We must NOT report it as a
+                        // `PlatformInsets.top`: Compose's `RootMeasurePolicy` (cf.
+                        // `RootMeasurePolicy.skiko.kt::positionWithInsets`) applies
+                        // platform insets as an *additive offset* on the popup
+                        // position (designed for iOS notches / Android status
+                        // bars, where the safe area is outside the Compose surface).
+                        // Reporting `top = titleBarHeight` here shifts every Popup,
+                        // DropdownMenu, ContextMenu, and Tooltip down by that
+                        // amount — visible as a consistent "title-bar-height
+                        // downward drift" of every popup the user opens. Popups
+                        // are free to overlap the title bar zone; the title bar
+                        // composable's own z-order keeps it visually on top of
+                        // the page content but popups (rendered in a higher
+                        // ComposeSceneLayer) naturally float above both.
+                        topInsetPx = { 0 },
+                        windowInfo = windowInfo,
+                        semanticsOwnerListener = semanticsOwnerListener,
+                        dragAndDropManager = dndManager,
+                        textToolbar = textToolbar,
+                    ),
+                invalidate = {
+                    requestRedrawCoalesced()
+                },
+            ).apply { compositionLocalContext = pendingCompositionLocalContext }
+
+        registerInboundDnD()
+        registerTouch()
+    }
+
+    /**
+     * EGL + Skia half of [attach]: resolves the native window handles, binds
+     * an EGL context/surface, creates the per-window [DirectContext] and
+     * starts the swap thread. Split out so [resumeGpu] can rebuild the GPU
+     * side alone after a hide/show cycle destroyed the native surface.
+     */
+    private fun attachGpu() {
         check(NativeTaoBridge.isLoaded && NativeTaoEglBridge.isLoaded) {
             "Tao Linux native libraries not loaded"
         }
@@ -301,50 +369,60 @@ internal class TaoComposeSceneHostLinux(
         // pass via [bindContextForRender].
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread = SwapThread(attachmentHandle).also { it.start() }
+        attachedKind = kind
+        // Force the next render to re-push size/scale into the fresh EGL
+        // surface and rebuild the Skia render target.
+        lastAppliedWidthPx = -1
+        lastAppliedHeightPx = -1
+        lastAppliedScale = Float.NaN
+    }
 
-        @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
-        val dndManager =
-            dev.nucleusframework.window.tao.TaoDragAndDropManager(
-                getRootNode = { scene!!.rootDragAndDropNode },
-                outboundLauncher = ::launchLinuxOutboundDrag,
-            )
-        scene =
-            CanvasLayersComposeScene(
-                density = Density(scale),
-                layoutDirection = GlobalLayoutDirection,
-                coroutineContext = coroutineContext + frameClock + flushingDispatcher,
-                platformContext =
-                    LinuxTaoPlatformContext(
-                        windowHandle = window.handle,
-                        // The custom CSD title bar is drawn inside the same Compose
-                        // scene as the rest of the content, so it shares the (0, 0)
-                        // origin with everything else. We must NOT report it as a
-                        // `PlatformInsets.top`: Compose's `RootMeasurePolicy` (cf.
-                        // `RootMeasurePolicy.skiko.kt::positionWithInsets`) applies
-                        // platform insets as an *additive offset* on the popup
-                        // position (designed for iOS notches / Android status
-                        // bars, where the safe area is outside the Compose surface).
-                        // Reporting `top = titleBarHeight` here shifts every Popup,
-                        // DropdownMenu, ContextMenu, and Tooltip down by that
-                        // amount — visible as a consistent "title-bar-height
-                        // downward drift" of every popup the user opens. Popups
-                        // are free to overlap the title bar zone; the title bar
-                        // composable's own z-order keeps it visually on top of
-                        // the page content but popups (rendered in a higher
-                        // ComposeSceneLayer) naturally float above both.
-                        topInsetPx = { 0 },
-                        windowInfo = windowInfo,
-                        semanticsOwnerListener = semanticsOwnerListener,
-                        dragAndDropManager = dndManager,
-                        textToolbar = textToolbar,
-                    ),
-                invalidate = {
-                    requestRedrawCoalesced()
-                },
-            ).apply { compositionLocalContext = pendingCompositionLocalContext }
+    /**
+     * Tears down the GPU side (swap thread, Skia, EGL attachment) while the
+     * window is hidden. Wayland only: `gtk_widget_hide` destroys the parent
+     * `wl_surface`, and any `eglSwapBuffers` racing that destruction commits
+     * to an orphaned subsurface — the compositor answers with a fatal
+     * protocol error (GDK "Error 71", observed as
+     * `wp_commit_timer_v1: "Commit already has timestamp"`). On X11 the XID
+     * survives a hide, so the attachment is kept.
+     *
+     * Called synchronously (via [dev.nucleusframework.window.tao.TaoWindow.onWillHide])
+     * on the event-loop thread BEFORE the GTK hide runs.
+     */
+    fun suspendGpu() {
+        if (attachmentHandle == 0L || gpuSuspended || attachedKind != 2) return
+        gpuSuspended = true
+        // Wait out any in-flight swap; after the join no other thread touches
+        // the EGL context (same protocol as [detach]).
+        swapThread?.shutdownAndJoin()
+        swapThread = null
+        NativeTaoEglBridge.nativeMakeCurrent(attachmentHandle)
+        cachedSurface?.close()
+        cachedSurface = null
+        cachedRt?.close()
+        cachedRt = null
+        // The DirectContext is bound to the EGL context being destroyed; the
+        // scene itself survives and renders again once [resumeGpu] rebuilds it.
+        directContext?.close()
+        directContext = null
+        NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
+        NativeTaoEglBridge.nativeDetach(attachmentHandle)
+        attachmentHandle = 0L
+    }
 
-        registerInboundDnD()
-        registerTouch()
+    /**
+     * Rebuilds the GPU side after the GTK window was shown again — GDK has
+     * created a brand-new `wl_surface`, so the EGL attachment is recreated
+     * from scratch. No-op unless [suspendGpu] ran.
+     */
+    fun resumeGpu() {
+        if (!gpuSuspended) return
+        gpuSuspended = false
+        attachGpu()
+        // The redraw gate may have latched while hidden (invalidations with no
+        // draw ever arriving); clear it so the re-arm below goes through.
+        redrawPending.set(false)
+        requestRedrawCoalesced()
     }
 
     @OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
@@ -1111,7 +1189,13 @@ internal class TaoComposeSceneHostLinux(
         // the move to Compose. When the pointer is inside the band we set the
         // resize cursor and swallow the event so Compose's own cursor /
         // `PointerIcon` plumbing can't overwrite it on the next motion.
-        val direction = currentResizeDirection(xPx, yPx)
+        //
+        // Skip entirely while a button is held: during a drag the platform
+        // grab delivers positions outside the window, which the band test
+        // would otherwise classify as "on the edge" and swallow — freezing
+        // any Compose gesture (e.g. a cross-window tab drag) the moment the
+        // pointer crosses the window border.
+        val direction = if (pressedButtons == 0) currentResizeDirection(xPx, yPx) else null
         if (resizeDecoration.onMove(direction)) return
 
         scene?.sendPointerEvent(
@@ -1169,6 +1253,7 @@ internal class TaoComposeSceneHostLinux(
         buttonCode: Int,
         pressed: Boolean,
     ) {
+        pressedButtons = (pressedButtons + if (pressed) 1 else -1).coerceAtLeast(0)
         // JBR-style peer hook: a LMB press inside the resize band starts the
         // native resize drag and is NOT forwarded to Compose. Matches
         // `WLDecoratedPeer.postMouseEvent` calling

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -172,6 +172,7 @@ pub(crate) fn run_event_loop_blocking() {
                     resizable,
                     visible,
                     maximized,
+                    popup_of,
                 } => {
                     #[allow(unused_mut)]
                     let mut builder = WindowBuilder::new()
@@ -181,6 +182,26 @@ pub(crate) fn run_event_loop_blocking() {
                         .with_resizable(resizable)
                         .with_visible(visible)
                         .with_maximized(maximized);
+                    // Linux: build cursor-following overlays as GTK_WINDOW_POPUP
+                    // transient children — on Wayland GDK maps them as
+                    // `wl_subsurface`s, the only client-positionable window
+                    // kind under xdg-shell. Silently ignored if the parent
+                    // handle is unknown (falls back to a regular toplevel).
+                    #[cfg(target_os = "linux")]
+                    if popup_of != 0 {
+                        use tao::platform::unix::{WindowBuilderExtUnix, WindowExtUnix};
+                        let parent_gtk = {
+                            let guard = WINDOWS.lock().unwrap();
+                            guard.as_ref().and_then(|map| {
+                                map.get(&popup_of).map(|w| w.gtk_window().clone())
+                            })
+                        };
+                        if let Some(parent_gtk) = parent_gtk {
+                            builder = builder.with_popup_transient_for(&parent_gtk);
+                        }
+                    }
+                    #[cfg(not(target_os = "linux"))]
+                    let _ = popup_of;
                     // Linux: request an ARGB visual so the GTK window's X
                     // visual matches the canonical visual that Mesa's EGL
                     // exposes through its EGLConfigs. Without this, GDK
@@ -210,22 +231,50 @@ pub(crate) fn run_event_loop_blocking() {
                     }
                 }
                 UserEvent::SetVisible { handle, visible } => {
-                    let guard = WINDOWS.lock().unwrap();
-                    if let Some(map) = guard.as_ref() {
-                        if let Some(w) = map.get(&handle) {
-                            w.set_visible(visible);
-                            // Force a fresh frame into the now-composited surface.
-                            // The first frame is rendered (SwapBuffers) while the
-                            // HWND is still hidden, but WGL/DWM does not reliably
-                            // retain that pre-show swap once ShowWindow composites
-                            // the window — it can reveal an undefined/black front
-                            // buffer until the next redraw. Re-presenting here
-                            // guarantees the content paints the instant the window
-                            // appears.
-                            if visible {
-                                w.request_redraw();
+                    // Linux: let the JVM suspend its EGL rendering BEFORE GTK
+                    // unmaps the window. On Wayland `gtk_widget_hide` destroys
+                    // the parent `wl_surface`; a swap racing that destruction
+                    // trips a fatal protocol error (GDK "Error 71"). Dispatched
+                    // outside the WINDOWS lock — the JVM handler re-enters
+                    // native code that takes the same lock.
+                    #[cfg(target_os = "linux")]
+                    if !visible {
+                        dispatch(handle, crate::events::EVENT_WILL_HIDE, 0, 0);
+                    }
+                    {
+                        let guard = WINDOWS.lock().unwrap();
+                        if let Some(map) = guard.as_ref() {
+                            if let Some(w) = map.get(&handle) {
+                                w.set_visible(visible);
+                                if visible {
+                                    // Linux: `set_visible` only queues the GTK
+                                    // show through tao's request channel. Show
+                                    // synchronously so the GDK surface already
+                                    // exists when EVENT_SHOWN (below) lets the
+                                    // JVM re-attach EGL. Idempotent with the
+                                    // queued request.
+                                    #[cfg(target_os = "linux")]
+                                    {
+                                        use gtk::prelude::WidgetExt;
+                                        use tao::platform::unix::WindowExtUnix;
+                                        w.gtk_window().show_all();
+                                    }
+                                    // Force a fresh frame into the now-composited surface.
+                                    // The first frame is rendered (SwapBuffers) while the
+                                    // HWND is still hidden, but WGL/DWM does not reliably
+                                    // retain that pre-show swap once ShowWindow composites
+                                    // the window — it can reveal an undefined/black front
+                                    // buffer until the next redraw. Re-presenting here
+                                    // guarantees the content paints the instant the window
+                                    // appears.
+                                    w.request_redraw();
+                                }
                             }
                         }
+                    }
+                    #[cfg(target_os = "linux")]
+                    if visible {
+                        dispatch(handle, crate::events::EVENT_SHOWN, 0, 0);
                     }
                 }
                 UserEvent::SetTitle { handle, title } => {

--- a/decorated-window-tao/src/main/native/src/events.rs
+++ b/decorated-window-tao/src/main/native/src/events.rs
@@ -145,6 +145,17 @@ pub(crate) const EVENT_WINDOW_READY: jint = 16; // a = width, b = height (logica
 pub(crate) const EVENT_SCROLL_LINE: jint = 17; // a = dx * SCROLL_FIXED_SCALE, b = dy * SCROLL_FIXED_SCALE
 pub(crate) const EVENT_SCROLL_PIXEL: jint = 18;
 pub(crate) const EVENT_MODIFIERS_CHANGED: jint = 22;
+// Linux only. Dispatched synchronously on the event-loop thread right
+// BEFORE the GTK window is hidden, so the JVM can suspend its EGL rendering
+// first — on Wayland `gtk_widget_hide` destroys the parent `wl_surface`
+// while the render loop keeps committing to the owned subsurface, which
+// trips a fatal protocol error (GDK "Error 71").
+#[cfg(target_os = "linux")]
+pub(crate) const EVENT_WILL_HIDE: jint = 23;
+// Linux only. Dispatched synchronously right AFTER the GTK window is shown
+// again (GDK surface re-created), so the JVM can re-attach its EGL rendering.
+#[cfg(target_os = "linux")]
+pub(crate) const EVENT_SHOWN: jint = 24;
 
 // Sub-pixel precision through the JNI int payload.
 pub(crate) const SCROLL_FIXED_SCALE: f64 = 100.0;
@@ -233,6 +244,12 @@ pub(crate) enum UserEvent {
         // "Linux: most size methods like maximized are async"). Setting it
         // at builder time avoids the glitch entirely.
         maximized: bool,
+        // Linux only: when non-zero, the handle of an existing window this
+        // window should be a GTK_WINDOW_POPUP transient child of. On Wayland
+        // GDK maps such windows as `wl_subsurface`s of the parent — the only
+        // window kind a client can freely position under xdg-shell. Used for
+        // cursor-following overlays (drag ghosts). Ignored on other platforms.
+        popup_of: u64,
     },
     SetVisible {
         handle: u64,

--- a/decorated-window-tao/src/main/native/src/platform/linux/dnd.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/dnd.rs
@@ -165,7 +165,7 @@ fn map_effect_to_action(effect: jint) -> DragAction {
 /// Falls back to multiplying by scale only when `translate_coordinates` fails
 /// (would only happen if the bin child isn't realised — unlikely once any
 /// drag is in flight).
-fn translate_to_content_phys(window: &gtk::ApplicationWindow, x: i32, y: i32) -> (i32, i32) {
+fn translate_to_content_phys(window: &gtk::Window, x: i32, y: i32) -> (i32, i32) {
     let scale = window
         .window()
         .map(|w| w.scale_factor())
@@ -350,7 +350,7 @@ fn percent_encode_path(input: &str) -> String {
 // ── Inbound: gtk_drag_dest_set + signal handlers ───────────────────────────
 
 fn install_inbound(handle: u64, callback: GlobalRef) -> Result<(), &'static str> {
-    let widget: gtk::ApplicationWindow =
+    let widget: gtk::Window =
         with_window(handle, |w| w.gtk_window().clone()).ok_or("window not found")?;
 
     // Defensive: in case Tao or some other layer registered a target. Tao

--- a/decorated-window-tao/src/main/native/src/platform/linux/handles.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/handles.rs
@@ -91,8 +91,8 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_NativeTaoBridge_nati
         if let Some(map) = guard.as_ref() {
             if let Some(window) = map.get(&(handle as u64)) {
                 let gtk_window = window.gtk_window();
-                let raw: *mut gtk::ffi::GtkApplicationWindow =
-                    glib::translate::ToGlibPtr::<*mut gtk::ffi::GtkApplicationWindow>::to_glib_none(
+                let raw: *mut gtk::ffi::GtkWindow =
+                    glib::translate::ToGlibPtr::<*mut gtk::ffi::GtkWindow>::to_glib_none(
                         gtk_window,
                     ).0;
                 out = raw as jlong;

--- a/decorated-window-tao/src/main/native/src/platform/linux/touch.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/touch.rs
@@ -86,7 +86,7 @@ struct Registration {
     event_id: glib::SignalHandlerId,
     /// The toplevel `ApplicationWindow` the handler is attached to; kept
     /// alive so the SignalHandlerId stays valid until revoke.
-    window: gtk::ApplicationWindow,
+    window: gtk::Window,
     /// State shared with the closure.
     state: Rc<TouchState>,
 }
@@ -140,7 +140,7 @@ fn with_window<R, F: FnOnce(&tao::window::Window) -> R>(handle: u64, f: F) -> Op
 /// We attach to the toplevel because Tao 0.35's bin_child is a no-window
 /// GtkBox: it has no GdkWindow of its own, so `connect_event` on it never
 /// fires (`bin_child.window()` returns the toplevel's window, not a child).
-fn to_physical_fixed(window: &gtk::ApplicationWindow, x: f64, y: f64) -> (i64, i64) {
+fn to_physical_fixed(window: &gtk::Window, x: f64, y: f64) -> (i64, i64) {
     let scale = window
         .window()
         .map(|w| w.scale_factor())
@@ -267,7 +267,7 @@ fn handle_touch(
     handle: u64,
     callback: &GlobalRef,
     state: &TouchState,
-    window: &gtk::ApplicationWindow,
+    window: &gtk::Window,
     ev: &EventTouch,
 ) {
     let Some(seq) = ev.event_sequence() else {
@@ -336,7 +336,7 @@ fn handle_touchpad_pinch(
     handle: u64,
     callback: &GlobalRef,
     state: &TouchState,
-    window: &gtk::ApplicationWindow,
+    window: &gtk::Window,
     ev: &EventTouchpadPinch,
 ) {
     let raw = ev.as_ref();
@@ -430,7 +430,7 @@ fn handle_touchpad_pinch(
 // ── Install / revoke ──────────────────────────────────────────────────────
 
 fn install(handle: u64, callback: GlobalRef) -> Result<(), &'static str> {
-    let window: gtk::ApplicationWindow =
+    let window: gtk::Window =
         with_window(handle, |w| w.gtk_window().clone()).ok_or("window not found")?;
 
     // Tao 0.35's bin_child is a no-window GtkBox — `connect_event` on it

--- a/decorated-window-tao/src/main/native/src/window_jni.rs
+++ b/decorated-window-tao/src/main/native/src/window_jni.rs
@@ -67,6 +67,7 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_NativeTaoBridge_nati
     resizable: jboolean,
     visible: jboolean,
     maximized: jboolean,
+    popup_of: jlong,
 ) {
     let title: String = match env.get_string(&title) {
         Ok(s) => s.into(),
@@ -81,6 +82,7 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_NativeTaoBridge_nati
         resizable: resizable != JNI_FALSE,
         visible: visible != JNI_FALSE,
         maximized: maximized != JNI_FALSE,
+        popup_of: popup_of as u64,
     });
 }
 

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform/unix.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform/unix.rs
@@ -76,7 +76,7 @@ pub trait WindowExtUnix {
   ) -> Result<Window, OsError>;
 
   /// Returns the `gtk::ApplicatonWindow` from gtk crate that is used by this window.
-  fn gtk_window(&self) -> &gtk::ApplicationWindow;
+  fn gtk_window(&self) -> &gtk::Window;
 
   /// Returns the vertical `gtk::Box` that is added by default as the sole child of this window.
   /// Returns `None` if the default vertical `gtk::Box` creation was disabled by [`WindowBuilderExtUnix::with_default_vbox`].
@@ -89,7 +89,7 @@ pub trait WindowExtUnix {
 }
 
 impl WindowExtUnix for Window {
-  fn gtk_window(&self) -> &gtk::ApplicationWindow {
+  fn gtk_window(&self) -> &gtk::Window {
     &self.window.window
   }
 
@@ -120,6 +120,14 @@ pub trait WindowBuilderExtUnix {
   /// Set this window as a transient dialog for `parent`
   /// <https://gtk-rs.org/gtk3-rs/stable/latest/docs/gdk/struct.Window.html#method.set_transient_for>
   fn with_transient_for(self, parent: &impl gtk::glib::IsA<gtk::Window>) -> WindowBuilder;
+
+  /// Nucleus patch: build this window as a `GTK_WINDOW_POPUP` transient for
+  /// `parent`. On Wayland GDK maps it as a `wl_subsurface` of the parent,
+  /// making it the only window kind a client can freely position under
+  /// xdg-shell (`gtk_window_move` → `wl_subsurface.set_position`, not
+  /// clipped to the parent). On X11 it is an override-redirect window.
+  /// For cursor-following overlays such as drag ghosts.
+  fn with_popup_transient_for(self, parent: &impl gtk::glib::IsA<gtk::Window>) -> WindowBuilder;
 
   /// Whether to enable or disable the internal draw for transparent window.
   ///
@@ -166,6 +174,12 @@ impl WindowBuilderExtUnix for WindowBuilder {
   fn with_transient_for(mut self, parent: &impl gtk::glib::IsA<gtk::Window>) -> WindowBuilder {
     use gtk::glib::Cast;
     self.platform_specific.parent = Parent::ChildOf(parent.clone().upcast());
+    self
+  }
+
+  fn with_popup_transient_for(mut self, parent: &impl gtk::glib::IsA<gtk::Window>) -> WindowBuilder {
+    use gtk::glib::Cast;
+    self.platform_specific.popup_transient_for = Some(parent.clone().upcast());
     self
   }
 

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
@@ -58,6 +58,11 @@ pub struct EventLoopWindowTarget<T> {
   pub(crate) app: gtk::Application,
   /// Window Ids of the application
   pub(crate) windows: Rc<RefCell<HashSet<WindowId>>>,
+  /// Nucleus patch: popup overlay windows (GTK_WINDOW_POPUP) keyed by their
+  /// synthesized ids. Not GtkApplicationWindows, so they can't be resolved
+  /// through `gtk_application_get_window_by_id` — the request router falls
+  /// back to this map.
+  pub(crate) popup_windows: Rc<RefCell<std::collections::HashMap<u32, gtk::Window>>>,
   /// Window requests sender
   pub(crate) window_requests_tx: glib::Sender<(WindowId, WindowRequest)>,
   /// Draw event sender
@@ -244,12 +249,15 @@ impl<T: 'static> EventLoop<T> {
     let (window_requests_tx, window_requests_rx) = glib::MainContext::channel(Priority::default());
     let display = gdk::Display::default()
       .expect("GdkDisplay not found. This usually means `gkt_init` hasn't called yet.");
+    let popup_windows: Rc<RefCell<std::collections::HashMap<u32, gtk::Window>>> =
+      Rc::new(RefCell::new(std::collections::HashMap::new()));
     let window_target = EventLoopWindowTarget {
       display,
       app,
       windows: Rc::new(RefCell::new(HashSet::new())),
       window_requests_tx,
       draw_tx: draw_tx_,
+      popup_windows: popup_windows.clone(),
       _marker: std::marker::PhantomData,
     };
 
@@ -294,12 +302,30 @@ impl<T: 'static> EventLoop<T> {
     }
 
     // Window Request
+    let popup_windows_ = popup_windows.clone();
     window_requests_rx.attach(Some(&context), move |(id, request)| {
-      if let Some(window) = app_.window_by_id(id.0) {
+      // Nucleus patch: popup overlay windows are plain gtk::Windows with
+      // synthesized ids — resolve them from the popup map when the
+      // GtkApplication lookup misses. All request arms operate through
+      // GtkWindowExt / WidgetExt, which both kinds implement.
+      let resolved: Option<gtk::Window> = app_
+        .window_by_id(id.0)
+        .map(|w| w.upcast::<gtk::Window>())
+        .or_else(|| popup_windows_.borrow().get(&id.0).cloned());
+      if let Some(window) = resolved {
         match request {
           WindowRequest::Title(title) => window.set_title(&title),
           WindowRequest::Position((x, y)) => window.move_(x, y),
-          WindowRequest::Size((w, h)) => window.resize(w, h),
+          WindowRequest::Size((w, h)) => {
+            // Nucleus patch: `gtk_window_resize` is a no-op on non-resizable
+            // windows (GTK follows the content's natural size instead); route
+            // the request through the widget size request in that case.
+            if window.is_resizable() {
+              window.resize(w, h);
+            } else {
+              window.set_size_request(w, h);
+            }
+          }
           WindowRequest::SizeConstraints(constraints) => {
             util::set_size_constraints(&window, constraints);
           }
@@ -587,7 +613,7 @@ impl<T: 'static> EventLoop<T> {
             });
 
             let tx_clone = event_tx.clone();
-            window.connect_enter_notify_event(move |_, _| {
+            window.connect_enter_notify_event(move |window, crossing| {
               if let Err(e) = tx_clone.send(Event::WindowEvent {
                 window_id: RootWindowId(id),
                 event: WindowEvent::CursorEntered {
@@ -599,26 +625,50 @@ impl<T: 'static> EventLoop<T> {
                   e
                 );
               }
+              // Nucleus patch: follow the enter with a CursorMoved carrying the
+              // entry coordinates. Crossing events are the ONLY position signal
+              // a window gets when the pointer lands on it without moving —
+              // e.g. the compositor's focus re-evaluation right after a
+              // button-held drag ends on Wayland (used for cross-window drop
+              // targeting, where global coordinates don't exist).
+              let scale_factor = window.scale_factor();
+              let (x, y) = crossing.position();
+              if let Err(e) = tx_clone.send(Event::WindowEvent {
+                window_id: RootWindowId(id),
+                event: WindowEvent::CursorMoved {
+                  position: LogicalPosition::new(x, y).to_physical(scale_factor as f64),
+                  device_id: DEVICE_ID,
+                  modifiers: ModifiersState::empty(),
+                },
+              }) {
+                log::warn!("Failed to send cursor moved event to event channel: {}", e);
+              }
               glib::Propagation::Proceed
             });
 
             let tx_clone = event_tx.clone();
             window.connect_motion_notify_event(move |window, motion| {
               if cursor_moved {
-                if let Some(cursor) = motion.device() {
-                  let scale_factor = window.scale_factor();
-                  let (_, x, y) = cursor.window_at_position();
-                  if let Err(e) = tx_clone.send(Event::WindowEvent {
-                    window_id: RootWindowId(id),
-                    event: WindowEvent::CursorMoved {
-                      position: LogicalPosition::new(x, y).to_physical(scale_factor as f64),
-                      device_id: DEVICE_ID,
-                      // this field is depracted so it is fine to pass empty state
-                      modifiers: ModifiersState::empty(),
-                    },
-                  }) {
-                    log::warn!("Failed to send cursor moved event to event channel: {}", e);
-                  }
+                // Nucleus patch: report the event's own coordinates instead of
+                // `Device::window_at_position()`. The latter resolves the window
+                // currently UNDER the pointer, so the moment a button-held drag
+                // crosses the window edge it stops tracking (breaks cross-window
+                // drag ghosts). Event coordinates keep flowing for the whole
+                // implicit grab — including negative / out-of-bounds values — on
+                // X11 and Wayland alike. macOS (mouseDragged) and Windows
+                // (SetCapture) already behave this way.
+                let scale_factor = window.scale_factor();
+                let (x, y) = motion.position();
+                if let Err(e) = tx_clone.send(Event::WindowEvent {
+                  window_id: RootWindowId(id),
+                  event: WindowEvent::CursorMoved {
+                    position: LogicalPosition::new(x, y).to_physical(scale_factor as f64),
+                    device_id: DEVICE_ID,
+                    // this field is depracted so it is fine to pass empty state
+                    modifiers: ModifiersState::empty(),
+                  },
+                }) {
+                  log::warn!("Failed to send cursor moved event to event channel: {}", e);
                 }
               }
               glib::Propagation::Stop

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/mod.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/mod.rs
@@ -52,6 +52,11 @@ pub struct PlatformSpecificWindowBuilderAttributes {
   pub rgba_visual: bool,
   pub cursor_moved: bool,
   pub default_vbox: bool,
+  /// Nucleus patch: build a `GTK_WINDOW_POPUP` transient for this window
+  /// instead of a `GtkApplicationWindow`. On Wayland GDK maps it as a
+  /// `wl_subsurface` of the parent — the only client-positionable window
+  /// kind under xdg-shell. For cursor-following overlays (drag ghosts).
+  pub popup_transient_for: Option<gtk::Window>,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -65,6 +70,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
       rgba_visual: false,
       cursor_moved: true,
       default_vbox: true,
+      popup_transient_for: None,
     }
   }
 }

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/window.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/window.rs
@@ -46,8 +46,9 @@ impl WindowId {
 pub struct Window {
   /// Window id.
   pub(crate) window_id: WindowId,
-  /// Gtk application window.
-  pub(crate) window: gtk::ApplicationWindow,
+  /// Gtk window. A `GtkApplicationWindow` for regular windows, a plain
+  /// `GTK_WINDOW_POPUP` for popup overlays (see `popup_transient_for`).
+  pub(crate) window: gtk::Window,
   pub(crate) default_vbox: Option<gtk::Box>,
   /// Window requests sender
   pub(crate) window_requests_tx: glib::Sender<(WindowId, WindowRequest)>,
@@ -71,6 +72,15 @@ pub struct Window {
   css_provider: CssProvider,
 }
 
+/// Synthesized ids for popup windows, disjoint from GtkApplicationWindow ids
+/// (which start at 1 and grow slowly). High bit set to make collisions
+/// impossible in practice.
+fn next_popup_window_id() -> u32 {
+  use std::sync::atomic::{AtomicU32, Ordering};
+  static NEXT: AtomicU32 = AtomicU32::new(0x8000_0000);
+  NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
 impl Window {
   pub(crate) fn new<T>(
     event_loop_window_target: &EventLoopWindowTarget<T>,
@@ -82,20 +92,44 @@ impl Window {
     let draw_tx = event_loop_window_target.draw_tx.clone();
     let is_wayland = event_loop_window_target.is_wayland();
 
-    let mut window_builder = gtk::ApplicationWindow::builder()
-      .application(app)
-      .accept_focus(attributes.focusable && attributes.focused);
-    if let Parent::ChildOf(parent) = pl_attribs.parent {
-      window_builder = window_builder.transient_for(&parent);
-    }
+    // Nucleus patch: `popup_transient_for` creates a `GTK_WINDOW_POPUP` window
+    // instead of a `GtkApplicationWindow`. On Wayland GDK maps such a window as
+    // a `wl_subsurface` of the transient parent ("wayland: prefer subsurface
+    // when possible", GTK 3.20+), which is the ONLY window kind a client can
+    // freely position under xdg-shell — `gtk_window_move` becomes
+    // `wl_subsurface.set_position` and the surface is not clipped to the
+    // parent. Used for cursor-following overlays (drag ghosts). On X11 it is
+    // an override-redirect window, positionable as usual.
+    let (window, window_id) = if let Some(popup_parent) = pl_attribs.popup_transient_for.clone() {
+      let window = gtk::Window::new(gtk::WindowType::Popup);
+      window.set_transient_for(Some(&popup_parent));
+      window.set_accept_focus(attributes.focusable && attributes.focused);
+      // Deliberately NOT added to the GtkApplication: popup overlays must not
+      // keep the app alive nor appear in `gtk_application_get_window_by_id`
+      // (their ids are synthesized below and routed via `popup_windows`).
+      let window_id = WindowId(next_popup_window_id());
+      event_loop_window_target
+        .popup_windows
+        .borrow_mut()
+        .insert(window_id.0, window.clone());
+      (window, window_id)
+    } else {
+      let mut window_builder = gtk::ApplicationWindow::builder()
+        .application(app)
+        .accept_focus(attributes.focusable && attributes.focused);
+      if let Parent::ChildOf(parent) = pl_attribs.parent {
+        window_builder = window_builder.transient_for(&parent);
+      }
 
-    let window = window_builder.build();
+      let window = window_builder.build();
 
-    if is_wayland {
-      WlHeader::setup(&window, &attributes.title);
-    }
+      if is_wayland {
+        WlHeader::setup(&window, &attributes.title);
+      }
 
-    let window_id = WindowId(window.id());
+      let window_id = WindowId(window.id());
+      (window.upcast::<gtk::Window>(), window_id)
+    };
     event_loop_window_target
       .windows
       .borrow_mut()
@@ -109,6 +143,14 @@ impl Window {
       .unwrap_or((800, 600));
     window.set_default_size(1, 1);
     window.resize(width, height);
+    // Nucleus patch: `gtk_window_resize` has no effect on a non-resizable
+    // window — GTK sizes it to the content's natural size instead, so a
+    // 200×40 overlay came up 200×200. Pin the requested size through the
+    // widget size request (the only sizing channel GTK honours when
+    // `resizable == false`). Applies to both X11 and Wayland.
+    if !attributes.resizable && !attributes.maximized {
+      window.set_size_request(width, height);
+    }
 
     if attributes.maximized {
       // Nucleus patch: apply `maximize()` synchronously, before the GTK window
@@ -272,7 +314,7 @@ impl Window {
       minimized,
       is_always_on_top,
       tiled,
-    ) = Self::setup_signals(&window, Some(&attributes));
+    ) = Self::setup_signals(&window, window_id, Some(&attributes));
 
     if let Some(icon) = attributes.window_icon {
       window.set_icon(Some(&icon.inner.into()));
@@ -314,7 +356,8 @@ impl Window {
   }
 
   fn setup_signals(
-    window: &gtk::ApplicationWindow,
+    window: &gtk::Window,
+    window_id: WindowId,
     attributes: Option<&WindowAttributes>,
   ) -> (
     Rc<AtomicI32>,
@@ -409,7 +452,7 @@ impl Window {
       // actually transitioning to avoid spamming the embedder hook.
       if event.changed_mask().contains(WindowState::ICONIFIED) {
         if let Some(hook) = crate::platform::linux::MINIMIZED_HOOK.get() {
-          hook(crate::window::WindowId(WindowId(window.id())), iconified);
+          hook(crate::window::WindowId(window_id), iconified);
         }
       }
       glib::Propagation::Proceed
@@ -442,6 +485,7 @@ impl Window {
     let draw_tx = event_loop_window_target.draw_tx.clone();
 
     let window_id = WindowId(window.id());
+    let window = window.upcast::<gtk::Window>();
     event_loop_window_target
       .windows
       .borrow_mut()
@@ -457,7 +501,7 @@ impl Window {
       minimized,
       is_always_on_top,
       tiled,
-    ) = Self::setup_signals(&window, None);
+    ) = Self::setup_signals(&window, window_id, None);
 
     let win = Self {
       window_id,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -33,6 +33,12 @@ fun NucleusApplicationScope.DecoratedWindow(
     // Fully borderless window (no macOS traffic lights) — for overlay/ghost windows.
     // Honoured by the Tao backend; the AWT backend currently ignores it.
     undecorated: Boolean = false,
+    // Linux/Tao only: make this window a popup overlay of [popupFor]. On
+    // Wayland it maps as a wl_subsurface of the parent — the only window kind
+    // a client can freely position under xdg-shell (coordinates are
+    // parent-relative). For cursor-following overlays such as drag ghosts.
+    // Ignored by the AWT backend and on macOS/Windows.
+    popupFor: NucleusWindow? = null,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -85,6 +91,7 @@ fun NucleusApplicationScope.DecoratedWindow(
                 focusable = focusable,
                 alwaysOnTop = alwaysOnTop,
                 undecorated = undecorated,
+                popupFor = popupFor,
                 minimumSize = minimumSize,
                 onPreviewKeyEvent = onPreviewKeyEvent,
                 onKeyEvent = onKeyEvent,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -43,6 +43,7 @@ internal object TaoDecoratedWindowAdapter {
         focusable: Boolean,
         alwaysOnTop: Boolean,
         undecorated: Boolean,
+        popupFor: NucleusWindow?,
         minimumSize: DpSize?,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
@@ -68,6 +69,7 @@ internal object TaoDecoratedWindowAdapter {
                 focusable = focusable,
                 alwaysOnTop = alwaysOnTop,
                 undecorated = undecorated,
+                popupFor = popupFor?.unsafe?.taoWindow,
                 onPreviewKeyEvent = onPreviewKeyEvent,
                 onKeyEvent = onKeyEvent,
             ) {


### PR DESCRIPTION
## What

Four Linux fixes uncovered by Zayit's cross-window tab drag & drop (kdroidFilter/Zayit#514) on native Wayland, plus the new primitive it needed. All verified on GNOME Wayland and X11/XWayland.

### `popupFor` — client-positionable overlay windows on Wayland

New parameter on `JewelDecoratedWindow` → `DecoratedWindow` → tao: builds the window as a `GTK_WINDOW_POPUP` transient child of another window. On Wayland GDK maps it as a **`wl_subsurface` of the parent** ("wayland: prefer subsurface when possible", GTK 3.20+) — the only window kind a client can freely position under xdg-shell: `gtk_window_move` becomes `wl_subsurface.set_position` (parent-relative), not clipped to the parent's bounds. On X11 it is a plain override-redirect window. This is what makes a cursor-following drag ghost possible on native Wayland (protocol-verified: `set_position` tracks at 60 Hz).

Popup windows are not `GtkApplicationWindow`s, so they carry synthesized ids (high-bit range) routed through a new `popup_windows` map in the request router; the vendored tao `Window.window` field is upcast to `gtk::Window` accordingly.

### Fatal Error 71 when hiding a window on native Wayland

`gtk_widget_hide` destroys the parent `wl_surface` while the EGL render loop keeps committing to its owned subsurface → `wp_commit_timer_v1: "Commit already has timestamp"` protocol error, GDK aborts the process. New synchronous `WILL_HIDE`/`SHOWN` native events let `TaoComposeSceneHostLinux` suspend the EGL attachment (join swap thread, tear down Skia/EGL) *before* the GTK hide and rebuild it on the fresh surface after show. X11 keeps its XID across hide and is untouched.

### Pointer tracking died at the window edge during drags

Two independent causes:
- The resize-band hit-test classified **every out-of-bounds position** as "on the edge" (`x < edge` matches all negative x, `x >= width - edge` all beyond) and swallowed the move before Compose saw it — freezing any drag gesture the instant the pointer crossed the border. Out-of-window positions are never a resize handle, and the band is skipped while a button is held.
- tao's motion handler used `Device::window_at_position()`, which resolves the window *under* the pointer and goes blind outside it. Replaced with the event's own coordinates, which keep flowing for the whole implicit grab (X11 and Wayland alike — verified with uinput-injected drags).

### Sizing + crossing details

- `gtk_window_resize` is a no-op on non-resizable windows (GTK follows the content's natural size — a 200×40 overlay came up 200×200). The requested size is pinned via `set_size_request` at creation and on later `Size` requests.
- `enter-notify` now also emits a `CursorMoved` with the entry coordinates — the only position signal a window gets when the pointer lands on it without moving (e.g. the compositor's focus re-evaluation right after a drag ends; used for cross-window drop targeting on Wayland, where global coordinates don't exist).

## Validation

- Repro harness (jewel-sample ghost window): 200×40 honoured; survives repeated hide/show cycles on native Wayland (previously died at the first hide); `wl_subsurface.set_position` tracks position updates at 60 Hz.
- Out-of-bounds motion during button-held drags verified with uinput-injected input (plain-GTK control test + Compose-level observer).
- Exercised end-to-end by Zayit's cross-window tab drag on GNOME Wayland and X11: ghost follows the cursor beyond the window, tab transfer between windows, no crash.

## Notes

- Linux natives rebuilt from the patched sources (`decorated-window-tao/src/main/native/linux/build.sh`); macOS/Windows binaries unaffected — no shared-code changes reach them (`popup_of` is ignored off-Linux).
- Known limitation, unchanged: a detached toplevel's placement on Wayland remains compositor-decided (xdg-shell has no toplevel positioning).