### PR TITLE
fix(decorated-window): application-scope dialogs are application-modal

### DIFF
--- a/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/LocalModalDialogCount.kt
+++ b/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/LocalModalDialogCount.kt
@@ -5,10 +5,27 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateOf
 
 /**
+ * Counts the modal dialogs opened at *application* scope — outside any
+ * decorated window's content, e.g. a settings dialog hoisted next to the
+ * window list so a single instance is shared by every window.
+ *
+ * It is the default value of [LocalModalDialogCount]: a dialog composed at
+ * application scope has no window-provided counter at its call site, so its
+ * increment lands here. Every decorated window observes this counter *in
+ * addition to* its own, which makes application-scope dialogs
+ * application-modal: all open windows (including ones created while the
+ * dialog is up) render their input blocker.
+ */
+val GlobalModalDialogCount: MutableState<Int> = mutableStateOf(0)
+
+/**
  * Counts the number of modal dialogs currently open above a decorated window.
  *
  * Provided (with a fresh [MutableState]`<Int>`) by each decorated window in
  * its scene setup, so overlapping windows each have their own counter.
+ * Defaults to [GlobalModalDialogCount] so a dialog composed outside any
+ * window becomes application-modal instead of incrementing a counter nobody
+ * observes.
  *
  * When a [DecoratedDialog] opens, it reads this local from the bridged outer
  * context and increments it; the parent window reacts by rendering a
@@ -18,5 +35,5 @@ import androidx.compose.runtime.mutableStateOf
  */
 val LocalModalDialogCount =
     compositionLocalOf<MutableState<Int>> {
-        mutableStateOf(0)
+        GlobalModalDialogCount
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.DpSize
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.DecoratedWindowState
+import dev.nucleusframework.window.GlobalModalDialogCount
 import dev.nucleusframework.window.LocalModalDialogCount
 import dev.nucleusframework.window.LocalTitleBarInfo
 import dev.nucleusframework.window.TitleBarInfo
@@ -485,12 +486,16 @@ private fun ApplicationScope.openDecoratedWindowLinux(
                                 scopeFactory().content()
                             }
                         }
-                        if (modalCount.value > 0) {
+                        if (modalCount.value > 0 || (!isDialog && GlobalModalDialogCount.value > 0)) {
                             // Dim the whole parent window while a dialog is open.
                             // Linux dialogs are undecorated (no compositor
                             // shadow), so the scrim is what visually pushes the
                             // parent back and lifts the dialog forward — on top
-                            // of swallowing pointer events.
+                            // of swallowing pointer events. GlobalModalDialogCount
+                            // covers dialogs composed at application scope, which
+                            // are application-modal: they block every window
+                            // except dialog windows themselves (the app-modal
+                            // dialog must stay interactive).
                             Box(
                                 modifier =
                                     Modifier
@@ -796,7 +801,7 @@ private fun ApplicationScope.openDecoratedWindowWindows(
                                 scopeFactory().content()
                             }
                         }
-                        if (modalCount.value > 0) {
+                        if (modalCount.value > 0 || (!isDialog && GlobalModalDialogCount.value > 0)) {
                             Box(
                                 modifier =
                                     Modifier


### PR DESCRIPTION
## Summary
- A `DecoratedDialog` composed outside any decorated window's content (e.g. a settings dialog hoisted next to the window list so one instance is shared by all windows) incremented the **default** value of `LocalModalDialogCount` — a counter no window observes. No input blocker was rendered, so the dialog blocked nothing.
- Promote that default to an explicit `GlobalModalDialogCount` and have every decorated window's blocker check it in addition to its own per-window counter: an application-scope dialog now blocks every open window, including windows created while it is up.
- Dialog windows themselves (`isDialog`) are excluded from the global blocker so the app-modal dialog stays interactive.
- Dialogs declared inside a window's content keep their per-window modality and `transient_for` behavior unchanged.

## Test plan
- [x] Zayit on native Wayland: settings dialog hoisted at application scope dims and blocks the main window while staying interactive itself
- [x] Dialog declared inside a window's content: blocks only its parent window (second window stays usable)
- [x] Closing the dialog restores interactivity
- [x] `compileKotlin` clean on decorated-window-core + decorated-window-tao