### PR TITLE
fix(tao-linux): multi-window redraw starvation + popup Wayland FIFO crash

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoEglBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoEglBridge.kt
@@ -54,6 +54,14 @@ internal object NativeTaoEglBridge {
      * Without it the subsurface renders ~scale× oversized and input is
      * miscalibrated.
      *
+     * [swapInterval] is passed to `eglSwapInterval`: 1 for toplevel-backed
+     * attachments (FIFO pacing against the compositor's frame callbacks),
+     * 0 for popup overlays whose EGL child hangs off GDK's own synchronized
+     * `wl_subsurface` — FIFO commits there stay cached compositor-side and
+     * Mesa's pending `wp_commit_timer_v1` timestamp is never consumed, so the
+     * next `set_timestamp` raises a fatal "Commit already has timestamp"
+     * protocol error (see [TaoWindow.isPopup]).
+     *
      * Returns 0 if libwayland-egl isn't available on the system; the caller
      * should fall back to the X11 path or surface a clear error.
      */
@@ -64,6 +72,7 @@ internal object NativeTaoEglBridge {
         widthPx: Int,
         heightPx: Int,
         bufferScale: Int,
+        swapInterval: Int,
     ): Long
 
     @JvmStatic

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoApplication.kt
@@ -74,7 +74,7 @@ object TaoApplication {
         popupOf: TaoWindow? = null,
     ): TaoWindow {
         val handle = handleSeq.getAndIncrement()
-        val window = TaoWindow(handle, isResizable = resizable)
+        val window = TaoWindow(handle, isResizable = resizable, isPopup = popupOf != null)
         windows[handle] = window
         NativeTaoBridge.nativeCreateWindow(
             handle,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoMainDispatcher.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoMainDispatcher.kt
@@ -109,7 +109,7 @@ internal object TaoMainDispatcher : CoroutineDispatcher() {
         // it yield to rendering + the throttled re-arm below.
         val deadlineNs = System.nanoTime() + PUMP_TIME_BUDGET_NS
         var pass = 0
-        @Suppress("TooGenericExceptionCaught", "PrintStackTrace")
+        @Suppress("TooGenericExceptionCaught", "PrintStackTrace", "LoopWithTooManyJumpStatements")
         while (pass++ < MAX_PUMP_PASSES) {
             var remaining = pending.size
             if (remaining == 0) break

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -23,6 +23,17 @@ class TaoWindow internal constructor(
      * — `frame.isResizable` gates the maximize button there too).
      */
     val isResizable: Boolean = true,
+    /**
+     * `true` when the window was created as a popup overlay of another window
+     * (`openWindow(popupOf = …)` — GTK_WINDOW_POPUP, mapped as a `wl_subsurface`
+     * on Wayland). The Linux host disables Mesa's FIFO frame pacing for these:
+     * their EGL child is a subsurface of GDK's own (synchronized) subsurface,
+     * so FIFO commits stay cached compositor-side and the pending
+     * `wp_commit_timer_v1` timestamp is never consumed — the next
+     * `set_timestamp` then kills the client with a fatal
+     * "Commit already has timestamp" protocol error.
+     */
+    val isPopup: Boolean = false,
 ) {
     @Volatile
     private var readyListener: ((Int, Int) -> Unit)? = null

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
@@ -340,7 +340,21 @@ internal class TaoComposeSceneHostLinux(
                     val physW = initialW.coerceAtLeast(1)
                     val physH = initialH.coerceAtLeast(1)
                     val bufferScale = scale.roundToInt().coerceAtLeast(1)
-                    val h = NativeTaoEglBridge.nativeAttachWayland(display, nativeWin, physW, physH, bufferScale)
+                    // Popup overlays: swap interval 0 — their EGL child hangs
+                    // off GDK's own synchronized wl_subsurface, where Mesa's
+                    // FIFO commit-timing state is never consumed and the next
+                    // set_timestamp is a fatal protocol error (see
+                    // TaoWindow.isPopup). Pacing there is event-driven anyway.
+                    val swapInterval = if (window.isPopup) 0 else 1
+                    val h =
+                        NativeTaoEglBridge.nativeAttachWayland(
+                            display,
+                            nativeWin,
+                            physW,
+                            physH,
+                            bufferScale,
+                            swapInterval,
+                        )
                     require(h != 0L) {
                         "Failed to create EGL context for wl_surface=$nativeWin — libwayland-egl missing?"
                     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -70,6 +70,7 @@ import kotlin.coroutines.CoroutineContext as KCoroutineContext
  * to whatever thread called `nativeAttach`, so all rendering must stay on it).
  */
 @OptIn(InternalComposeUiApi::class)
+@Suppress("LargeClass", "TooManyFunctions")
 internal class TaoComposeSceneHostWindows(
     private val window: TaoWindow,
     private val coroutineContext: CoroutineContext = EmptyCoroutineContext,

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
@@ -986,7 +986,7 @@ JNIEXPORT jlong JNICALL
 Java_dev_nucleusframework_window_tao_NativeTaoEglBridge_nativeAttachWayland(
     JNIEnv *env, jclass clazz,
     jlong wlDisplayPtr, jlong wlSurfacePtr,
-    jint widthPx, jint heightPx, jint bufferScale)
+    jint widthPx, jint heightPx, jint bufferScale, jint swapInterval)
 {
     (void) env; (void) clazz;
     if (!wlDisplayPtr || !wlSurfacePtr) return 0;
@@ -1263,8 +1263,16 @@ Java_dev_nucleusframework_window_tao_NativeTaoEglBridge_nativeAttachWayland(
      * current on a separate thread and calls `nativePresent` there, so the
      * GTK main thread keeps draining wl events while the swap thread waits
      * on the compositor — and we get true hardware vsync without melting
-     * the CPU. */
-    if (p_eglSwapInterval) p_eglSwapInterval(edpy, 1);
+     * the CPU.
+     *
+     * swapInterval == 0 is used for popup overlays (drag ghosts): their EGL
+     * child is a subsurface of GDK's own synchronized wl_subsurface, so FIFO
+     * commits stay cached compositor-side and Mesa's pending
+     * wp_commit_timer_v1 timestamp is never consumed — the next
+     * set_timestamp raises a fatal "Commit already has timestamp" protocol
+     * error. Interval 0 keeps Mesa off the fifo/commit-timing path entirely;
+     * pacing for those surfaces is event-driven (pointer motion) anyway. */
+    if (p_eglSwapInterval) p_eglSwapInterval(edpy, swapInterval ? 1 : 0);
 
     EglAttachment *att = (EglAttachment *) calloc(1, sizeof(EglAttachment));
     if (!att) {

--- a/decorated-window-tao/src/main/native/vendor/tao-patches/0004-linux-drain-draw-queue.patch
+++ b/decorated-window-tao/src/main/native/vendor/tao-patches/0004-linux-drain-draw-queue.patch
@@ -1,0 +1,40 @@
+--- a/src/platform_impl/linux/event_loop.rs
++++ b/src/platform_impl/linux/event_loop.rs
+@@ -1030,7 +1030,15 @@
+                 break code;
+               }
+               ControlFlow::Wait => {
+-                if !events.is_empty() {
++                // Pending redraws must prevent the blocking gtk iteration just
++                // like pending events: `request_redraw` only pushes into the
++                // draw channel without waking the glib main context, so a
++                // redraw queued while this loop is parked in
++                // `gtk::main_iteration_do(true)` would otherwise stall until
++                // an unrelated GTK event arrives. With several windows
++                // animating, the DrawQueue state below serves the queue one
++                // wakeup at a time and every other window's frame starves.
++                if !events.is_empty() || !draws.is_empty() {
+                   callback(
+                     Event::NewEvents(StartCause::WaitCancelled {
+                       start: Instant::now(),
+@@ -1056,7 +1064,7 @@
+                     &mut control_flow,
+                   );
+                   state = EventState::EventQueue;
+-                } else if !events.is_empty() {
++                } else if !events.is_empty() || !draws.is_empty() {
+                   callback(
+                     Event::NewEvents(StartCause::WaitCancelled {
+                       start,
+@@ -1101,7 +1109,10 @@
+                 break code;
+               }
+               _ => {
+-                if let Ok(id) = draws.try_recv() {
++                // Drain ALL pending redraws in one pass so N windows are
++                // served within the same loop cycle instead of one window
++                // per wakeup.
++                while let Ok(id) = draws.try_recv() {
+                   callback(
+                     Event::RedrawRequested(RootWindowId(id)),
+                     window_target,

--- a/decorated-window-tao/src/main/native/vendor/tao-patches/README.md
+++ b/decorated-window-tao/src/main/native/vendor/tao-patches/README.md
@@ -17,6 +17,7 @@ of an external workaround in the parent module — see `../../../../VENDORING_PL
 | 0001  | `0001-linux-resize-zones.patch`           | 1     | Linux    | Widen resize edge band to 8 px and corner zone to 16 px (logical), set the resize cursor before `begin_resize_drag` so it persists during the drag. Adds a `corner` parameter to `crate::window::hit_test`. |
 | 0002  | `0002-linux-cursor-preserve-on-motion.patch` | 2 | Linux    | Only override the cursor on edge-zone entry / exit. Outside resize zones the application-level cursor (text I-beam, hand, custom icon) is preserved across motion events. |
 | 0003  | `0003-linux-realize-on-build.patch`       | 3     | Linux    | Realise the GtkApplicationWindow at the end of `Window::new` so the underlying GdkWindow (X11 XID / Wayland wl_surface) is valid synchronously when the constructor returns. |
+| 0004  | `0004-linux-drain-draw-queue.patch`       | 4     | Linux    | `run_return`: treat pending redraws like pending events (don't park in the blocking `gtk_main_iteration` while `draws` is non-empty) and drain the whole draw channel per cycle instead of one redraw per wakeup. Fixes multi-window frame starvation (each window rendered at ~refresh/N). |
 
 ## Bump procedure (e.g. 0.35 → 0.36)
 

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/linux/event_loop.rs
@@ -1030,7 +1030,15 @@ impl<T: 'static> EventLoop<T> {
                 break code;
               }
               ControlFlow::Wait => {
-                if !events.is_empty() {
+                // Pending redraws must prevent the blocking gtk iteration just
+                // like pending events: `request_redraw` only pushes into the
+                // draw channel without waking the glib main context, so a
+                // redraw queued while this loop is parked in
+                // `gtk::main_iteration_do(true)` would otherwise stall until
+                // an unrelated GTK event arrives. With several windows
+                // animating, the DrawQueue state below serves the queue one
+                // wakeup at a time and every other window's frame starves.
+                if !events.is_empty() || !draws.is_empty() {
                   callback(
                     Event::NewEvents(StartCause::WaitCancelled {
                       start: Instant::now(),
@@ -1056,7 +1064,7 @@ impl<T: 'static> EventLoop<T> {
                     &mut control_flow,
                   );
                   state = EventState::EventQueue;
-                } else if !events.is_empty() {
+                } else if !events.is_empty() || !draws.is_empty() {
                   callback(
                     Event::NewEvents(StartCause::WaitCancelled {
                       start,
@@ -1101,7 +1109,10 @@ impl<T: 'static> EventLoop<T> {
                 break code;
               }
               _ => {
-                if let Ok(id) = draws.try_recv() {
+                // Drain ALL pending redraws in one pass so N windows are
+                // served within the same loop cycle instead of one window
+                // per wakeup.
+                while let Ok(id) = draws.try_recv() {
                   callback(
                     Event::RedrawRequested(RootWindowId(id)),
                     window_target,


### PR DESCRIPTION
## Summary

- **Vendored tao patch 0004** (`run_return`, Linux): pending redraws now prevent the blocking `gtk_main_iteration` (previously only user events did — `request_redraw` pushes into the draw channel without waking the glib context), and the whole draw channel is drained per loop cycle instead of one redraw per wakeup. With N windows animating, every other window's frame used to wait for an unrelated GTK event, collapsing per-window frame rate to ~refresh/N.
- **Popup overlays attach with `eglSwapInterval(0)` on Wayland** (`TaoWindow.isPopup`, threaded through `nativeAttachWayland`): their EGL child is a subsurface of GDK's own synchronized `wl_subsurface`, so Mesa's FIFO commits stay cached compositor-side and the pending `wp_commit_timer_v1` timestamp is never consumed — the next `set_timestamp` killed the client with a fatal "Commit already has timestamp" protocol error (GDK Error 71) during tab-drag ghosts. The starvation fix exposed this race by letting ghosts render back-to-back frames. Interval 0 keeps Mesa off the fifo/commit-timing path entirely; popup pacing is event-driven (pointer motion) anyway.
- style: suppress pre-existing detekt violations in the module (pump loop jump statements, Windows host LargeClass/TooManyFunctions — mirroring the Linux host's suppressions).

## Test plan

- [x] Reproduced multi-window slowness in SeforimApp (Wayland + X11), verified smooth rendering after patch
- [x] Reproduced tab-drag ghost protocol crash with `WAYLAND_DEBUG=1`, verified fix (drag works, no protocol error)
- [x] `:decorated-window-tao:ktlintCheck` and `:decorated-window-tao:detekt` green
- [ ] CI native builds (Windows/macOS unaffected — Linux-only code paths)