### PR TITLE
fix(tao-linux): multi-modifier state dropped in ModifiersChanged

### DIFF
--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
@@ -762,12 +762,13 @@ impl<T: 'static> EventLoop<T> {
             let tx_clone = event_tx.clone();
             let keyboard_handler = Rc::new(move |event_key: EventKey, element_state| {
               // if we have a modifier lets send it
-              let mut mods = keyboard::get_modifiers(event_key.clone());
-              if !mods.is_empty() {
-                // if we release the modifier tell the world
-                if ElementState::Released == element_state {
-                  mods = ModifiersState::empty();
-                }
+              if !keyboard::get_modifiers(event_key.clone()).is_empty() {
+                // Nucleus patch: emit the FULL modifier state, not just the
+                // pressed key's own bit — upstream sent `{SHIFT}` when Shift
+                // was pressed while Ctrl was held, dropping Ctrl from the
+                // state and breaking every Ctrl+Shift+<key> shortcut.
+                let mods =
+                  keyboard::get_modifier_state(&event_key, ElementState::Pressed == element_state);
 
                 if let Err(e) = tx_clone.send(Event::WindowEvent {
                   window_id: RootWindowId(id),

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/keyboard.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/keyboard.rs
@@ -176,6 +176,36 @@ pub(crate) fn get_modifiers(key: EventKey) -> ModifiersState {
   result
 }
 
+/// Nucleus patch: full modifier state at the time of [key], patched for the
+/// key itself. GDK's `EventKey::state()` reflects the state *before* the
+/// event, so a modifier key press doesn't include its own bit yet and a
+/// release still does. Upstream only forwards [get_modifiers] (the pressed
+/// key's own bit), so holding Ctrl and then pressing Shift emitted
+/// `ModifiersChanged({SHIFT})` and dropped Ctrl — Ctrl+Shift+<key> shortcuts
+/// never matched on the Linux backend.
+pub(crate) fn get_modifier_state(key: &EventKey, pressed: bool) -> ModifiersState {
+  let state = key.state();
+  let mut result = ModifiersState::empty();
+  if state.contains(gdk::ModifierType::SHIFT_MASK) {
+    result |= ModifiersState::SHIFT;
+  }
+  if state.contains(gdk::ModifierType::CONTROL_MASK) {
+    result |= ModifiersState::CONTROL;
+  }
+  if state.contains(gdk::ModifierType::MOD1_MASK) {
+    result |= ModifiersState::ALT;
+  }
+  if state.contains(gdk::ModifierType::SUPER_MASK) || state.contains(gdk::ModifierType::MOD4_MASK) {
+    result |= ModifiersState::SUPER;
+  }
+  let own = get_modifiers(key.clone());
+  if pressed {
+    result | own
+  } else {
+    result - own
+  }
+}
+
 pub(crate) fn make_key_event(
   key: &EventKey,
   is_repeat: bool,


### PR DESCRIPTION
## Summary
- The vendored tao GTK keyboard handler emitted `ModifiersChanged` with only the pressed key's own modifier bit: holding Ctrl and then pressing Shift sent `{SHIFT}`, dropping Ctrl from the cached modifier state. Every `Ctrl+Shift+<key>` shortcut was dead on the Linux backend; single-modifier shortcuts (`Ctrl+T`, `Ctrl+W`…) worked, which masked the bug.
- Add `keyboard::get_modifier_state()`: builds the full state from GDK `EventKey::state()` and patches in/out the event's own key, since GDK reports the pre-event state (a modifier press doesn't include its own bit yet; a release still does).
- `keyboard_handler` now emits that full state on modifier press/release instead of the single bit / empty state.

## Test plan
- [x] Debug-logged Compose key events in a consumer app (Zayit) on native Wayland: before — `Shift` down arrived with `ctrl=false` and `Ctrl+Shift+O` never matched; after — `Shift` down carries `ctrl=true` and `Ctrl+Shift+O` / `Ctrl+Shift+A` shortcuts fire.
- [x] Single-modifier shortcuts still work (`Ctrl+T`, `Ctrl+W`, `Ctrl+H`).
- [x] `cargo build --release` clean on linux-x64.