### PR TITLE
feat(core-runtime): runtime window backend query with AWT fallback

### DIFF
--- a/core-runtime/src/main/kotlin/dev/nucleusframework/core/runtime/WindowBackend.kt
+++ b/core-runtime/src/main/kotlin/dev/nucleusframework/core/runtime/WindowBackend.kt
@@ -1,0 +1,60 @@
+package dev.nucleusframework.core.runtime
+
+/**
+ * The window backend a Nucleus application is running on, resolved at runtime.
+ *
+ * External libraries (taskbar, notifications, tray, …) can branch on
+ * [WindowBackend.Current] to adapt their behaviour — e.g. avoid touching the
+ * AWT event dispatch thread when running on [Tao] — while depending only on
+ * `core-runtime` (pure JVM, no Compose / no Tao).
+ *
+ * The active backend is recorded by `nucleusApplication` at launch via
+ * [setActive]. When the host application does **not** use Nucleus, nothing
+ * records it and [Current] falls back to [Awt] — the safe default, since a
+ * plain Compose Desktop / Swing app is AWT-based.
+ *
+ * ```
+ * if (WindowBackend.Current == WindowBackend.Tao) {
+ *     // no AWT EDT available — post work through the native event loop instead
+ * }
+ * ```
+ */
+enum class WindowBackend {
+    /** AWT-bound backend (`decorated-window-jbr` / `decorated-window-jni`, or a non-Nucleus AWT app). */
+    Awt,
+
+    /** No-AWT backend (`decorated-window-tao`), driven by a native event loop. */
+    Tao,
+    ;
+
+    companion object {
+        @Volatile
+        private var active: WindowBackend? = null
+
+        /**
+         * The backend the running application uses, or [Awt] when the app does
+         * not use Nucleus (nothing has called [setActive]).
+         */
+        @JvmStatic
+        val Current: WindowBackend
+            get() = active ?: Awt
+
+        /**
+         * `true` when a Nucleus entry point has recorded a backend — i.e. the
+         * app is launched through `nucleusApplication`. When `false`, [Current]
+         * is the [Awt] fallback rather than an explicitly resolved value.
+         */
+        @JvmStatic
+        val isNucleusManaged: Boolean
+            get() = active != null
+
+        /**
+         * Records the resolved backend. Called once by Nucleus at application
+         * launch; not intended for application or library code.
+         */
+        @JvmStatic
+        fun setActive(backend: WindowBackend) {
+            active = backend
+        }
+    }
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.window.application
 import dev.nucleusframework.application.internal.TaoLauncher
+import dev.nucleusframework.core.runtime.WindowBackend
 import dev.nucleusframework.graalvm.GraalVmInitializer
 import java.util.Locale
 
@@ -67,7 +68,16 @@ fun nucleusApplication(
 
     primePlatformIntegrations(args)
 
-    when (resolveBackend(backend)) {
+    val resolved = resolveBackend(backend)
+
+    // Record the resolved backend so external libraries (depending only on
+    // core-runtime) can query WindowBackend.Current without a reflective
+    // classpath probe or a Compose composition local.
+    WindowBackend.setActive(
+        if (resolved == NucleusBackend.Tao) WindowBackend.Tao else WindowBackend.Awt,
+    )
+
+    when (resolved) {
         NucleusBackend.Tao -> TaoLauncher.run(args, content)
         NucleusBackend.Awt, NucleusBackend.Auto ->
             application {


### PR DESCRIPTION
## Summary
- Add `WindowBackend` (`Awt` / `Tao`) enum to **`core-runtime`** so external libraries can detect the active windowing backend while depending only on the pure-JVM base module (no Compose, no Tao).
- `WindowBackend.Current` returns the resolved backend, falling back to `Awt` when the host app does not use Nucleus; `isNucleusManaged` distinguishes the fallback from an explicitly resolved backend.
- `nucleusApplication(...)` records the resolved backend via `WindowBackend.setActive(...)` at launch, right after `resolveBackend(...)`.
- Follows the existing `Platform.Current` companion idiom; `@JvmStatic` accessors for Java consumers.

## Notes
- The request enum `NucleusBackend` (`Auto/Awt/Tao`) is left unchanged for API stability — `WindowBackend` is the resolved runtime fact (`Auto` has no meaning as a "current" answer).
- `LocalNucleusBackend` (CompositionLocal) untouched — remains the in-composition path for code already depending on `nucleus-application`.

## Test plan
- [x] `:core-runtime:compileKotlin` + `:nucleus-application:compileKotlin`
- [x] `ktlintCheck` + `detekt` on both modules