### PR TITLE
feat(packaging): passwordless signed self-update for Linux DEB/RPM

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -239,6 +239,10 @@ nucleus.application {
                 // enabled.set(true)
                 // keyId.set("ABCD1234DEADBEEF")          // GPG key id / fingerprint / email
                 // keyFile.set(file("packaging/signing-key.asc")) // optional: imported into a throwaway keyring
+
+                // Passwordless self-update: installs a signature-verifying helper + polkit policy so
+                // the app applies a verified update without a root password prompt. Requires enabled = true.
+                // silentUpdate.set(true)
             }
         }
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/LinuxSigningSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/LinuxSigningSettings.kt
@@ -67,6 +67,21 @@ abstract class LinuxSigningSettings {
     /** Method used to sign `.deb` packages. Default: [DebSignMethod.Detached]. */
     @get:Input
     var debMethod: DebSignMethod = DebSignMethod.Detached
+
+    /**
+     * Enable passwordless self-update for DEB/RPM installs (Linux only).
+     *
+     * Requires [enabled] — the update helper only installs packages whose detached signature
+     * verifies against the public key bundled in the app. When on, the package ships a root-owned
+     * update helper plus a polkit policy that lets the app apply a verified update without a
+     * password prompt. Off by default. Falls back to the standard `pkexec` (password) install when
+     * the helper is absent.
+     */
+    @get:Input
+    val silentUpdate: Property<Boolean> =
+        objects.notNullProperty<Boolean>().apply {
+            set(NucleusProperties.linuxSignSilentUpdate(providers).orElse(false))
+        }
 }
 
 /**

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/LinuxSigner.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/LinuxSigner.kt
@@ -40,6 +40,7 @@ internal class LinuxSigner(
         keyFile: File?,
         passphrase: String?,
         debMethod: DebSignMethod,
+        requireDetachedSignature: Boolean = false,
     ) {
         if (packages.isEmpty()) return
 
@@ -50,28 +51,91 @@ internal class LinuxSigner(
                     return
                 }
 
+        withKeyring(keyFile, passphrase) { home, passphraseFile ->
+            for (pkg in packages) {
+                val wroteDetached =
+                    when (pkg.extension.lowercase()) {
+                        "rpm" -> {
+                            signRpm(gpg, home, keyId, passphraseFile, pkg)
+                            false
+                        }
+                        "deb" -> signDeb(gpg, home, keyId, passphraseFile, debMethod, pkg)
+                        else -> false
+                    }
+                // The silent-update helper verifies a detached `<pkg>.asc`; make sure one exists
+                // even for formats whose primary signature lives elsewhere (RPM header, _gpgorigin).
+                if (requireDetachedSignature && !wroteDetached) {
+                    detachSign(gpg, home, keyId, passphraseFile, pkg)
+                }
+                exportPublicKey(gpg, home, keyId, File(pkg.parentFile, "${pkg.name}.pub.asc"))
+            }
+        }
+    }
+
+    /**
+     * Exports just the public key for [keyId] to [destination], without touching any package.
+     * Used to bundle the key inside the app before packaging so the update helper can verify
+     * downloads against it.
+     */
+    fun exportPublicKey(
+        keyId: String,
+        keyFile: File?,
+        passphrase: String?,
+        destination: File,
+    ) {
+        val gpg =
+            findInPath("gpg")
+                ?: run {
+                    logger.warn("Public key export skipped: 'gpg' not found in PATH")
+                    return
+                }
+        withKeyring(keyFile, passphrase) { home, _ ->
+            exportPublicKey(gpg, home, keyId, destination)
+        }
+    }
+
+    /**
+     * Runs [block] with a throwaway `GNUPGHOME` that has [keyFile] imported (if given), so the
+     * user's real keyring is never touched. The keyring and its agent are cleaned up afterwards.
+     */
+    private fun withKeyring(
+        keyFile: File?,
+        passphrase: String?,
+        block: (home: File, passphraseFile: File?) -> Unit,
+    ) {
+        val gpg = findInPath("gpg") ?: return
         val home = Files.createTempDirectory("nucleus-gpg").toFile()
         restrictToOwner(home)
         // Allow non-interactive (loopback) passphrase entry in this throwaway keyring.
         File(home, "gpg-agent.conf").writeText("allow-loopback-pinentry\n")
         val passphraseFile = passphrase?.let { writePassphraseFile(home, it) }
-
         try {
             if (keyFile != null) {
                 importKey(gpg, home, keyFile, passphraseFile)
             }
-            for (pkg in packages) {
-                when (pkg.extension.lowercase()) {
-                    "rpm" -> signRpm(gpg, home, keyId, passphraseFile, pkg)
-                    "deb" -> signDeb(gpg, home, keyId, passphraseFile, debMethod, pkg)
-                    else -> Unit
-                }
-                exportPublicKey(gpg, home, keyId, File(pkg.parentFile, "${pkg.name}.pub.asc"))
-            }
+            block(home, passphraseFile)
         } finally {
             killAgent(home)
             home.deleteRecursively()
         }
+    }
+
+    /** Writes a detached, armored `<pkg>.asc` signature next to [pkg]. */
+    private fun detachSign(
+        gpg: File,
+        home: File,
+        keyId: String,
+        passphraseFile: File?,
+        pkg: File,
+    ) {
+        val sig = File(pkg.parentFile, "${pkg.name}.asc")
+        logger.lifecycle("Writing detached signature ${sig.name}")
+        runTool(
+            tool = gpg,
+            args =
+                gpgBaseArgs(home, passphraseFile) +
+                    listOf("-u", keyId, "--detach-sign", "--armor", "-o", sig.absolutePath, pkg.absolutePath),
+        )
     }
 
     private fun gpgBaseArgs(
@@ -145,6 +209,7 @@ internal class LinuxSigner(
         )
     }
 
