### PR TITLE
fix(tao): rename object to TaoWheelPinchZoom to match call sites (fixes #281 build)

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelPinchZoom.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelPinchZoom.kt
@@ -2,13 +2,19 @@ package dev.nucleusframework.window.tao.render
 
 import kotlin.math.pow
 
-internal object TaoWindowsPinchZoom {
+/**
+ * Maps a Ctrl+wheel / precision-touchpad wheel delta to a multiplicative zoom step.
+ * Shared by the Windows and Linux hosts, which both synthesise a magnify gesture from
+ * Ctrl+wheel so it zooms (never scrolls) — the AWT backend has no pinch-zoom, so this
+ * gives Windows/Linux the same behaviour.
+ */
+internal object TaoWheelPinchZoom {
     private const val WHEEL_DELTAS_PER_DOUBLING: Float = 12f
 
     /**
-     * Windows reports Ctrl+wheel / precision-touchpad pinch as WHEEL_DELTA-normalized
-     * deltas. Treat them as a continuous stream: fractional deltas compose to the
-     * same zoom as a single larger delta, and one full wheel delta stays moderate.
+     * Wheel deltas are WHEEL_DELTA-normalized (≈1.0 per notch, fractional for precision
+     * touchpads). Treat them as a continuous stream: fractional deltas compose to the same
+     * zoom as a single larger delta, and one full wheel delta stays moderate.
      */
     fun stepFromWheelDelta(delta: Float): Float = if (delta == 0f) 1f else 2f.pow(delta / WHEEL_DELTAS_PER_DOUBLING)
 }


### PR DESCRIPTION
## Summary
#281 renamed `TaoWindowsPinchZoom.kt` → `TaoWheelPinchZoom.kt` with `git mv`, which staged the file at its new path but with its **old content**; the follow-up edit renaming the `object` was left unstaged. The merged commit therefore declares `object TaoWindowsPinchZoom` while both `TaoComposeSceneHost{Linux,Windows}` call `TaoWheelPinchZoom.stepFromWheelDelta(...)` — a compile break.

Rename the declaration to `TaoWheelPinchZoom` so it matches the call sites.

## Test plan
- [x] `:decorated-window-tao:compileKotlin` clean