### PR TITLE
fix(updater): suppress SwallowedException blocking Maven publish

### DIFF
--- a/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/NucleusUpdater.kt
+++ b/updater-runtime/src/main/kotlin/dev/nucleusframework/updater/NucleusUpdater.kt
@@ -155,9 +155,11 @@ class NucleusUpdater(
                 dest.writeBytes(response.body())
             }
         } catch (
-            @Suppress("TooGenericExceptionCaught") e: Exception,
+            @Suppress("TooGenericExceptionCaught", "SwallowedException") e: Exception,
         ) {
-            // Signature unavailable — silent update will fall back to the prompting install path.
+            // Deliberately swallowed: the detached signature is optional, so any failure here
+            // (missing .asc, network error) just means the silent update falls back to the
+            // standard password-prompting install path — not an error worth surfacing.
         }
     }
 


### PR DESCRIPTION
## Summary
`2.0.0-alpha-202607042242` and `202607050152` never published to Maven Central. Root cause: the `downloadDetachedSignature` helper added for Linux passwordless updates (#280) has an intentionally empty catch — the detached `<pkg>.asc` is optional and its absence just falls back to the prompting install — but detekt's `SwallowedException` flagged it. That failed `:updater-runtime:check`, which fails the `preMerge` gate, and the publish step is **skipped** when preMerge fails (so it shows as a failed publish run, never a rejected deploy).

Add `SwallowedException` to the `@Suppress` next to the existing `TooGenericExceptionCaught`, with a comment explaining the deliberate swallow.

## Test plan
- [x] `./gradlew preMerge --continue` BUILD SUCCESSFUL locally (JDK 17; the exact gate CI runs — 112 tasks executed incl. detekt/tests)
- [x] `:updater-runtime:check` clean