### PR TITLE
fix(launcher-windows): support Tao backend by addressing windows via HWND

### DIFF
--- a/example/src/main/kotlin/com/example/demo/FillCenterDemoWindow.kt
+++ b/example/src/main/kotlin/com/example/demo/FillCenterDemoWindow.kt
@@ -232,8 +232,9 @@ private fun NucleusDecoratedWindowScope.DemoWindowTabContent(
             }
         }
         "Launcher" -> {
+            val hwnd = nucleusWindow.unsafe.taoWindow?.nativeHandle ?: 0L
             when (Platform.Current) {
-                Platform.Windows -> WindowsLauncherScreen(nucleusWindow.unsafe.awtWindow!!)
+                Platform.Windows -> WindowsLauncherScreen(hwnd)
                 Platform.MacOS -> MacOsLauncherScreen()
                 Platform.Linux -> LauncherScreen()
                 else -> {}

--- a/example/src/main/kotlin/com/example/demo/Main.kt
+++ b/example/src/main/kotlin/com/example/demo/Main.kt
@@ -146,7 +146,7 @@ fun main(args: Array<String>) =
                 state = state,
                 onCloseRequest = ::exitApplication,
                 title = "Nucleus Demo",
-                minimumSize = DpSize(1200.dp, 480.dp),
+                minimumSize = DpSize(1300.dp, 480.dp),
             ) {
                 CompositionLocalProvider(
                     LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr,
@@ -155,21 +155,10 @@ fun main(args: Array<String>) =
                         buildList {
                             addAll(listOf("Nucleus", "Fill Title", "Gallery", "Taskbar", "Scroll Test"))
                             add("Notifications (Common)")
-                            if (Platform.Current == Platform.MacOS ||
-                                Platform.Current == Platform.Linux ||
-                                Platform.Current == Platform.Windows
-                            ) {
-                                add("Notifications")
-                            }
-                            if (Platform.Current == Platform.Windows ||
-                                Platform.Current == Platform.Linux ||
-                                Platform.Current == Platform.MacOS
-                            ) {
-                                add("Launcher")
-                            }
+                            add("Notifications")
+                            add("Launcher")
                             add("Media Control")
                             add("Auto-Launch")
-
                             add("Hotkeys")
                             if (Platform.Current == Platform.MacOS) {
                                 add("Menu")
@@ -299,8 +288,9 @@ fun main(args: Array<String>) =
                             }
                         }
                         "Launcher" -> {
+                            val hwnd = nucleusWindow.unsafe.taoWindow?.nativeHandle ?: 0L
                             when (Platform.Current) {
-                                Platform.Windows -> WindowsLauncherScreen(nucleusWindow.unsafe.awtWindow!!)
+                                Platform.Windows -> WindowsLauncherScreen(hwnd)
                                 Platform.MacOS -> MacOsLauncherScreen()
                                 Platform.Linux -> LauncherScreen()
                                 else -> {}

--- a/example/src/main/kotlin/com/example/demo/WindowsBadgeScreen.kt
+++ b/example/src/main/kotlin/com/example/demo/WindowsBadgeScreen.kt
@@ -43,7 +43,6 @@ import dev.nucleusframework.launcher.windows.WindowsBadgeManager
 import dev.nucleusframework.launcher.windows.WindowsJumpListManager
 import dev.nucleusframework.launcher.windows.WindowsOverlayIcon
 import dev.nucleusframework.launcher.windows.WindowsThumbnailToolbar
-import java.awt.Window
 
 private const val EVENT_LOG_MAX = 30
 
@@ -58,7 +57,7 @@ private val DEMO_ICONS =
 
 @Suppress("FunctionNaming")
 @Composable
-fun WindowsLauncherScreen(window: Window) {
+fun WindowsLauncherScreen(hwnd: Long) {
     val events = remember { mutableStateListOf<String>() }
 
     Surface(modifier = Modifier.fillMaxSize()) {
@@ -72,9 +71,9 @@ fun WindowsLauncherScreen(window: Window) {
         ) {
             BadgeSection(events)
             HorizontalDivider()
-            OverlayIconSection(window, events)
+            OverlayIconSection(hwnd, events)
             HorizontalDivider()
-            ThumbnailToolbarSection(window, events)
+            ThumbnailToolbarSection(hwnd, events)
             HorizontalDivider()
             JumpListSection(events)
             HorizontalDivider()
@@ -274,7 +273,7 @@ private fun JumpListSection(events: MutableList<String>) {
 @Suppress("FunctionNaming")
 @Composable
 private fun OverlayIconSection(
-    window: Window,
+    hwnd: Long,
     events: MutableList<String>,
 ) {
     Text("Overlay Icon", style = MaterialTheme.typography.headlineSmall)
@@ -288,7 +287,7 @@ private fun OverlayIconSection(
             Button(onClick = {
                 val ok =
                     WindowsOverlayIcon.setIcon(
-                        window,
+                        hwnd,
                         TaskbarIconSource.FromStock(stockIcon),
                         description = label,
                     )
@@ -301,7 +300,7 @@ private fun OverlayIconSection(
 
     OutlinedButton(
         onClick = {
-            val ok = WindowsOverlayIcon.clearIcon(window)
+            val ok = WindowsOverlayIcon.clearIcon(hwnd)
             val msg = if (ok) "Overlay cleared" else "Clear FAILED: ${WindowsOverlayIcon.lastError}"
             events.add(0, msg)
             if (events.size > EVENT_LOG_MAX) events.removeLast()
@@ -313,7 +312,7 @@ private fun OverlayIconSection(
 @Suppress("FunctionNaming", "LongMethod")
 @Composable
 private fun ThumbnailToolbarSection(
-    window: Window,
+    hwnd: Long,
     events: MutableList<String>,
 ) {
     var toolbarAdded by remember { mutableStateOf(false) }
@@ -326,7 +325,7 @@ private fun ThumbnailToolbarSection(
 
     DisposableEffect(Unit) {
         onDispose {
-            if (toolbarAdded) WindowsThumbnailToolbar.unregister(window)
+            if (toolbarAdded) WindowsThumbnailToolbar.unregister(hwnd)
         }
     }
 
@@ -342,7 +341,7 @@ private fun ThumbnailToolbarSection(
                         )
                     }
                 val ok =
-                    WindowsThumbnailToolbar.setButtons(window, buttons) { buttonId ->
+                    WindowsThumbnailToolbar.setButtons(hwnd, buttons) { buttonId ->
                         val name = DEMO_ICONS.getOrNull(buttonId)?.first ?: "?"
                         events.add(0, "Toolbar click: $name (id=$buttonId)")
                         if (events.size > EVENT_LOG_MAX) events.removeLast()
@@ -362,7 +361,7 @@ private fun ThumbnailToolbarSection(
 
         OutlinedButton(
             onClick = {
-                WindowsThumbnailToolbar.unregister(window)
+                WindowsThumbnailToolbar.unregister(hwnd)
                 toolbarAdded = false
                 events.add(0, "Toolbar unregistered")
                 if (events.size > EVENT_LOG_MAX) events.removeLast()

--- a/launcher-windows/src/main/kotlin/dev/nucleusframework/launcher/windows/NativeWindowsTaskbarBridge.kt
+++ b/launcher-windows/src/main/kotlin/dev/nucleusframework/launcher/windows/NativeWindowsTaskbarBridge.kt
@@ -10,7 +10,7 @@ internal object NativeWindowsTaskbarBridge {
 
     val isLoaded: Boolean get() = loaded
 
-    // ---- HWND extraction ----
+    // ---- HWND extraction (AWT interop) ----
 
     @JvmStatic
     external fun nativeGetHwnd(window: Window): Long
@@ -19,7 +19,7 @@ internal object NativeWindowsTaskbarBridge {
 
     @JvmStatic
     external fun nativeSetOverlayIcon(
-        window: Window,
+        hwnd: Long,
         iconType: Int,
         iconPath: String,
         iconIndex: Int,
@@ -27,13 +27,14 @@ internal object NativeWindowsTaskbarBridge {
     ): String?
 
     @JvmStatic
-    external fun nativeClearOverlayIcon(window: Window): String?
+    external fun nativeClearOverlayIcon(hwnd: Long): String?
 
     // ---- Thumbnail Toolbar ----
 
+    @Suppress("LongParameterList")
     @JvmStatic
     external fun nativeThumbBarSetButtons(
-        window: Window,
+        hwnd: Long,
         ids: IntArray,
         tooltips: Array<String>,
         flags: IntArray,
@@ -45,7 +46,7 @@ internal object NativeWindowsTaskbarBridge {
 
     @JvmStatic
     external fun nativeThumbBarUpdateButtons(
-        window: Window,
+        hwnd: Long,
         ids: IntArray,
         tooltips: Array<String>,
         flags: IntArray,
@@ -55,8 +56,5 @@ internal object NativeWindowsTaskbarBridge {
     ): String?
 
     @JvmStatic
-    external fun nativeThumbBarUnregister(window: Window): String?
-
-    @JvmStatic
-    external fun nativeThumbBarUnregisterByHwnd(hwnd: Long): String?
+    external fun nativeThumbBarUnregister(hwnd: Long): String?
 }

--- a/launcher-windows/src/main/kotlin/dev/nucleusframework/launcher/windows/WindowsOverlayIcon.kt
+++ b/launcher-windows/src/main/kotlin/dev/nucleusframework/launcher/windows/WindowsOverlayIcon.kt
@@ -12,6 +12,10 @@ import java.util.logging.Logger
  * Unlike [WindowsBadgeManager] which requires APPX/MSIX packaging, overlay icons
  * work with **all packaging types** (APPX, NSIS, MSI, distributable).
  *
+ * Windows are addressed by raw `HWND`, so any windowing backend works: pass
+ * `TaoWindow.nativeHandle` on the Tao backend, or use the AWT overloads which
+ * resolve the `HWND` via [WindowsWindowHandle].
+ *
  * Thread-safe singleton.
  */
 object WindowsOverlayIcon {
@@ -27,13 +31,13 @@ object WindowsOverlayIcon {
     /**
      * Set an overlay icon on the taskbar button.
      *
-     * @param window      The AWT window whose taskbar button gets the overlay.
+     * @param hwnd        The `HWND` of the window whose taskbar button gets the overlay.
      * @param icon        The icon source.
      * @param description Accessibility text describing the overlay.
      * @return true if the overlay was set successfully.
      */
     fun setIcon(
-        window: Window,
+        hwnd: Long,
         icon: TaskbarIconSource,
         description: String = "",
     ): Boolean {
@@ -43,7 +47,7 @@ object WindowsOverlayIcon {
         }
         val error =
             NativeWindowsTaskbarBridge.nativeSetOverlayIcon(
-                window,
+                hwnd,
                 iconType = icon.nativeType(),
                 iconPath = icon.nativePath(),
                 iconIndex = icon.nativeIndex(),
@@ -57,23 +61,45 @@ object WindowsOverlayIcon {
     }
 
     /**
+     * Set an overlay icon on the taskbar button of an AWT window.
+     *
+     * @param window      The AWT window whose taskbar button gets the overlay.
+     * @param icon        The icon source.
+     * @param description Accessibility text describing the overlay.
+     * @return true if the overlay was set successfully.
+     */
+    fun setIcon(
+        window: Window,
+        icon: TaskbarIconSource,
+        description: String = "",
+    ): Boolean = setIcon(WindowsWindowHandle.of(window), icon, description)
+
+    /**
      * Remove the overlay icon from the taskbar button.
      *
-     * @param window The AWT window.
+     * @param hwnd The `HWND` of the window.
      * @return true if the overlay was cleared successfully.
      */
-    fun clearIcon(window: Window): Boolean {
+    fun clearIcon(hwnd: Long): Boolean {
         if (!isAvailable) {
             lastError = "Native library not available"
             return false
         }
-        val error = NativeWindowsTaskbarBridge.nativeClearOverlayIcon(window)
+        val error = NativeWindowsTaskbarBridge.nativeClearOverlayIcon(hwnd)
         lastError = error
         if (error != null) {
             logger.warning("ClearOverlayIcon failed: $error")
         }
         return error == null
     }
+
+    /**
+     * Remove the overlay icon from the taskbar button of an AWT window.
+     *
+     * @param window The AWT window.
+     * @return true if the overlay was cleared successfully.
+     */
+    fun clearIcon(window: Window): Boolean = clearIcon(WindowsWindowHandle.of(window))
 }
 
 @Suppress("MagicNumber")

--- a/launcher-windows/src/main/kotlin/dev/nucleusframework/launcher/windows/WindowsThumbnailToolbar.kt
+++ b/launcher-windows/src/main/kotlin/dev/nucleusframework/launcher/windows/WindowsThumbnailToolbar.kt
@@ -11,7 +11,13 @@ import java.util.logging.Logger
  * Buttons are registered once per window with [setButtons]; after that, only
  * their state (icon, tooltip, flags) can be updated via [updateButtons].
  *
- * Click events are delivered on the AWT EDT via the [ThumbBarClickListener] callback.
+ * Windows are addressed by raw `HWND`, so any windowing backend works: pass
+ * `TaoWindow.nativeHandle` on the Tao backend, or use the AWT overloads which
+ * resolve the `HWND` via [WindowsWindowHandle].
+ *
+ * Click events are delivered via the [ThumbBarClickListener] callback on the
+ * thread that owns the window (the AWT EDT for AWT windows, the Tao event loop
+ * for Tao windows).
  *
  * Works with **all packaging types** (APPX, NSIS, MSI, distributable).
  *
@@ -24,7 +30,7 @@ object WindowsThumbnailToolbar {
     var lastError: String? = null
         private set
 
-    // Cache HWND per window so we can unregister even after the AWT peer is disposed
+    // Cache HWND per AWT window so we can unregister even after the peer is disposed
     private val hwndCache = ConcurrentHashMap<Window, Long>()
 
     /** Whether the native library is loaded and functional on this platform. */
@@ -36,13 +42,13 @@ object WindowsThumbnailToolbar {
      * This can only be called **once** per window — Windows does not allow adding buttons
      * after the initial registration. To change button state later, use [updateButtons].
      *
-     * @param window  The AWT window whose taskbar thumbnail gets the buttons.
+     * @param hwnd    The `HWND` of the window whose taskbar thumbnail gets the buttons.
      * @param buttons Up to 7 buttons. Each must have a unique [ThumbnailToolbarButton.id] (0–6).
-     * @param onClick Callback invoked on the AWT EDT when any button is clicked.
+     * @param onClick Callback invoked on the window's owning thread when any button is clicked.
      * @return true if the buttons were added successfully.
      */
     fun setButtons(
-        window: Window,
+        hwnd: Long,
         buttons: List<ThumbnailToolbarButton>,
         onClick: ThumbBarClickListener? = null,
     ): Boolean {
@@ -54,14 +60,10 @@ object WindowsThumbnailToolbar {
             "Maximum ${ThumbnailToolbarButton.MAX_BUTTONS} buttons allowed, got ${buttons.size}"
         }
 
-        // Cache HWND while the AWT peer is still alive
-        val hwnd = NativeWindowsTaskbarBridge.nativeGetHwnd(window)
-        if (hwnd != 0L) hwndCache[window] = hwnd
-
         val arrays = marshalButtons(buttons)
         val error =
             NativeWindowsTaskbarBridge.nativeThumbBarSetButtons(
-                window,
+                hwnd,
                 arrays.ids,
                 arrays.tooltips,
                 arrays.flags,
@@ -73,9 +75,24 @@ object WindowsThumbnailToolbar {
         lastError = error
         if (error != null) {
             logger.warning("ThumbBarSetButtons failed: $error")
-            hwndCache.remove(window)
         }
         return error == null
+    }
+
+    /**
+     * Register thumbnail toolbar buttons for an AWT window. See [setButtons].
+     */
+    fun setButtons(
+        window: Window,
+        buttons: List<ThumbnailToolbarButton>,
+        onClick: ThumbBarClickListener? = null,
+    ): Boolean {
+        // Cache HWND while the AWT peer is still alive
+        val hwnd = WindowsWindowHandle.of(window)
+        if (hwnd != 0L) hwndCache[window] = hwnd
+        val added = setButtons(hwnd, buttons, onClick)
+        if (!added) hwndCache.remove(window)
+        return added
     }
 
     /**
@@ -84,12 +101,12 @@ object WindowsThumbnailToolbar {
      * Only call this after [setButtons] has been called for the same window.
      * Button IDs must match those originally registered.
      *
-     * @param window  The AWT window.
+     * @param hwnd    The `HWND` of the window.
      * @param buttons Updated button definitions (same IDs as originally registered).
      * @return true if the buttons were updated successfully.
      */
     fun updateButtons(
-        window: Window,
+        hwnd: Long,
         buttons: List<ThumbnailToolbarButton>,
     ): Boolean {
         if (!isAvailable) {
@@ -100,7 +117,7 @@ object WindowsThumbnailToolbar {
         val arrays = marshalButtons(buttons)
         val error =
             NativeWindowsTaskbarBridge.nativeThumbBarUpdateButtons(
-                window,
+                hwnd,
                 arrays.ids,
                 arrays.tooltips,
                 arrays.flags,
@@ -116,31 +133,41 @@ object WindowsThumbnailToolbar {
     }
 
     /**
+     * Update the state of previously registered buttons of an AWT window. See [updateButtons].
+     */
+    fun updateButtons(
+        window: Window,
+        buttons: List<ThumbnailToolbarButton>,
+    ): Boolean = updateButtons(hwndCache[window] ?: WindowsWindowHandle.of(window), buttons)
+
+    /**
      * Unregister the thumbnail toolbar callback and restore the original window procedure.
      *
      * Call this when the window is closing or when you no longer need button click events.
      *
-     * @param window The AWT window.
+     * @param hwnd The `HWND` of the window.
      * @return true if cleanup succeeded.
      */
-    fun unregister(window: Window): Boolean {
+    fun unregister(hwnd: Long): Boolean {
         if (!isAvailable) {
             lastError = "Native library not available"
             return false
         }
-        // Try cached HWND first (works even after AWT peer is disposed)
-        val cachedHwnd = hwndCache.remove(window)
-        val error =
-            if (cachedHwnd != null && cachedHwnd != 0L) {
-                NativeWindowsTaskbarBridge.nativeThumbBarUnregisterByHwnd(cachedHwnd)
-            } else {
-                NativeWindowsTaskbarBridge.nativeThumbBarUnregister(window)
-            }
+        val error = NativeWindowsTaskbarBridge.nativeThumbBarUnregister(hwnd)
         lastError = error
         if (error != null) {
             logger.warning("ThumbBarUnregister failed: $error")
         }
         return error == null
+    }
+
+    /**
+     * Unregister the thumbnail toolbar of an AWT window. Uses the `HWND` cached
+     * at [setButtons] time, so it works even after the AWT peer is disposed.
+     */
+    fun unregister(window: Window): Boolean {
+        val hwnd = hwndCache.remove(window) ?: WindowsWindowHandle.of(window)
+        return unregister(hwnd)
     }
 
     private data class ButtonArrays(

--- a/launcher-windows/src/main/kotlin/dev/nucleusframework/launcher/windows/WindowsWindowHandle.kt
+++ b/launcher-windows/src/main/kotlin/dev/nucleusframework/launcher/windows/WindowsWindowHandle.kt
@@ -1,0 +1,24 @@
+package dev.nucleusframework.launcher.windows
+
+import java.awt.Window
+
+/**
+ * Resolves the Win32 `HWND` backing an AWT window.
+ *
+ * The launcher APIs ([WindowsOverlayIcon], [WindowsThumbnailToolbar]) address
+ * windows by raw `HWND`, so they work with any windowing backend (AWT, Tao).
+ * This helper covers the AWT side; non-AWT backends expose their `HWND`
+ * directly (e.g. `TaoWindow.nativeHandle`).
+ */
+object WindowsWindowHandle {
+    /**
+     * @return the `HWND` of [window] as a `Long`, or 0 if the native library
+     *   is unavailable or the window has no realized peer yet.
+     */
+    fun of(window: Window): Long =
+        if (NativeWindowsTaskbarBridge.isLoaded) {
+            NativeWindowsTaskbarBridge.nativeGetHwnd(window)
+        } else {
+            0L
+        }
+}

--- a/launcher-windows/src/main/native/windows/nucleus_launcher_windows.cpp
+++ b/launcher-windows/src/main/native/windows/nucleus_launcher_windows.cpp
@@ -790,14 +790,14 @@ Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeGetH
 
 JNIEXPORT jstring JNICALL
 Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeSetOverlayIcon(
-    JNIEnv *env, jclass, jobject awtWindow,
+    JNIEnv *env, jclass, jlong jHwnd,
     jint iconType, jstring jIconPath, jint iconIndex, jstring jDescription)
 {
     std::lock_guard<std::mutex> lock(g_tb_mutex);
     if (!EnsureTaskbarList()) return env->NewStringUTF("ITaskbarList3 not available");
 
-    HWND hwnd = GetHwndFromAwtWindow(env, awtWindow);
-    if (!hwnd) return env->NewStringUTF("Could not get HWND");
+    HWND hwnd = (HWND)(intptr_t)jHwnd;
+    if (!hwnd) return env->NewStringUTF("Invalid HWND");
 
     std::wstring path = toWString(env, jIconPath);
     HICON hIcon = LoadIconByType(iconType, path, iconIndex);
@@ -813,13 +813,13 @@ Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeSetO
 
 JNIEXPORT jstring JNICALL
 Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeClearOverlayIcon(
-    JNIEnv *env, jclass, jobject awtWindow)
+    JNIEnv *env, jclass, jlong jHwnd)
 {
     std::lock_guard<std::mutex> lock(g_tb_mutex);
     if (!EnsureTaskbarList()) return env->NewStringUTF("ITaskbarList3 not available");
 
-    HWND hwnd = GetHwndFromAwtWindow(env, awtWindow);
-    if (!hwnd) return env->NewStringUTF("Could not get HWND");
+    HWND hwnd = (HWND)(intptr_t)jHwnd;
+    if (!hwnd) return env->NewStringUTF("Invalid HWND");
 
     HRESULT hr = g_taskbarList->SetOverlayIcon(hwnd, nullptr, nullptr);
     if (FAILED(hr)) return errorString(env, "ClearOverlayIcon failed", hr);
@@ -832,7 +832,7 @@ Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeClea
 
 JNIEXPORT jstring JNICALL
 Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeThumbBarSetButtons(
-    JNIEnv *env, jclass, jobject awtWindow,
+    JNIEnv *env, jclass, jlong jHwnd,
     jintArray jIds, jobjectArray jTooltips, jintArray jFlags,
     jintArray jIconTypes, jobjectArray jIconPaths, jintArray jIconIndices,
     jobject jCallback)
@@ -840,8 +840,8 @@ Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeThum
     std::lock_guard<std::mutex> lock(g_tb_mutex);
     if (!EnsureTaskbarList()) return env->NewStringUTF("ITaskbarList3 not available");
 
-    HWND hwnd = GetHwndFromAwtWindow(env, awtWindow);
-    if (!hwnd) return env->NewStringUTF("Could not get HWND");
+    HWND hwnd = (HWND)(intptr_t)jHwnd;
+    if (!hwnd) return env->NewStringUTF("Invalid HWND");
 
     int count = env->GetArrayLength(jIds);
     if (count <= 0 || count > 7) return env->NewStringUTF("Invalid button count (1-7)");
@@ -949,15 +949,15 @@ Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeThum
 
 JNIEXPORT jstring JNICALL
 Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeThumbBarUpdateButtons(
-    JNIEnv *env, jclass, jobject awtWindow,
+    JNIEnv *env, jclass, jlong jHwnd,
     jintArray jIds, jobjectArray jTooltips, jintArray jFlags,
     jintArray jIconTypes, jobjectArray jIconPaths, jintArray jIconIndices)
 {
     std::lock_guard<std::mutex> lock(g_tb_mutex);
     if (!EnsureTaskbarList()) return env->NewStringUTF("ITaskbarList3 not available");
 
-    HWND hwnd = GetHwndFromAwtWindow(env, awtWindow);
-    if (!hwnd) return env->NewStringUTF("Could not get HWND");
+    HWND hwnd = (HWND)(intptr_t)jHwnd;
+    if (!hwnd) return env->NewStringUTF("Invalid HWND");
 
     auto *state = (ThumbBarState *)GetPropW(hwnd, THUMBBAR_PROP);
     if (!state || !state->buttonsAdded)
@@ -994,17 +994,6 @@ Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeThum
 
 JNIEXPORT jstring JNICALL
 Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeThumbBarUnregister(
-    JNIEnv *env, jclass, jobject awtWindow)
-{
-    std::lock_guard<std::mutex> lock(g_tb_mutex);
-    HWND hwnd = GetHwndFromAwtWindow(env, awtWindow);
-    if (!hwnd) return env->NewStringUTF("Could not get HWND");
-    CleanupThumbBarState(env, hwnd);
-    return nullptr;
-}
-
-JNIEXPORT jstring JNICALL
-Java_dev_nucleusframework_launcher_windows_NativeWindowsTaskbarBridge_nativeThumbBarUnregisterByHwnd(
     JNIEnv *env, jclass, jlong jHwnd)
 {
     std::lock_guard<std::mutex> lock(g_tb_mutex);


### PR DESCRIPTION
The Windows launcher APIs (overlay icon, thumbnail toolbar) previously required a `java.awt.Window`, which is `null` on the Tao backend. This crashed the example's Launcher tab with a NullPointerException.

### Changes
- JNI bridge now takes a raw HWND (`Long`) for overlay and thumbnail toolbar operations instead of extracting it from an AWT peer.
- `WindowsOverlayIcon` and `WindowsThumbnailToolbar` expose HWND overloads while keeping backward-compatible `java.awt.Window` overloads.
- Add `WindowsWindowHandle` helper to resolve the HWND of an AWT window.
- Update the example to pass `nucleusWindow.unsafe.taoWindow.nativeHandle` on Windows, removing the unsafe `awtWindow!!` assertion.

### Validation
- `:launcher-windows:detektMain` ✅
- `:launcher-windows:ktlintMainSourceSetCheck` ✅
- `:example:ktlintMainSourceSetCheck` ✅
- `:example:compileKotlin` ✅
- `:example:run` under the Tao backend launches without NPE ✅

Note: native DLLs are gitignored and rebuilt by CI; only the C++ source changes are committed.