### PR TITLE
style: fix lint failures from #273 (import order, hitTest complexity)

### DIFF
--- a/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
+++ b/decorated-window-jewel/src/main/kotlin/dev/nucleusframework/window/jewel/JewelDecoratedWindow.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.rememberWindowState
 import dev.nucleusframework.application.NucleusApplicationScope
-import dev.nucleusframework.application.NucleusWindow
 import dev.nucleusframework.application.NucleusDecoratedWindowScope
+import dev.nucleusframework.application.NucleusWindow
 import dev.nucleusframework.window.AwtDecoratedWindowScope
 import dev.nucleusframework.window.DecoratedWindow
 import dev.nucleusframework.window.NucleusDecoratedWindowTheme

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ResizeFrameDecoration.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ResizeFrameDecoration.kt
@@ -71,11 +71,7 @@ internal class ResizeFrameDecoration(
         heightLogical: Int,
         forTouch: Boolean = false,
     ): Direction? {
-        if (widthLogical <= 0 || heightLogical <= 0) return null
-        // A pointer OUTSIDE the window (delivered during a button-held drag by
-        // the platform grab) is not on a resize handle — without this guard
-        // `x < edge` / `x >= width - edge` match every out-of-bounds position.
-        if (x < 0f || y < 0f || x >= widthLogical || y >= heightLogical) return null
+        if (!isInsideFrame(x, y, widthLogical, heightLogical)) return null
         val edge = if (forTouch) touchEdgeThicknessLogical else edgeThicknessLogical
         val nearLeft = x < edge
         val nearRight = x >= widthLogical - edge
@@ -96,6 +92,25 @@ internal class ResizeFrameDecoration(
             else -> null
         }
     }
+
+    /**
+     * A pointer OUTSIDE the window (delivered during a button-held drag by the
+     * platform grab) is never on a resize handle — without this guard
+     * `x < edge` / `x >= width - edge` match every out-of-bounds position and
+     * the caller swallows the whole drag stream at the window border.
+     */
+    private fun isInsideFrame(
+        x: Float,
+        y: Float,
+        widthLogical: Int,
+        heightLogical: Int,
+    ): Boolean =
+        widthLogical > 0 &&
+            heightLogical > 0 &&
+            x >= 0f &&
+            y >= 0f &&
+            x < widthLogical &&
+            y < heightLogical
 
     /**
      * Pointer-move hook. If [direction] is non-null the cursor is updated to


### PR DESCRIPTION
## What

The `v2.0.0-alpha-202607021927` publish run failed on `ktlintMainSourceSetCheck`: the `NucleusWindow` import added in #273 broke lexicographic ordering in `JewelDecoratedWindow.kt`. While at it, the out-of-bounds guard added to `ResizeFrameDecoration.hitTest` pushed it past detekt's cyclomatic-complexity limit (21 > 20) — extracted into a documented `isInsideFrame` helper, no behavior change.

## Validation

`ktlintCheck` + `detekt` on decorated-window-jewel / decorated-window-tao / nucleus-application: only the pre-existing findings in untouched files (`TaoMainDispatcher.kt`, `TaoComposeSceneHostWindows.kt`) remain.