### PR TITLE
fix(decorated-window): react to runtime resizable changes across backends

### DIFF
--- a/decorated-window-awt/build.gradle.kts
+++ b/decorated-window-awt/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     api(project(":decorated-window-core"))
     implementation(project(":core-runtime"))
     api(libs.compose.desktop.common)
+    testImplementation(kotlin("test"))
+    testImplementation(compose.desktop.currentOs)
 }
 
 java {

--- a/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/AwtDecoratedWindowScope.kt
+++ b/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/AwtDecoratedWindowScope.kt
@@ -56,6 +56,7 @@ fun DecoratedWindowState.Companion.of(window: ComposeWindow): DecoratedWindowSta
         minimized = window.isMinimized,
         maximized = window.placement == WindowPlacement.Maximized,
         active = window.isActive,
+        resizable = window.isResizable,
     )
 
 /**
@@ -168,12 +169,20 @@ fun FrameWindowScope.DecoratedWindowBody(
         window.addWindowStateListener(adapter)
         window.addComponentListener(adapter)
 
+        // Frame.setResizable fires a bound property change — without this,
+        // runtime resizability changes don't recompose the title bar and the
+        // maximize button stays out of sync until the next window event (#260).
+        val resizableListener =
+            java.beans.PropertyChangeListener { updateWindowShape() }
+        window.addPropertyChangeListener("resizable", resizableListener)
+
         val quitHandlerInstalled = installSystemQuitHandler(onCloseRequest)
 
         onDispose {
             window.removeWindowListener(adapter)
             window.removeWindowStateListener(adapter)
             window.removeComponentListener(adapter)
+            window.removePropertyChangeListener("resizable", resizableListener)
             if (quitHandlerInstalled) {
                 Desktop.getDesktop().setQuitHandler(null)
             }

--- a/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/WindowControlArea.kt
+++ b/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/WindowControlArea.kt
@@ -78,8 +78,10 @@ fun TitleBarScope.WindowControlArea(
                             alignment = buttonAlignment,
                         )
                     } else {
+                        // Gate on the snapshot-backed state so runtime
+                        // setResizable() recomposes the button (#260).
                         val frame = window as? Frame
-                        if (frame != null && frame.isResizable) {
+                        if (frame != null && state.isResizable) {
                             if (state.isMaximized) {
                                 ControlButton(
                                     onClick = { frame.extendedState = Frame.NORMAL },

--- a/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/WindowsWindowControlArea.kt
+++ b/decorated-window-awt/src/main/kotlin/dev/nucleusframework/window/WindowsWindowControlArea.kt
@@ -83,9 +83,10 @@ fun TitleBarScope.WindowsWindowControlArea(
                 contentDescription = "Exit fullscreen",
             )
         } else {
-            // Maximize/Restore button (only if resizable)
+            // Maximize/Restore button (only if resizable — read from the
+            // snapshot-backed state so runtime setResizable() recomposes, #260)
             val frame = window as? Frame
-            if (frame != null && frame.isResizable) {
+            if (frame != null && state.isResizable) {
                 if (state.isMaximized) {
                     WindowsCaptionButton(
                         onClick = { frame.extendedState = Frame.NORMAL },

--- a/decorated-window-awt/src/test/kotlin/dev/nucleusframework/window/RuntimeResizableE2eTest.kt
+++ b/decorated-window-awt/src/test/kotlin/dev/nucleusframework/window/RuntimeResizableE2eTest.kt
@@ -1,0 +1,91 @@
+package dev.nucleusframework.window
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import java.awt.GraphicsEnvironment
+import java.awt.event.WindowEvent
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.SwingUtilities
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end regression test for issue #260: [DecoratedWindowState.isResizable]
+ * must recompose immediately when `Frame.setResizable()` is called after the
+ * window is shown — without waiting for another window event (activation,
+ * minimize/restore, resize).
+ *
+ * Opens a real window; skipped in headless environments (CI without display).
+ */
+class RuntimeResizableE2eTest {
+    @Test
+    fun stateReactsToRuntimeSetResizable() {
+        if (GraphicsEnvironment.isHeadless()) {
+            println("SKIPPED: headless environment, no display to open a real window")
+            return
+        }
+        println("Running against display: ${System.getenv("DISPLAY") ?: System.getenv("WAYLAND_DISPLAY")}")
+
+        val sawResizable = CountDownLatch(1)
+        val sawNonResizable = CountDownLatch(1)
+        val sawResizableAgain = CountDownLatch(2)
+        val windowRef = AtomicReference<ComposeWindow>()
+
+        val appThread =
+            thread(name = "resizable-e2e") {
+                application(exitProcessOnExit = false) {
+                    // Undecorated, like the real JBR/JNI backends — DecoratedWindowBody
+                    // sets window.shape on Linux, which AWT forbids on decorated frames.
+                    Window(
+                        onCloseRequest = ::exitApplication,
+                        title = "resizable-e2e",
+                        undecorated = true,
+                    ) {
+                        DecoratedWindowBody(title = "resizable-e2e", icon = null, undecorated = true) {
+                            windowRef.set(window)
+                            val resizable = state.isResizable
+                            LaunchedEffect(resizable) {
+                                if (resizable) {
+                                    sawResizable.countDown()
+                                    sawResizableAgain.countDown()
+                                } else {
+                                    sawNonResizable.countDown()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        try {
+            assertTrue(
+                sawResizable.await(30, TimeUnit.SECONDS),
+                "Window never composed with state.isResizable = true",
+            )
+
+            SwingUtilities.invokeAndWait { windowRef.get().isResizable = false }
+            assertTrue(
+                sawNonResizable.await(10, TimeUnit.SECONDS),
+                "state.isResizable did not react to runtime setResizable(false) — issue #260 regression",
+            )
+
+            SwingUtilities.invokeAndWait { windowRef.get().isResizable = true }
+            assertTrue(
+                sawResizableAgain.await(10, TimeUnit.SECONDS),
+                "state.isResizable did not react to runtime setResizable(true) — issue #260 regression",
+            )
+        } finally {
+            windowRef.get()?.let { w ->
+                SwingUtilities.invokeLater {
+                    w.dispatchEvent(WindowEvent(w, WindowEvent.WINDOW_CLOSING))
+                }
+            }
+            appThread.join(TimeUnit.SECONDS.toMillis(15))
+        }
+    }
+}

--- a/decorated-window-core/build.gradle.kts
+++ b/decorated-window-core/build.gradle.kts
@@ -18,6 +18,7 @@ val publishVersion =
 dependencies {
     implementation(project(":core-runtime"))
     api(libs.compose.foundation)
+    testImplementation(kotlin("test"))
 }
 
 // ---------- Native JNI builds ----------

--- a/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/DecoratedWindowCore.kt
+++ b/decorated-window-core/src/main/kotlin/dev/nucleusframework/window/DecoratedWindowCore.kt
@@ -101,14 +101,31 @@ value class DecoratedWindowState(
     val isTiled: Boolean
         get() = state and Tiled != 0UL
 
+    /**
+     * True when the window can be resized by the user. Gates the
+     * maximize/restore caption button and title-bar double-click maximize.
+     * Kept in sync with runtime resizability changes
+     * (`Frame.setResizable`, `TaoWindow.setResizable`).
+     */
+    val isResizable: Boolean
+        get() = state and Resizable != 0UL
+
     fun copy(
         fullscreen: Boolean = isFullscreen,
         minimized: Boolean = isMinimized,
         maximized: Boolean = isMaximized,
         active: Boolean = isActive,
         tiled: Boolean = isTiled,
+        resizable: Boolean = isResizable,
     ): DecoratedWindowState =
-        of(fullscreen = fullscreen, minimized = minimized, maximized = maximized, active = active, tiled = tiled)
+        of(
+            fullscreen = fullscreen,
+            minimized = minimized,
+            maximized = maximized,
+            active = active,
+            tiled = tiled,
+            resizable = resizable,
+        )
 
     override fun toString(): String = "${javaClass.simpleName}(isFullscreen=$isFullscreen, isActive=$isActive)"
 
@@ -118,6 +135,7 @@ value class DecoratedWindowState(
         val Minimize: ULong = 1UL shl 2
         val Maximize: ULong = 1UL shl 3
         val Tiled: ULong = 1UL shl 4
+        val Resizable: ULong = 1UL shl 5
 
         fun of(
             fullscreen: Boolean = false,
@@ -125,13 +143,15 @@ value class DecoratedWindowState(
             maximized: Boolean = false,
             active: Boolean = true,
             tiled: Boolean = false,
+            resizable: Boolean = true,
         ): DecoratedWindowState =
             DecoratedWindowState(
                 (if (fullscreen) Fullscreen else 0UL) or
                     (if (minimized) Minimize else 0UL) or
                     (if (maximized) Maximize else 0UL) or
                     (if (active) Active else 0UL) or
-                    (if (tiled) Tiled else 0UL),
+                    (if (tiled) Tiled else 0UL) or
+                    (if (resizable) Resizable else 0UL),
             )
     }
 }

--- a/decorated-window-core/src/test/kotlin/dev/nucleusframework/window/DecoratedWindowStateTest.kt
+++ b/decorated-window-core/src/test/kotlin/dev/nucleusframework/window/DecoratedWindowStateTest.kt
@@ -1,0 +1,45 @@
+package dev.nucleusframework.window
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DecoratedWindowStateTest {
+    @Test
+    fun resizableDefaultsToTrue() {
+        assertTrue(DecoratedWindowState.of().isResizable)
+    }
+
+    @Test
+    fun ofSetsResizableBit() {
+        assertFalse(DecoratedWindowState.of(resizable = false).isResizable)
+        assertTrue(DecoratedWindowState.of(resizable = true).isResizable)
+    }
+
+    @Test
+    fun copyTogglesResizableWithoutAffectingOtherBits() {
+        val state =
+            DecoratedWindowState.of(
+                fullscreen = true,
+                minimized = true,
+                maximized = true,
+                active = false,
+                tiled = true,
+                resizable = true,
+            )
+        val nonResizable = state.copy(resizable = false)
+
+        assertFalse(nonResizable.isResizable)
+        assertTrue(nonResizable.isFullscreen)
+        assertTrue(nonResizable.isMinimized)
+        assertTrue(nonResizable.isMaximized)
+        assertFalse(nonResizable.isActive)
+        assertTrue(nonResizable.isTiled)
+    }
+
+    @Test
+    fun copyPreservesResizableByDefault() {
+        val state = DecoratedWindowState.of(resizable = false)
+        assertFalse(state.copy(active = false).isResizable)
+    }
+}

--- a/decorated-window-jbr/src/main/kotlin/dev/nucleusframework/window/TitleBar.Linux.kt
+++ b/decorated-window-jbr/src/main/kotlin/dev/nucleusframework/window/TitleBar.Linux.kt
@@ -49,7 +49,7 @@ internal fun AwtDecoratedWindowScope.LinuxTitleBar(
                     ) {
                         if (state.isMaximized) {
                             window.extendedState = Frame.NORMAL
-                        } else {
+                        } else if (window.isResizable) {
                             window.extendedState = Frame.MAXIMIZED_BOTH
                         }
                     }

--- a/decorated-window-jni/src/main/kotlin/dev/nucleusframework/window/TitleBar.Linux.kt
+++ b/decorated-window-jni/src/main/kotlin/dev/nucleusframework/window/TitleBar.Linux.kt
@@ -149,7 +149,7 @@ private fun AwtDecoratedWindowScope.NativeLinuxTitleBar(
                                         // Double-click: toggle maximize
                                         if (state.isMaximized) {
                                             window.extendedState = Frame.NORMAL
-                                        } else {
+                                        } else if (window.isResizable) {
                                             window.extendedState = Frame.MAXIMIZED_BOTH
                                         }
                                     } else {
@@ -214,7 +214,7 @@ private fun AwtDecoratedWindowScope.FallbackLinuxTitleBar(
                         if (now - lastPress in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
                             if (state.isMaximized) {
                                 window.extendedState = Frame.NORMAL
-                            } else {
+                            } else if (window.isResizable) {
                                 window.extendedState = Frame.MAXIMIZED_BOTH
                             }
                         }

--- a/decorated-window-jni/src/main/kotlin/dev/nucleusframework/window/TitleBar.Windows.kt
+++ b/decorated-window-jni/src/main/kotlin/dev/nucleusframework/window/TitleBar.Windows.kt
@@ -190,7 +190,7 @@ private fun AwtDecoratedWindowScope.NativeWindowsTitleBar(
                                     ) {
                                         if (state.isMaximized) {
                                             window.extendedState = Frame.NORMAL
-                                        } else {
+                                        } else if (window.isResizable) {
                                             window.extendedState = Frame.MAXIMIZED_BOTH
                                         }
                                     } else {
@@ -246,7 +246,7 @@ private fun AwtDecoratedWindowScope.FallbackWindowsTitleBar(
                         if (now - lastPress in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
                             if (state.isMaximized) {
                                 window.extendedState = Frame.NORMAL
-                            } else {
+                            } else if (window.isResizable) {
                                 window.extendedState = Frame.MAXIMIZED_BOTH
                             }
                         }

--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -20,6 +20,8 @@ dependencies {
     implementation(project(":core-runtime"))
     implementation(libs.compose.desktop.common)
     testImplementation(kotlin("test"))
+    // Skiko native runtime for the opt-in real-window smoke test
+    testImplementation(compose.desktop.currentOs)
 }
 
 java {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
@@ -306,7 +306,8 @@ fun DecoratedWindowScope.BasicTitleBar(
                 ) {
                     val now = System.currentTimeMillis()
                     if (now - lastPress in
-                        viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis
+                        viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis &&
+                        (taoWindow.isMaximized || taoWindow.isResizable)
                     ) {
                         taoWindow.setMaximized(!taoWindow.isMaximized)
                         // Cancel any in-flight touch drag — the second press

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -219,7 +219,8 @@ internal fun ApplicationScope.openDecoratedWindow(
     val scopeFactory: ColumnScope.() -> TaoDecoratedWindowScope = {
         object : TaoDecoratedWindowScope, ColumnScope by this {
             override val window: TaoWindow = window
-            override val state: DecoratedWindowState get() = stateHolder.value
+            override val state: DecoratedWindowState
+                get() = stateHolder.value.copy(resizable = window.isResizable)
         }
     }
 
@@ -383,7 +384,7 @@ internal fun ApplicationScope.openDecoratedWindow(
  * Native GTK decorations are kept; the user's [TitleBar] composable still
  * works as a sub-bar inside the content area.
  */
-@Suppress("FunctionNaming", "LongParameterList", "LongMethod")
+@Suppress("FunctionNaming", "LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 private fun ApplicationScope.openDecoratedWindowLinux(
     window: TaoWindow,
     title: String,
@@ -427,7 +428,8 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     val scopeFactory: ColumnScope.() -> TaoDecoratedWindowScope = {
         object : TaoDecoratedWindowScope, ColumnScope by this {
             override val window: TaoWindow = window
-            override val state: DecoratedWindowState get() = stateHolder.value
+            override val state: DecoratedWindowState
+                get() = stateHolder.value.copy(resizable = window.isResizable)
         }
     }
 
@@ -756,7 +758,8 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     val scopeFactory: androidx.compose.foundation.layout.ColumnScope.() -> TaoDecoratedWindowScope = {
         object : TaoDecoratedWindowScope, androidx.compose.foundation.layout.ColumnScope by this {
             override val window: TaoWindow = window
-            override val state: DecoratedWindowState get() = stateHolder.value
+            override val state: DecoratedWindowState
+                get() = stateHolder.value.copy(resizable = window.isResizable)
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -219,6 +219,13 @@ fun ApplicationScope.DecoratedWindow(
     }
 
     // ── State → window sync ──
+    // `resizable` is consumed at builder time above; re-apply runtime changes
+    // so driving the parameter matches the AWT backends' behaviour (#260).
+    LaunchedEffect(window, resizable) {
+        if (window.isResizable != resizable) {
+            window.setResizable(resizable)
+        }
+    }
     LaunchedEffect(window, state.size, state.placement) {
         // Maximized / Fullscreen windows derive their size from the
         // OS-managed placement, not from `state.size`. Skip the

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoBridge.kt
@@ -283,6 +283,12 @@ internal object NativeTaoBridge {
     )
 
     @JvmStatic
+    external fun nativeSetResizable(
+        handle: Long,
+        resizable: Boolean,
+    )
+
+    @JvmStatic
     external fun nativeSetMinimized(
         handle: Long,
         minimized: Boolean,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -2,6 +2,7 @@
 
 package dev.nucleusframework.window.tao
 
+import androidx.compose.runtime.mutableStateOf
 import dev.nucleusframework.core.runtime.Platform
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
@@ -16,13 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 @Suppress("TooManyFunctions")
 class TaoWindow internal constructor(
     val handle: Long,
-    /**
-     * `true` when the window was created with `resizable = true`. Surfaced to
-     * Compose so [WindowControlsLinux] can hide the maximize button on
-     * non-resizable windows (matches the `decorated-window-jni` behaviour
-     * — `frame.isResizable` gates the maximize button there too).
-     */
-    val isResizable: Boolean = true,
+    isResizable: Boolean = true,
     /**
      * `true` when the window was created as a popup overlay of another window
      * (`openWindow(popupOf = …)` — GTK_WINDOW_POPUP, mapped as a `wl_subsurface`
@@ -35,6 +30,28 @@ class TaoWindow internal constructor(
      */
     val isPopup: Boolean = false,
 ) {
+    // Snapshot-backed so Compose consumers (WindowControls*, resize hit-test
+    // gating) recompose when resizability changes at runtime — the AWT
+    // backends get the same reactivity from DecoratedWindowState (#260).
+    private val resizableState = mutableStateOf(isResizable)
+
+    /**
+     * `true` when the window can currently be resized by the user. Initially
+     * the `resizable` flag the window was created with; tracks runtime
+     * [setResizable] calls. Surfaced to Compose so [WindowControlsLinux] /
+     * [WindowControlsWindows] can hide the maximize button on non-resizable
+     * windows (matches the `decorated-window-jni` behaviour).
+     */
+    val isResizable: Boolean
+        get() = resizableState.value
+
+    /** Enables/disables user resizing (borders, maximize) at runtime. */
+    fun setResizable(resizable: Boolean) {
+        if (resizableState.value == resizable) return
+        resizableState.value = resizable
+        NativeTaoBridge.nativeSetResizable(handle, resizable)
+    }
+
     @Volatile
     private var readyListener: ((Int, Int) -> Unit)? = null
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowControlsWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/WindowControlsWindows.kt
@@ -87,7 +87,7 @@ private val WindowsCloseButtonPressed = Color(0xFFF1707A)
  * returns HTCLIENT for the title bar zone — DWM never repaints native buttons
  * on top, which would otherwise happen on non-JBR JDKs.
  */
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "CyclomaticComplexMethod")
 @Composable
 internal fun WindowControlsWindows(
     win: TaoWindow,
@@ -140,8 +140,11 @@ internal fun WindowControlsWindows(
                         },
                     contentDescription = "Exit fullscreen",
                 )
-            } else if (state.isMaximized) {
-                // Maximize / Restore — switches icon based on actual window state
+            } else if (win.isResizable && state.isMaximized) {
+                // Maximize / Restore — switches icon based on actual window state.
+                // Hidden when non-resizable (win.isResizable is snapshot-backed,
+                // so runtime setResizable() recomposes — mirrors the AWT
+                // backends' WindowsWindowControlArea gating, #260).
                 WindowsCaptionButton(
                     onClick = { win.setMaximized(false) },
                     isDark = isDark,
@@ -157,7 +160,7 @@ internal fun WindowControlsWindows(
                         },
                     contentDescription = "Restore",
                 )
-            } else {
+            } else if (win.isResizable) {
                 WindowsCaptionButton(
                     onClick = { win.setMaximized(true) },
                     isDark = isDark,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -1031,7 +1031,6 @@ internal class TaoComposeSceneHostWindows(
                     keyboardModifiers = currentKeyboardModifiers,
                 ),
         )
-
     }
 
     fun onKeyEvent(

--- a/decorated-window-tao/src/main/native/src/event_loop.rs
+++ b/decorated-window-tao/src/main/native/src/event_loop.rs
@@ -352,6 +352,14 @@ pub(crate) fn run_event_loop_blocking() {
                         }
                     }
                 }
+                UserEvent::SetResizable { handle, resizable } => {
+                    let guard = WINDOWS.lock().unwrap();
+                    if let Some(map) = guard.as_ref() {
+                        if let Some(w) = map.get(&handle) {
+                            w.set_resizable(resizable);
+                        }
+                    }
+                }
                 UserEvent::SetMinimized { handle, minimized } => {
                     {
                         let guard = WINDOWS.lock().unwrap();

--- a/decorated-window-tao/src/main/native/src/events.rs
+++ b/decorated-window-tao/src/main/native/src/events.rs
@@ -274,6 +274,10 @@ pub(crate) enum UserEvent {
         handle: u64,
         maximized: bool,
     },
+    SetResizable {
+        handle: u64,
+        resizable: bool,
+    },
     SetMinimized {
         handle: u64,
         minimized: bool,

--- a/decorated-window-tao/src/main/native/src/window_jni.rs
+++ b/decorated-window-tao/src/main/native/src/window_jni.rs
@@ -117,6 +117,19 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_NativeTaoBridge_nati
 }
 
 #[no_mangle]
+pub extern "system" fn Java_dev_nucleusframework_window_tao_NativeTaoBridge_nativeSetResizable(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: jlong,
+    resizable: jboolean,
+) {
+    send_user_event(UserEvent::SetResizable {
+        handle: handle as u64,
+        resizable: resizable != JNI_FALSE,
+    });
+}
+
+#[no_mangle]
 pub extern "system" fn Java_dev_nucleusframework_window_tao_NativeTaoBridge_nativeRequestRedraw(
     _env: JNIEnv,
     _class: JClass,

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -238,7 +238,10 @@ static LRESULT CALLBACK decoWndProc(
         int borderWidth = getResizeBorderWidth(hwnd, TRUE);
         int borderHeight = getResizeBorderWidth(hwnd, FALSE);
 
-        if (!IsZoomed(hwnd) && !state->isFullscreen) {
+        /* Resize borders only while the window is actually resizable —
+         * tao's set_resizable(false) drops WS_THICKFRAME at runtime. */
+        LONG_PTR style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+        if (!IsZoomed(hwnd) && !state->isFullscreen && (style & WS_THICKFRAME)) {
             if (pt.x < windowRect.left + borderWidth &&
                 pt.y < windowRect.top + borderHeight) return HTTOPLEFT;
             if (pt.x >= windowRect.right - borderWidth &&

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoRuntimeResizableSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoRuntimeResizableSmokeTest.kt
@@ -1,0 +1,78 @@
+package dev.nucleusframework.window.tao
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Opt-in smoke test (set `NUCLEUS_TAO_SMOKE=1`) — opens a real Tao window and
+ * verifies runtime resizability parity with the AWT backends (#260): driving
+ * the `resizable` parameter to `false` after the window is shown must update
+ * [TaoWindow.isResizable] and the scope's [DecoratedWindowState.isResizable].
+ *
+ * Not run by default: it takes over the calling thread with the native event
+ * loop and needs a display.
+ */
+class TaoRuntimeResizableSmokeTest {
+    @Test
+    fun runtimeResizableToggleAppliesAndRecomposes() {
+        if (System.getenv("NUCLEUS_TAO_SMOKE") == null) {
+            println("SKIPPED: set NUCLEUS_TAO_SMOKE=1 to run the real-window Tao smoke test")
+            return
+        }
+
+        val windowFlag = AtomicReference<Boolean>()
+        val stateFlag = AtomicReference<Boolean>()
+
+        // The tao event loop takes over this thread; if exitApplication is
+        // never reached the forked test JVM would hang with no timeout.
+        thread(isDaemon = true, name = "tao-smoke-watchdog") {
+            Thread.sleep(WATCHDOG_MS)
+            Runtime.getRuntime().halt(WATCHDOG_EXIT_CODE)
+        }
+
+        taoApplication {
+            var resizable by remember { mutableStateOf(true) }
+            DecoratedWindow(
+                onCloseRequest = ::exitApplication,
+                title = "resizable-smoke",
+                resizable = resizable,
+            ) {
+                val scope = this
+                LaunchedEffect(Unit) {
+                    delay(SETTLE_MS) // let the window map and paint
+                    resizable = false
+                    delay(APPLY_MS) // let the re-apply effect + recomposition run
+                    windowFlag.set(scope.window.isResizable)
+                    stateFlag.set(scope.state.isResizable)
+                    exitApplication()
+                }
+            }
+        }
+
+        assertEquals(
+            false,
+            windowFlag.get(),
+            "TaoWindow.isResizable did not flip after driving resizable=false at runtime",
+        )
+        assertEquals(
+            false,
+            stateFlag.get(),
+            "state.isResizable did not flip after driving resizable=false at runtime",
+        )
+    }
+
+    private companion object {
+        const val SETTLE_MS = 3_000L
+        const val APPLY_MS = 2_000L
+        const val WATCHDOG_MS = 120_000L
+        const val WATCHDOG_EXIT_CODE = 42
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoWindowResizableTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoWindowResizableTest.kt
@@ -1,0 +1,14 @@
+package dev.nucleusframework.window.tao
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TaoWindowResizableTest {
+    @Test
+    fun reflectsCreationFlag() {
+        assertTrue(TaoWindow(handle = 1L).isResizable)
+        assertTrue(TaoWindow(handle = 2L, isResizable = true).isResizable)
+        assertFalse(TaoWindow(handle = 3L, isResizable = false).isResizable)
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/TaoWheelPinchZoomTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/TaoWheelPinchZoomTest.kt
@@ -4,26 +4,26 @@ import kotlin.math.pow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class TaoWindowsPinchZoomTest {
+class TaoWheelPinchZoomTest {
     @Test
     fun fullWheelDeltaProducesModerateZoomStep() {
-        val step = TaoWindowsPinchZoom.stepFromWheelDelta(1f)
+        val step = TaoWheelPinchZoom.stepFromWheelDelta(1f)
 
         assertEquals(1.05946, step.toDouble(), absoluteTolerance = 0.0001)
     }
 
     @Test
     fun fractionalDeltasAccumulateLikeOneFullDelta() {
-        val quarterStep = TaoWindowsPinchZoom.stepFromWheelDelta(0.25f).toDouble()
-        val fullStep = TaoWindowsPinchZoom.stepFromWheelDelta(1f).toDouble()
+        val quarterStep = TaoWheelPinchZoom.stepFromWheelDelta(0.25f).toDouble()
+        val fullStep = TaoWheelPinchZoom.stepFromWheelDelta(1f).toDouble()
 
         assertEquals(fullStep, quarterStep.pow(4), absoluteTolerance = 0.0001)
     }
 
     @Test
     fun zoomOutIsInverseOfZoomIn() {
-        val zoomIn = TaoWindowsPinchZoom.stepFromWheelDelta(1f).toDouble()
-        val zoomOut = TaoWindowsPinchZoom.stepFromWheelDelta(-1f).toDouble()
+        val zoomIn = TaoWheelPinchZoom.stepFromWheelDelta(1f).toDouble()
+        val zoomOut = TaoWheelPinchZoom.stepFromWheelDelta(-1f).toDouble()
 
         assertEquals(1.0, zoomIn * zoomOut, absoluteTolerance = 0.0001)
     }


### PR DESCRIPTION
Closes #260

## Summary

The maximize/restore caption button was gated on a non-reactive `frame.isResizable` read during composition (`WindowsWindowControlArea`, `WindowControlArea`), and `DecoratedWindowState` had no resizable bit — so runtime `setResizable()` calls only took effect on the next window event (activation, minimize/restore).

- **Core**: new `Resizable` bit on `DecoratedWindowState` (`isResizable`, wired through `of()`/`copy()`, defaults to `true`)
- **AWT backends (JNI + JBR)**: `DecoratedWindowBody` listens to the `"resizable"` bound property fired by `Frame.setResizable()` and refreshes the snapshot-backed state; both control areas now gate the maximize button on `state.isResizable` — the button appears/disappears immediately
- **Double-click maximize**: gated on `isResizable` in all title bars (JNI Windows/Linux, JBR Linux, Tao); restoring an already-maximized window stays allowed
- **Tao parity** (runtime resizability was not supported at all):
  - Rust: `UserEvent::SetResizable` + `nativeSetResizable` JNI export dispatching `tao::Window::set_resizable` (same pattern as `SetMaximized`)
  - `TaoWindow.isResizable` is now snapshot-backed with a public `setResizable()`; the `DecoratedWindow` composable re-applies the `resizable` parameter at runtime; scope `state` carries the bit
  - `WindowControlsWindows` hides maximize when non-resizable (Linux already did)
  - Windows WndProc hit-test honors `WS_THICKFRAME`, so border-resize is disabled too
- **Drive-by fixes** (pre-existing, blocked `check`): `TaoWindowsPinchZoomTest` referenced the renamed `TaoWheelPinchZoom` class; one ktlint violation in `TaoComposeSceneHostWindows.kt`

Windows/macOS native binaries are rebuilt by the existing `build-natives.yaml` CI (module already covered); the Linux `.so` was rebuilt and the new symbol verified locally.

## Test plan

- [x] `DecoratedWindowStateTest` — resizable bit logic (of/copy defaults, bit independence)
- [x] `RuntimeResizableE2eTest` — real-window AWT e2e: opens a window, calls `setResizable(false)` then `(true)` at runtime, asserts the state recomposes without any other window event (auto-skipped headless)
- [x] `TaoRuntimeResizableSmokeTest` — opt-in (`NUCLEUS_TAO_SMOKE=1`) real Tao/GTK window on Wayland with the rebuilt native lib: drives `resizable=false` at runtime, asserts `TaoWindow.isResizable` and `state.isResizable` flip
- [x] `check` (ktlint + detekt + tests) green on all five touched modules
- [ ] Manual check of the original repro on Windows 11 / JNI backend once CI natives are built