+    /** Signs a `.deb`. Returns `true` when it wrote a detached `<pkg>.asc` (the `Detached` method). */
     private fun signDeb(
         gpg: File,
         home: File,
@@ -152,7 +217,7 @@ internal class LinuxSigner(
         passphraseFile: File?,
         debMethod: DebSignMethod,
         pkg: File,
-    ) {
+    ): Boolean {
         val gpgOpts =
             buildString {
                 append("--homedir ${home.absolutePath} --batch --yes --no-tty")
@@ -163,21 +228,15 @@ internal class LinuxSigner(
 
         when (debMethod) {
             DebSignMethod.Detached -> {
-                val sig = File(pkg.parentFile, "${pkg.name}.asc")
-                logger.lifecycle("Signing DEB ${pkg.name} (detached ${sig.name})")
-                runTool(
-                    tool = gpg,
-                    args =
-                        gpgBaseArgs(home, passphraseFile) +
-                            listOf("-u", keyId, "--detach-sign", "--armor", "-o", sig.absolutePath, pkg.absolutePath),
-                )
+                detachSign(gpg, home, keyId, passphraseFile, pkg)
+                return true
             }
             DebSignMethod.DpkgSig -> {
                 val dpkgSig =
                     findInPath("dpkg-sig")
                         ?: run {
                             logger.warn("DEB signing skipped for ${pkg.name}: 'dpkg-sig' not found in PATH")
-                            return
+                            return false
                         }
                 logger.lifecycle("Signing DEB ${pkg.name} (dpkg-sig)")
                 runTool(
@@ -190,7 +249,7 @@ internal class LinuxSigner(
                     findInPath("debsigs")
                         ?: run {
                             logger.warn("DEB signing skipped for ${pkg.name}: 'debsigs' not found in PATH")
-                            return
+                            return false
                         }
                 logger.lifecycle("Signing DEB ${pkg.name} (debsigs/_gpgorigin)")
                 runTool(
@@ -199,6 +258,7 @@ internal class LinuxSigner(
                 )
             }
         }
+        return false
     }
 
     private fun exportPublicKey(

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/LinuxUpdateHelper.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/LinuxUpdateHelper.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal
+
+/**
+ * The passwordless update helper installed next to a signed Linux app.
+ *
+ * It is invoked through `pkexec` (scoped by a polkit policy to this exact path) and:
+ * 1. verifies the downloaded package's detached `<pkg>.asc` signature against the public key
+ *    bundled in the app (`resources/nucleus-update.pub.asc`), in a throwaway keyring;
+ * 2. ensures the package upgrades THIS app only — the new package name must match the package
+ *    that owns the helper file — so `allow_active=yes` cannot install arbitrary packages;
+ * 3. installs via `dpkg -i` / `rpm -U`.
+ *
+ * The script is fully self-contained (resolves its own location via `readlink`) and uses no
+ * electron-builder macros, so it can be embedded verbatim in the afterInstall heredoc and exercised
+ * directly in tests. Exit codes: 2 usage, 3 package mismatch, 4 missing key/signature, gpg's own
+ * non-zero on a failed signature.
+ */
+internal object LinuxUpdateHelper {
+    val SCRIPT: String =
+        $$"""
+        #!/usr/bin/env bash
+        # Installed by Nucleus. Verifies a signed update against the bundled public key and,
+        # if valid and for this same app, installs it. Invoked via pkexec (see polkit policy).
+        set -eu
+        if [ "$#" -lt 1 ]; then echo "usage: nucleus-update-helper <package>" >&2; exit 2; fi
+        PKG="$1"
+        [ -f "$PKG" ] || { echo "package not found: $PKG" >&2; exit 2; }
+        SELF="$(readlink -f "$0")"
+        APPDIR="$(dirname "$SELF")"
+        PUBKEY="$APPDIR/resources/nucleus-update.pub.asc"
+        SIG="$PKG.asc"
+        [ -f "$PUBKEY" ] || { echo "missing public key: $PUBKEY" >&2; exit 4; }
+        [ -f "$SIG" ]    || { echo "missing signature: $SIG" >&2; exit 4; }
+
+        # Verify the detached signature against the bundled key in a throwaway keyring.
+        KR="$(mktemp -d)"; trap 'rm -rf "$KR"' EXIT; chmod 700 "$KR"
+        gpg --homedir "$KR" --batch --quiet --import "$PUBKEY"
+        gpg --homedir "$KR" --batch --verify "$SIG" "$PKG"
+
+        # Only upgrade THIS app: the new package's name must match the package that owns the helper.
+        case "$PKG" in
+          *.deb)
+            OWNER="$(dpkg -S "$SELF" 2>/dev/null | cut -d: -f1 | head -n1)"
+            NEW="$(dpkg-deb -f "$PKG" Package)"
+            [ -n "$OWNER" ] && [ "$NEW" = "$OWNER" ] || { echo "package mismatch: $NEW != $OWNER" >&2; exit 3; }
+            exec dpkg -i "$PKG"
+            ;;
+          *.rpm)
+            OWNER="$(rpm -qf --qf '%{NAME}' "$SELF" 2>/dev/null)"
+            NEW="$(rpm -qp --qf '%{NAME}' "$PKG")"
+            [ -n "$OWNER" ] && [ "$NEW" = "$OWNER" ] || { echo "package mismatch: $NEW != $OWNER" >&2; exit 3; }
+            exec rpm -U "$PKG"
+            ;;
+          *) echo "unsupported package: $PKG" >&2; exit 2 ;;
+        esac
+        """.trimIndent()
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NucleusProjectProperties.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NucleusProjectProperties.kt
@@ -31,6 +31,7 @@ internal object NucleusProperties {
     internal const val LINUX_SIGN_KEY_ID = "compose.desktop.linux.signing.keyId"
     internal const val LINUX_SIGN_KEY_FILE = "compose.desktop.linux.signing.keyFile"
     internal const val LINUX_SIGN_PASSPHRASE = "compose.desktop.linux.signing.passphrase"
+    internal const val LINUX_SIGN_SILENT_UPDATE = "compose.desktop.linux.signing.silentUpdate"
     internal const val CHECK_JDK_VENDOR = "compose.desktop.packaging.checkJdkVendor"
     internal const val DISABLE_MULTIMODULE_RESOURCES = "org.jetbrains.compose.resources.multimodule.disable"
     internal const val SYNC_RESOURCES_PROPERTY = "compose.ios.resources.sync"
@@ -82,6 +83,9 @@ internal object NucleusProperties {
 
     @Suppress("MaxLineLength")
     fun linuxSignPassphrase(providers: ProviderFactory): Provider<String> = providers.valueOrNull(LINUX_SIGN_PASSPHRASE)
+
+    @Suppress("MaxLineLength")
+    fun linuxSignSilentUpdate(providers: ProviderFactory): Provider<Boolean> = providers.valueOrNull(LINUX_SIGN_SILENT_UPDATE).toBooleanProvider(false)
 
     fun checkJdkVendor(providers: ProviderFactory): Provider<Boolean> = providers.valueOrNull(CHECK_JDK_VENDOR).toBooleanProvider(true)
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -12,6 +12,7 @@ import dev.nucleusframework.desktop.application.dsl.ReleaseChannel
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import dev.nucleusframework.desktop.application.internal.UpdateYmlGenerator
 import dev.nucleusframework.desktop.application.internal.LinuxSigner
+import dev.nucleusframework.desktop.application.internal.LinuxUpdateHelper
 import dev.nucleusframework.desktop.application.internal.MacSigner
 import dev.nucleusframework.desktop.application.internal.MacSignerImpl
 import dev.nucleusframework.desktop.application.internal.NoCertificateSigner
@@ -231,6 +232,7 @@ abstract class AbstractElectronBuilderPackageTask
             val workingAppDir = copyAppImage(originalAppDir, outputDir, logger)
 
             ensureResourcesDirForElectronBuilder(workingAppDir)
+            bundleUpdatePublicKey(workingAppDir, dist)
             ensureLinuxExecutableAlias(workingAppDir)
             updateExecutableTypeInAppImage(workingAppDir, targetFormat, logger, packageVersion.orNull)
             ensureMacAdHocSigning(workingAppDir, targetFormat)
@@ -240,7 +242,7 @@ abstract class AbstractElectronBuilderPackageTask
 
             val linuxIconOverride = prepareLinuxIconSet(outputDir)
             val windowsIconOverride = resolveWindowsIcon()
-            val linuxAfterInstallTemplate = prepareLinuxAfterInstallTemplate(outputDir)
+            val linuxAfterInstallTemplate = prepareLinuxAfterInstallTemplate(outputDir, isLinuxSilentUpdateEnabled(dist))
             if (targetFormat == TargetFormat.AppX) {
                 val hasExplicitWindowsIcon =
                     dist.windows.iconFile.orNull
@@ -916,7 +918,52 @@ abstract class AbstractElectronBuilderPackageTask
                         ?.asFile,
                 passphrase = signing.passphrase.orNull,
                 debMethod = signing.debMethod,
+                requireDetachedSignature = isLinuxSilentUpdateEnabled(dist),
             )
+        }
+
+        /**
+         * Whether passwordless signature-verified self-update should be wired into this DEB/RPM.
+         * Requires Linux, a deb/rpm target, and signing to be fully configured.
+         */
+        private fun isLinuxSilentUpdateEnabled(dist: JvmApplicationDistributions): Boolean {
+            if (currentOS != OS.Linux) return false
+            if (targetFormat != TargetFormat.Deb && targetFormat != TargetFormat.Rpm) return false
+            val signing = dist.linux.signing
+            if (!signing.silentUpdate.get()) return false
+            if (!signing.enabled.get()) {
+                logger.warn("linux.signing.silentUpdate requires linux.signing.enabled = true; ignoring silentUpdate")
+                return false
+            }
+            if (signing.keyId.orNull.isNullOrBlank()) {
+                logger.warn("linux.signing.silentUpdate requires a signing.keyId; ignoring silentUpdate")
+                return false
+            }
+            return true
+        }
+
+        /**
+         * Exports the signing public key into the app's `resources/` so the installed update helper
+         * can verify downloaded updates against it. Must run before electron-builder packages the app.
+         */
+        private fun bundleUpdatePublicKey(
+            workingAppDir: File,
+            dist: JvmApplicationDistributions,
+        ) {
+            if (!isLinuxSilentUpdateEnabled(dist)) return
+            val signing = dist.linux.signing
+            val keyId = signing.keyId.orNull ?: return
+            val dest = workingAppDir.resolve("resources/nucleus-update.pub.asc")
+            dest.parentFile.mkdirs()
+            LinuxSigner(runExternalTool, logger).exportPublicKey(
+                keyId = keyId,
+                keyFile =
+                    signing.keyFile.orNull
+                        ?.asFile,
+                passphrase = signing.passphrase.orNull,
+                destination = dest,
+            )
+            logger.lifecycle("Bundled update public key into resources/nucleus-update.pub.asc")
         }
 
         private fun prepareLinuxIconSet(outputDir: File): File? {
@@ -1110,7 +1157,10 @@ abstract class AbstractElectronBuilderPackageTask
             }
         }
 
-        private fun prepareLinuxAfterInstallTemplate(outputDir: File): File? {
+        private fun prepareLinuxAfterInstallTemplate(
+            outputDir: File,
+            silentUpdate: Boolean,
+        ): File? {
             if (currentOS != OS.Linux) return null
             if (targetFormat != TargetFormat.Deb &&
                 targetFormat != TargetFormat.Rpm &&
@@ -1184,9 +1234,58 @@ abstract class AbstractElectronBuilderPackageTask
                 fi
                 """.trimIndent() + "\n"
 
-            templateFile.writeText(script)
+            val fullScript = if (silentUpdate) script + linuxSilentUpdateAfterInstallBlock() else script
+            templateFile.writeText(fullScript)
             logger.info("Generated Linux after-install template at: ${templateFile.absolutePath}")
             return templateFile
+        }
+
+        /**
+         * Root-run afterInstall fragment that installs the passwordless update helper plus a polkit
+         * policy scoped to it. The helper verifies a detached signature against the bundled public
+         * key and only upgrades the package that owns the helper, so `allow_active=yes` cannot be
+         * abused to install arbitrary packages. `${'$'}{executable}`/`${'$'}{sanitizedProductName}`
+         * are substituted by electron-builder at package time.
+         */
+        private fun linuxSilentUpdateAfterInstallBlock(): String {
+            val header =
+                $$"""
+                # --- Nucleus passwordless self-update (signature-verified) ---
+                NUCLEUS_HELPER='/opt/${sanitizedProductName}/nucleus-update-helper'
+                NUCLEUS_POLKIT_ACTION='dev.nucleusframework.${executable}.update'
+
+                cat > "$NUCLEUS_HELPER" <<'NUCLEUS_HELPER_EOF'
+                """.trimIndent()
+            val footer =
+                $$"""
+                NUCLEUS_HELPER_EOF
+                chmod 0755 "$NUCLEUS_HELPER"
+                chown root:root "$NUCLEUS_HELPER" 2>/dev/null || true
+
+                # polkit policy: an ACTIVE local session may run ONLY this helper without a password.
+                POLKIT_DIR='/usr/share/polkit-1/actions'
+                if mkdir -p "$POLKIT_DIR" 2>/dev/null; then
+                cat > "$POLKIT_DIR/$NUCLEUS_POLKIT_ACTION.policy" <<NUCLEUS_POLKIT_EOF
+                <?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+                 "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+                <policyconfig>
+                  <action id="$NUCLEUS_POLKIT_ACTION">
+                    <description>Install ${sanitizedProductName} updates</description>
+                    <message>Authentication is required to install ${sanitizedProductName} updates</message>
+                    <defaults>
+                      <allow_any>auth_admin</allow_any>
+                      <allow_inactive>auth_admin</allow_inactive>
+                      <allow_active>yes</allow_active>
+                    </defaults>
+                    <annotate key="org.freedesktop.policykit.exec.path">$NUCLEUS_HELPER</annotate>
+                    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+                  </action>
+                </policyconfig>
+                NUCLEUS_POLKIT_EOF
+                fi
+                """.trimIndent()
+            return "\n" + header + "\n" + LinuxUpdateHelper.SCRIPT + "\n" + footer + "\n"
         }
 
         private fun resizeIcon(

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/LinuxSignerTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/LinuxSignerTest.kt
@@ -4,6 +4,7 @@ import dev.nucleusframework.desktop.application.dsl.DebSignMethod
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.process.ExecOperations
 import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assume
 import org.junit.Rule
@@ -76,12 +77,94 @@ class LinuxSignerTest {
         assertTrue("detached signature did not verify", detachedSignatureVerifies(deb, detachedSig, publicKey))
     }
 
+    @Test
+    fun `silent-update signing also writes a detached asc for rpm`() {
+        Assume.assumeTrue("requires gpg, rpm and rpmbuild", toolsAvailable("gpg", "rpm", "rpmbuild"))
+
+        val keyHome = tmp.newFolder().apply { restrict() }
+        val keyId = generateKey(keyHome)
+        val privateKey = exportPrivateKey(keyHome, keyId)
+        val rpm = buildMinimalRpm()
+
+        // --- code under test ---
+        LinuxSigner(runner(), project.logger).sign(
+            packages = listOf(rpm),
+            keyId = keyId,
+            keyFile = privateKey,
+            passphrase = passphrase,
+            debMethod = DebSignMethod.Detached,
+            requireDetachedSignature = true,
+        )
+
+        val detached = File(rpm.parentFile, "${rpm.name}.asc")
+        val publicKey = File(rpm.parentFile, "${rpm.name}.pub.asc")
+        assertTrue("detached .asc not written for rpm", detached.isFile && detached.length() > 0)
+        assertTrue("detached rpm signature did not verify", detachedSignatureVerifies(rpm, detached, publicKey))
+    }
+
+    @Test
+    fun `update helper accepts a valid signature and rejects a tampered or missing one`() {
+        Assume.assumeTrue("requires gpg and dpkg-deb", toolsAvailable("gpg", "dpkg-deb"))
+
+        val keyHome = tmp.newFolder().apply { restrict() }
+        val keyId = generateKey(keyHome)
+
+        // Lay out the install dir exactly as the package would: helper + bundled public key.
+        val appDir = tmp.newFolder()
+        val helper =
+            File(appDir, "nucleus-update-helper").apply {
+                writeText(LinuxUpdateHelper.SCRIPT)
+                setExecutable(true)
+            }
+        File(appDir, "resources").mkdirs()
+        File(appDir, "resources/nucleus-update.pub.asc")
+            .writeText(capture("gpg", "--homedir", keyHome.absolutePath, "--batch", "--armor", "--export", keyId))
+
+        val pkg = buildMinimalDeb(appDir)
+        val sig = File("${pkg.absolutePath}.asc")
+        run(
+            "gpg", "--homedir", keyHome.absolutePath, "--batch", "--yes",
+            "--pinentry-mode", "loopback", "--passphrase", passphrase,
+            "-u", keyId, "--detach-sign", "--armor", "-o", sig.absolutePath, pkg.absolutePath,
+        )
+
+        // Valid signature: passes verification, then stops at the ownership check (exit 3) because
+        // the helper is not actually owned by an installed package in this test environment.
+        assertEquals("valid signature must pass verification", 3, exitCodeOf("bash", helper.absolutePath, pkg.absolutePath))
+
+        // Tampered package: the detached signature no longer matches → rejected at verification.
+        pkg.appendBytes(byteArrayOf(0))
+        val tampered = exitCodeOf("bash", helper.absolutePath, pkg.absolutePath)
+        assertTrue("tampered package must be rejected (got $tampered)", tampered != 0 && tampered != 3)
+
+        // Missing signature → explicit refusal (exit 4).
+        sig.delete()
+        assertEquals("missing signature must be refused", 4, exitCodeOf("bash", helper.absolutePath, pkg.absolutePath))
+    }
+
+    private fun buildMinimalDeb(dir: File): File {
+        val root = tmp.newFolder()
+        File(root, "DEBIAN").mkdirs()
+        File(root, "DEBIAN/control").writeText(
+            buildString {
+                appendLine("Package: nucleus-helper-test")
+                appendLine("Version: 1.0.0")
+                appendLine("Architecture: amd64")
+                appendLine("Maintainer: Nucleus Test <test@nucleus.dev>")
+                appendLine("Description: helper test package")
+            },
+        )
+        val deb = File(dir, "nucleus-helper-test_1.0.0_amd64.deb")
+        run("dpkg-deb", "--build", "--nocheck", root.absolutePath, deb.absolutePath)
+        return deb
+    }
+
     private fun detachedSignatureVerifies(
         deb: File,
         sig: File,
         publicKey: File,
     ): Boolean {
-        val verifyHome = tmp.newFolder("deb-verify").apply { restrict() }
+        val verifyHome = tmp.newFolder().apply { restrict() }
         run("gpg", "--homedir", verifyHome.absolutePath, "--batch", "--import", publicKey.absolutePath)
         val output =
             capture(
@@ -141,7 +224,7 @@ class LinuxSignerTest {
     }
 
     private fun buildMinimalRpm(): File {
-        val top = tmp.newFolder("rpmbuild")
+        val top = tmp.newFolder()
         listOf("SPECS", "BUILD", "RPMS", "SOURCES").forEach { File(top, it).mkdirs() }
         val spec = File(top, "SPECS/foo.spec")
         spec.writeText(
@@ -165,7 +248,7 @@ class LinuxSignerTest {
         rpm: File,
         publicKey: File,
     ): Boolean {
-        val db = tmp.newFolder("rpmdb")
+        val db = tmp.newFolder()
         run("rpm", "--dbpath", db.absolutePath, "--initdb")
         run("rpm", "--dbpath", db.absolutePath, "--import", publicKey.absolutePath)
         val output = capture("rpm", "--dbpath", db.absolutePath, "-K", rpm.absolutePath, env = mapOf("LC_ALL" to "C"))
@@ -184,6 +267,12 @@ class LinuxSignerTest {
     private fun run(vararg command: String) {
         val exit = process(command.toList(), emptyMap()).waitFor()
         check(exit == 0) { "command failed ($exit): ${command.joinToString(" ")}" }
+    }
+
+    private fun exitCodeOf(vararg command: String): Int {
+        val proc = process(command.toList(), emptyMap())
+        proc.inputStream.readBytes() // drain so the process never blocks on a full pipe
+        return proc.waitFor()
     }
 
     private fun capture(

--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/NucleusUpdater.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/NucleusUpdater.kt
@@ -115,6 +115,11 @@ class NucleusUpdater(
                 if (finalFile.exists()) finalFile.delete()
                 tempFile.renameTo(finalFile)
 
+                // Best-effort: fetch the detached signature next to the package so a signature-verified
+                // silent install (Linux passwordless update) can use it. Absent signature is not fatal —
+                // the installer simply falls back to the standard (password-prompting) path.
+                downloadDetachedSignature(targetFile.url, File(finalFile.parentFile, "${finalFile.name}.asc"))
+
                 emit(DownloadProgress(bytesDownloaded, totalBytes, PERCENT_MAX, finalFile))
             } catch (e: UpdateException) {
                 tempFile.delete()
@@ -129,6 +134,32 @@ class NucleusUpdater(
                 throw NetworkException("Download failed", e)
             }
         }.flowOn(Dispatchers.IO)
+
+    /**
+     * Downloads `<url>.asc` to [dest] if present. Failures are swallowed: the detached signature is
+     * optional and only used by the Linux passwordless self-update helper.
+     */
+    private fun downloadDetachedSignature(
+        url: String,
+        dest: File,
+    ) {
+        try {
+            val requestBuilder =
+                HttpRequest
+                    .newBuilder()
+                    .uri(URI.create("$url.asc"))
+                    .GET()
+            applyAuthHeaders(requestBuilder)
+            val response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofByteArray())
+            if (response.statusCode() == HTTP_OK) {
+                dest.writeBytes(response.body())
+            }
+        } catch (
+            @Suppress("TooGenericExceptionCaught") e: Exception,
+        ) {
+            // Signature unavailable — silent update will fall back to the prompting install path.
+        }
+    }
 
     fun installAndRestart(installerFile: File) {
         writeUpdateMarker()

--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/PlatformInstaller.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/internal/PlatformInstaller.kt
@@ -111,10 +111,18 @@ internal object PlatformInstaller {
             currentExecutablePath()
                 ?: error("Cannot resolve application launcher from the running process")
 
+        // Prefer the passwordless, signature-verifying update helper installed alongside the app
+        // (see the Gradle plugin's afterInstall script). It only runs without a password when its
+        // polkit policy is present, and only installs a package whose detached signature verifies
+        // against the bundled public key. Falls back to the standard prompting install otherwise.
+        val helper = resolveUpdateHelper(launcher)
+        val signatureFile = File("${packageFile.absolutePath}.asc")
         val installCmd =
-            when (extension) {
-                "deb" -> "pkexec dpkg -i \"\$PKG_FILE\""
-                "rpm" -> "pkexec rpm -U \"\$PKG_FILE\""
+            when {
+                helper != null && signatureFile.isFile ->
+                    "pkexec \"${helper.absolutePath}\" \"\$PKG_FILE\""
+                extension == "deb" -> "pkexec dpkg -i \"\$PKG_FILE\""
+                extension == "rpm" -> "pkexec rpm -U \"\$PKG_FILE\""
                 else -> error("Unsupported package format: $extension")
             }
 
@@ -149,8 +157,8 @@ internal object PlatformInstaller {
             |# which would prevent the application from relaunching.
             |$installCmd
             |
-            |# Clean up the package file
-            |rm -f "${'$'}PKG_FILE"
+            |# Clean up the package file and its detached signature
+            |rm -f "${'$'}PKG_FILE" "${'$'}PKG_FILE.asc"
             |$relaunchCmd
             |# Clean up this script
             |rm -f "${'$'}{0}"
@@ -163,6 +171,18 @@ internal object PlatformInstaller {
             .redirectError(ProcessBuilder.Redirect.DISCARD)
             .start()
     }
+
+    /**
+     * Resolves the passwordless update helper installed next to the app, or `null` if absent.
+     *
+     * The helper lives beside the real launcher binary (e.g. `/opt/<App>/nucleus-update-helper`).
+     * The running launcher may be a `/usr/bin` symlink, so resolve through it to the install dir.
+     */
+    private fun resolveUpdateHelper(launcher: String): File? =
+        File(launcher)
+            .canonicalFile.parentFile
+            ?.resolve("nucleus-update-helper")
+            ?.takeIf { it.isFile }
 
     /**
      * Resolves the absolute path of the executable that launched the current process.


### PR DESCRIPTION
## Summary
Opt-in passwordless auto-update for signed Linux packages. When `linux.signing.silentUpdate` is enabled (requires `signing.enabled`), the app can apply a verified update without a root password prompt.

The packaged app ships:
- **An update helper** (`LinuxUpdateHelper.SCRIPT`) that verifies the downloaded package's detached `<pkg>.asc` signature against the public key bundled in the app (in a throwaway keyring), refuses to install anything but an upgrade of *this same* package (so `allow_active=yes` can't install arbitrary packages), then runs `dpkg -i` / `rpm -U`. Self-contained (resolves its own path via `readlink`), so it embeds verbatim in the `afterInstall` heredoc and is exercised directly in tests.
- **A polkit policy** scoping `pkexec` to that exact helper path.

Plumbing:
- `LinuxSigner` exports the public key next to the app and guarantees a detached signature per package (`requireDetachedSignature`); keyring setup refactored into a shared `withKeyring` block.
- `AbstractElectronBuilderPackageTask` installs the helper + polkit policy + public key via `afterInstall`.
- `NucleusUpdater` best-effort fetches `<url>.asc` next to the package; `PlatformInstaller` prefers the helper when it and the signature are present, else falls back to the standard prompting `pkexec` install.
- `silentUpdate` defaults **off**; a missing helper/signature always degrades to the existing password-prompt path.

## Test plan
- [x] `LinuxSignerTest` extended (+95 lines) covering public-key export, detached-signature guarantee, and the helper script's verify/package-match/exit-code behavior
- [ ] ⚠️ Tests not run in this environment: the `plugin-build` composite's Kotlin compiler rejects the default JDK 25 (`JavaVersion.parse("25")` throws) and the only local JDK 21 is a JRE without `javac`. Needs a run on the standard JBR 21 toolchain / CI.
- [ ] Manual: build a signed DEB with `silentUpdate = true`, install, trigger an update → applies without password; tamper the `.asc` → helper refuses