### PR TITLE
fix(tao): smooth, tear-free Windows resize

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -842,9 +842,10 @@ private fun ApplicationScope.openDecoratedWindowWindows(
             } else {
                 w to h
             }
-        host.onResized(initialW, initialH)
         host.syncTitleBarHeight()
-        host.onRedrawRequested()
+        // onResized renders synchronously, so this doubles as the guaranteed
+        // first paint before the window is shown (no separate onRedrawRequested).
+        host.onResized(initialW, initialH)
         if (visible) window.show()
     }
     window.onResized { w, h ->
@@ -872,6 +873,7 @@ private fun ApplicationScope.openDecoratedWindowWindows(
         host.detach()
     }
     window.onScaleFactorChanged { host.onScaleFactorChanged(it) }
+    window.onSizeMoveChanged { host.onResizeLoopChanged(it) }
     window.onPointerMoved { x, y -> if (enabled) host.onPointerMove(x, y) }
     window.onPointerExited { if (enabled) host.onPointerExited() }
     window.onPointerButton { b, p -> if (enabled) host.onPointerButton(b, p) }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoBridge.kt
@@ -683,6 +683,13 @@ object TaoEventCode {
      * shown again (GDK surface re-created) so the host can re-attach EGL.
      */
     const val SHOWN: Int = 24
+
+    /**
+     * Windows only. `a` = 1 when the OS modal resize/move loop starts
+     * (WM_ENTERSIZEMOVE), 0 when it ends (WM_EXITSIZEMOVE). The host drops
+     * VSync while active so border-drag frames don't block on VBlank.
+     */
+    const val SIZE_MOVE: Int = 25
 }
 
 /** Trackpad gesture kind reported by [NativeTaoBridge.EventCallback.onTrackpadGesture]. */

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoGlBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoGlBridge.kt
@@ -82,6 +82,18 @@ internal object NativeTaoGlBridge {
     @JvmStatic
     external fun nativePresent(handle: Long)
 
+    /**
+     * Toggles VSync via `eglSwapInterval`: `true` = pace presents on the display
+     * refresh (default), `false` = present immediately. Dropped to `false` for
+     * the duration of the OS modal resize/move loop so the synchronous
+     * per-WM_SIZE present doesn't block on VBlank while a border is dragged.
+     */
+    @JvmStatic
+    external fun nativeSetVSyncEnabled(
+        handle: Long,
+        enabled: Boolean,
+    )
+
     @JvmStatic
     external fun nativeWidth(handle: Long): Int
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoWindowsDecoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoWindowsDecoBridge.kt
@@ -140,6 +140,14 @@ internal object NativeTaoWindowsDecoBridge {
     external fun nativeIsMaximized(hwnd: Long): Boolean
 
     /**
+     * Refresh rate (Hz) of the monitor the window is on, or `0` if it can't be
+     * resolved. Used to cap the render rate during the modal resize loop (VSync
+     * is off then) so a border drag doesn't render far above the display refresh.
+     */
+    @JvmStatic
+    external fun nativeMonitorRefreshHz(hwnd: Long): Int
+
+    /**
      * Atomic unmaximize + reposition under the finger when a touch drag
      * starts on a maximized window. Returns the restored outer rect as
      * `[x, y, w, h]` in physical pixels, or `null` on failure.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -87,6 +87,9 @@ class TaoWindow internal constructor(
     @Volatile
     private var willHideListener: (() -> Unit)? = null
     private var shownListener: (() -> Unit)? = null
+
+    @Volatile
+    private var sizeMoveListener: ((Boolean) -> Unit)? = null
     private var pointerMoveListener: ((Int, Int) -> Unit)? = null
 
     @Volatile
@@ -574,6 +577,16 @@ class TaoWindow internal constructor(
         shownListener = block
     }
 
+    /**
+     * Windows only. Fires on the event-loop thread when the OS modal
+     * resize/move loop starts (`true`, WM_ENTERSIZEMOVE) and ends (`false`,
+     * WM_EXITSIZEMOVE). The host drops VSync while active so a border drag
+     * isn't throttled to the display refresh. No source on macOS / Linux.
+     */
+    fun onSizeMoveChanged(block: (active: Boolean) -> Unit) {
+        sizeMoveListener = block
+    }
+
     fun onPointerMoved(block: (xFixed: Int, yFixed: Int) -> Unit) {
         pointerMoveListener = block
     }
@@ -704,6 +717,7 @@ class TaoWindow internal constructor(
             TaoEventCode.MODIFIERS_CHANGED -> modifierState = a
             TaoEventCode.WILL_HIDE -> willHideListener?.invoke()
             TaoEventCode.SHOWN -> shownListener?.invoke()
+            TaoEventCode.SIZE_MOVE -> sizeMoveListener?.invoke(a != 0)
             TaoEventCode.SCROLL_LINE -> {
                 // AWT sends the wheel rotation as scrollDelta and leaves the
                 // platform line-count policy in MouseWheelEvent.scrollAmount.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -116,6 +116,16 @@ internal class TaoComposeSceneHostWindows(
     private var heightPx: Int = 0
     private var scale: Float = 1f
 
+    /**
+     * While the OS modal resize loop is active (VSync off, see
+     * [onResizeLoopChanged]) this is the minimum spacing between resize
+     * repaints — a frame cap that coalesces the WM_SIZE flood down to roughly
+     * the display refresh so we don't render far above what the monitor shows.
+     * 0 = uncapped (outside the loop, or when the refresh rate is unknown).
+     */
+    private var resizeFrameIntervalNanos: Long = 0L
+    private var lastResizePaintNanos: Long = 0L
+
     private var lastPointerX: Float = 0f
     private var lastPointerY: Float = 0f
 
@@ -758,10 +768,71 @@ internal class TaoComposeSceneHostWindows(
         if (widthPxNew == widthPx && heightPxNew == heightPx) return
         widthPx = widthPxNew
         heightPx = heightPxNew
-        NativeTaoGlBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
         scene?.size = IntSize(widthPx, heightPx)
         updateWindowInfoSize()
-        window.requestRedraw()
+
+        // Frame cap during the modal resize loop. VSync is off then (see
+        // onResizeLoopChanged), so nothing paces the render loop: Win32 can
+        // deliver WM_SIZE far above the display refresh and we'd render frames
+        // the monitor never shows — the CPU/GPU spike observed during resize.
+        // Coalesce the burst to ~refresh by skipping repaints that fall inside
+        // one frame interval. The swap-chain resize (nativeResize) is deferred
+        // to the frame we actually paint, so a coalesced-out WM_SIZE never
+        // leaves an enlarged-but-unpainted (black) surface: the child simply
+        // lags the window by at most one refresh interval, which the monitor
+        // can't display anyway. The final size is reconciled on loop exit.
+        if (resizeFrameIntervalNanos > 0L) {
+            val now = System.nanoTime()
+            if (now - lastResizePaintNanos < resizeFrameIntervalNanos) return
+            lastResizePaintNanos = now
+        }
+
+        NativeTaoGlBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
+        // Paint synchronously instead of deferring via requestRedraw().
+        //
+        // WM_SIZE dispatches Resized -> onResized synchronously on the GL
+        // thread (the Tao runner only buffers events when re-entered from its
+        // own handler, which the OS modal size loop is not). `nativeResize`
+        // just grew the render-surface child HWND; ANGLE, however, only resizes
+        // and re-presents its D3D11 swap chain on the next eglSwapBuffers. If we
+        // returned to DefWindowProc now and left the present to a later
+        // WM_PAINT-driven RedrawRequested, DWM would composite the freshly
+        // exposed strip of the enlarged surface before the swap chain caught up
+        // — the black edge seen while dragging a border. Rendering here closes
+        // that gap: the swap chain is resized and a full-size frame presented
+        // before the WndProc returns. It also removes the async request-redraw
+        // round trip (and its `redrawPending` coalescing), which starved paints
+        // during a fast-resize message flood.
+        onRedrawRequested()
+    }
+
+    /**
+     * Enter/leave the OS modal resize/move loop (WM_ENTERSIZEMOVE /
+     * WM_EXITSIZEMOVE). VSync is dropped while the loop is active so the
+     * synchronous per-WM_SIZE present in [onResized] doesn't block on the
+     * display refresh — the window edge tracks the cursor with no added
+     * latency. To stop that from turning into an uncapped render loop (VSync
+     * being the usual frame limiter), [onResized] paces itself to the monitor
+     * refresh via [resizeFrameIntervalNanos] for the duration. On exit VSync is
+     * restored and the swap chain is reconciled to the exact final size (a
+     * coalesced-out last WM_SIZE may have left it one step behind).
+     */
+    fun onResizeLoopChanged(active: Boolean) {
+        if (attachmentHandle == 0L) return
+        if (active) {
+            NativeTaoGlBridge.nativeSetVSyncEnabled(attachmentHandle, false)
+            val hz = if (hwnd != 0L) NativeTaoWindowsDecoBridge.nativeMonitorRefreshHz(hwnd) else 0
+            // Allow ~10% headroom over the refresh period so timing jitter
+            // doesn't drop every other frame into the next interval (beating
+            // down to half-rate). Unknown refresh (0) leaves the loop uncapped.
+            resizeFrameIntervalNanos = if (hz > 1) 1_000_000_000L / hz * 9 / 10 else 0L
+            lastResizePaintNanos = 0L
+        } else {
+            resizeFrameIntervalNanos = 0L
+            NativeTaoGlBridge.nativeSetVSyncEnabled(attachmentHandle, true)
+            NativeTaoGlBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
+            onRedrawRequested()
+        }
     }
 
     fun onScaleFactorChanged(newScale: Float) {

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -22,7 +22,7 @@ use crate::events::{
 };
 #[cfg(target_os = "windows")]
 use crate::events::{
-    dispatch_trackpad_gesture, TRACKPAD_GESTURE_MAGNIFY, TRACKPAD_PHASE_CHANGED,
+    dispatch_trackpad_gesture, EVENT_SIZE_MOVE, TRACKPAD_GESTURE_MAGNIFY, TRACKPAD_PHASE_CHANGED,
     TRACKPAD_VALUE_FIXED_SCALE,
 };
 use crate::keymap;
@@ -71,6 +71,20 @@ fn on_tao_magnify(window_id: tao::window::WindowId, value: f32) {
     );
 }
 
+// Modal resize/move loop begin/end, forwarded by the vendored Tao
+// SIZE_MOVE_HOOK patch (WM_ENTERSIZEMOVE / WM_EXITSIZEMOVE). The embedder drops
+// VSync while `active` so the synchronous per-WM_SIZE present doesn't block on
+// the display refresh during a border drag. Like the magnify hook this is never
+// re-entered by our own calls (we never programmatically enter a size/move
+// loop) and holds no Tao lock at call time, so we dispatch straight to the JVM.
+#[cfg(target_os = "windows")]
+fn on_tao_size_move(window_id: tao::window::WindowId, active: bool) {
+    let Some(handle) = handle_for(window_id) else {
+        return;
+    };
+    dispatch(handle, EVENT_SIZE_MOVE, if active { 1 } else { 0 }, 0);
+}
+
 pub(crate) fn run_event_loop_blocking() {
     // GTK backend selection. Default: let GDK auto-pick (= native Wayland on
     // a Wayland session, X11 elsewhere). The Wayland-native path goes through
@@ -116,6 +130,9 @@ pub(crate) fn run_event_loop_blocking() {
     // Trackpad pinch / Ctrl+wheel → magnify gesture (see on_tao_magnify).
     #[cfg(target_os = "windows")]
     tao::platform::windows::set_magnify_hook(on_tao_magnify);
+    // Modal resize/move loop → VSync toggle (see on_tao_size_move).
+    #[cfg(target_os = "windows")]
+    tao::platform::windows::set_size_move_hook(on_tao_size_move);
     #[cfg(target_os = "macos")]
     tao::platform::macos::set_minimized_hook(on_tao_minimized);
     #[cfg(target_os = "linux")]

--- a/decorated-window-tao/src/main/native/src/events.rs
+++ b/decorated-window-tao/src/main/native/src/events.rs
@@ -156,6 +156,11 @@ pub(crate) const EVENT_WILL_HIDE: jint = 23;
 // again (GDK surface re-created), so the JVM can re-attach its EGL rendering.
 #[cfg(target_os = "linux")]
 pub(crate) const EVENT_SHOWN: jint = 24;
+// Windows only. Fired on WM_ENTERSIZEMOVE (`a = 1`) and WM_EXITSIZEMOVE
+// (`a = 0`) so the embedder can drop VSync during the OS modal resize/move
+// loop — see `on_tao_size_move`.
+#[cfg(target_os = "windows")]
+pub(crate) const EVENT_SIZE_MOVE: jint = 25;
 
 // Sub-pixel precision through the JNI int payload.
 pub(crate) const SCROLL_FIXED_SCALE: f64 = 100.0;

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform/windows.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform/windows.rs
@@ -490,3 +490,24 @@ pub(crate) static MAGNIFY_HOOK: std::sync::OnceLock<fn(crate::window::WindowId, 
 pub fn set_magnify_hook(hook: fn(crate::window::WindowId, f32)) {
   let _ = MAGNIFY_HOOK.set(hook);
 }
+
+// PATCH(nucleus): modal size/move loop hook.
+//
+// Windows runs a modal message loop between WM_ENTERSIZEMOVE and WM_EXITSIZEMOVE
+// while the user drags a resize border or the title bar. Tao has no event for
+// it, so the WM_ENTERSIZEMOVE / WM_EXITSIZEMOVE handlers call this hook (`true`
+// on enter, `false` on exit). The embedder uses it to drop VSync
+// (`eglSwapInterval(0)`) for the duration, so the synchronous per-WM_SIZE
+// present doesn't block on the display refresh and the border tracks the cursor
+// with no added latency; paced VSync is restored on exit. Idempotent: the first
+// installed hook wins; runs on the event-loop thread inside the window
+// procedure, so it must not block or pump messages.
+pub(crate) static SIZE_MOVE_HOOK: std::sync::OnceLock<fn(crate::window::WindowId, bool)> =
+  std::sync::OnceLock::new();
+
+/// Install a hook invoked from the WM_ENTERSIZEMOVE (`true`) and WM_EXITSIZEMOVE
+/// (`false`) handlers whenever the OS modal size/move loop starts or ends.
+/// See [`SIZE_MOVE_HOOK`].
+pub fn set_size_move_hook(hook: fn(crate::window::WindowId, bool)) {
+  let _ = SIZE_MOVE_HOOK.set(hook);
+}

--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/windows/event_loop.rs
@@ -1029,6 +1029,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
         .window_state
         .lock()
         .set_window_flags_in_place(|f| f.insert(WindowFlags::MARKER_IN_SIZE_MOVE));
+      // PATCH(nucleus): notify the embedder the modal size/move loop started.
+      if let Some(hook) = crate::platform::windows::SIZE_MOVE_HOOK.get() {
+        hook(RootWindowId(WindowId(window.0 as _)), true);
+      }
       result = ProcResult::Value(LRESULT(0));
     }
 
@@ -1039,6 +1043,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
         let _ = unsafe { PostMessageW(Some(window), WM_LBUTTONUP, WPARAM::default(), lparam) };
       }
       state.set_window_flags_in_place(|f| f.remove(WindowFlags::MARKER_IN_SIZE_MOVE));
+      drop(state);
+      // PATCH(nucleus): notify the embedder the modal size/move loop ended.
+      if let Some(hook) = crate::platform::windows::SIZE_MOVE_HOOK.get() {
+        hook(RootWindowId(WindowId(window.0 as _)), false);
+      }
       result = ProcResult::Value(LRESULT(0));
     }
 

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_gl.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_gl.c
@@ -477,6 +477,23 @@ Java_dev_nucleusframework_window_tao_NativeTaoGlBridge_nativePresent(
     pEglSwapBuffers(att->eglDisplay, att->eglSurface);
 }
 
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_NativeTaoGlBridge_nativeSetVSyncEnabled(
+    JNIEnv *env, jclass clazz, jlong handle, jboolean enabled)
+{
+    (void)env; (void)clazz;
+    GlAttachment *att = (GlAttachment *)(uintptr_t)handle;
+    if (!att || !pEglSwapInterval) return;
+    /* eglSwapInterval applies to the draw surface of the current context, so
+     * make our window surface current first (an overlay/popup renderer may have
+     * left its pbuffer bound on this thread). interval 1 = pace on the display
+     * refresh (default — keeps animations aligned to VBlank); interval 0 =
+     * present immediately, set for the duration of the OS modal resize/move
+     * loop so border-drag frames don't block on VBlank. */
+    pEglMakeCurrent(att->eglDisplay, att->eglSurface, att->eglSurface, att->eglContext);
+    pEglSwapInterval(att->eglDisplay, enabled ? 1 : 0);
+}
+
 JNIEXPORT jint JNICALL
 Java_dev_nucleusframework_window_tao_NativeTaoGlBridge_nativeWidth(
     JNIEnv *env, jclass clazz, jlong handle)

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -700,6 +700,41 @@ static int clampInt(int value, int minValue, int maxValue) {
     return value;
 }
 
+/* Refresh rate (Hz) of the monitor the window is currently on, used to cap the
+ * resize render rate while VSync is disabled during the modal resize loop.
+ * Resolves the monitor's current display mode via EnumDisplaySettingsW; falls
+ * back to GetDeviceCaps(VREFRESH), then 0 when nothing usable is available (the
+ * caller then leaves the resize loop uncapped). */
+JNIEXPORT jint JNICALL
+Java_dev_nucleusframework_window_tao_NativeTaoWindowsDecoBridge_nativeMonitorRefreshHz(
+    JNIEnv *env, jclass clazz, jlong hwndLong)
+{
+    (void)env; (void)clazz;
+    HWND hwnd = (HWND)(uintptr_t)hwndLong;
+    if (!hwnd || !IsWindow(hwnd)) return 0;
+
+    HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFOEXW mi;
+    mi.cbSize = sizeof(mi);
+    if (GetMonitorInfoW(hMon, (MONITORINFO *)&mi)) {
+        DEVMODEW dm;
+        memset(&dm, 0, sizeof(dm));
+        dm.dmSize = sizeof(dm);
+        if (EnumDisplaySettingsW(mi.szDevice, ENUM_CURRENT_SETTINGS, &dm)
+            && dm.dmDisplayFrequency > 1) {
+            return (jint)dm.dmDisplayFrequency;
+        }
+    }
+
+    HDC hdc = GetDC(hwnd);
+    if (hdc) {
+        int vr = GetDeviceCaps(hdc, VREFRESH);
+        ReleaseDC(hwnd, hdc);
+        if (vr > 1) return (jint)vr;
+    }
+    return 0;
+}
+
 /* Win32 IsZoomed. */
 JNIEXPORT jboolean JNICALL
 Java_dev_nucleusframework_window_tao_NativeTaoWindowsDecoBridge_nativeIsMaximized(


### PR DESCRIPTION
## Summary

Fixes a black edge along the dragged border and the laggy feel when resizing a window on the Tao **Windows** backend. Repaint was deferred through an async `requestRedraw` round trip (`WM_SIZE` → UserEvent → `WM_PAINT` → `RedrawRequested`), so the ANGLE D3D11 swap chain lagged the window and DWM composited the freshly-exposed strip before it caught up; the round trip + its `redrawPending` latch also starved paints during a `WM_SIZE` flood.

- **Synchronous paint on resize** — `onResized` renders inline instead of deferring. `WM_SIZE` dispatches `Resized` synchronously on the GL thread (the Tao runner only buffers when re-entered from its own handler, which the OS modal loop is not), so the swap chain is resized and a full-size frame presented before `DefWindowProc` returns. Removes the black edge and the async hop.
- **VSync off during the modal resize/move loop** — otherwise each synchronous present blocks on VBlank. New `SIZE_MOVE_HOOK` in vendored tao (`WM_ENTERSIZEMOVE`/`WM_EXITSIZEMOVE`) → `EVENT_SIZE_MOVE` → host toggles `NativeTaoGlBridge.nativeSetVSyncEnabled` (`eglSwapInterval`).
- **Frame cap at the monitor refresh** — VSync-off removed the natural frame limiter, so an uncapped render loop spiked CPU/GPU. `onResizeLoopChanged` reads `NativeTaoWindowsDecoBridge.nativeMonitorRefreshHz` and paces `onResized` to ~refresh; the swap-chain resize is deferred to the painted frame so a coalesced-out `WM_SIZE` never leaves an enlarged-but-unpainted (black) surface. The exact final size is reconciled on loop exit.

All Windows-only; macOS/Linux paths untouched (the new event never fires there).

## Changes
- Kotlin: `TaoComposeSceneHostWindows` (sync paint, VSync toggle, refresh cap), `TaoWindow`/`NativeTaoBridge` (`SIZE_MOVE` event + listener), `NativeTaoGlBridge` (`nativeSetVSyncEnabled`), `NativeTaoWindowsDecoBridge` (`nativeMonitorRefreshHz`), `DecoratedWindow` wiring.
- Native C: `nucleus_tao_gl.c` (`nativeSetVSyncEnabled`), `nucleus_tao_windows_deco.c` (`nativeMonitorRefreshHz`).
- Vendored tao: `SIZE_MOVE_HOOK` + `set_size_move_hook`, called from the `WM_ENTERSIZEMOVE`/`WM_EXITSIZEMOVE` handlers.
- Rust crate: `on_tao_size_move` → `EVENT_SIZE_MOVE=25`.

## Test plan
- [ ] Rebuild natives (`decorated-window-tao/src/main/native/windows/build.bat`) — `buildNativeWindows` is skipped by Gradle when the DLL already exists.
- [ ] Drag each border/corner (esp. right/bottom and left/top): no black edge, edge tracks the cursor.
- [ ] Task Manager → GPU during a sustained drag: usage plateaus around the display refresh instead of exploding.
- [ ] Verify on 60/120/144/240 Hz displays and across a DPI change.
- [ ] Maximize/restore, programmatic resize, and DecoratedDialog resize still paint correctly.
- [ ] Regression check: smooth-scroll pacing unchanged (VSync restored on loop exit).