### PR TITLE
ci(release-desktop): download native artifacts before packaging sample

### DIFF
--- a/.github/workflows/release-desktop.yaml
+++ b/.github/workflows/release-desktop.yaml
@@ -25,9 +25,13 @@ jobs:
       - name: Validate release ref
         uses: ./.github/actions/validate-release-ref
 
+  build-natives:
+    needs: validate-release-ref
+    uses: ./.github/workflows/build-natives.yaml
+
   build:
     name: Build (${{ matrix.os }} / ${{ matrix.arch }})
-    needs: validate-release-ref
+    needs: [validate-release-ref, build-natives]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
@@ -80,6 +84,181 @@ jobs:
           setup-gradle: 'true'
           setup-node: 'true'
           node-version: ${{ matrix.node-version || '24' }}
+
+      - name: Download darkmode-detector native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: darkmode-detector/src/main/resources/nucleus/native/
+          pattern: '*-natives*'
+          merge-multiple: true
+
+      - name: Download native-ssl artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: native-ssl/src/main/resources/nucleus/native/
+          pattern: 'ssl-*'
+          merge-multiple: true
+
+      - name: Download decorated-window-jbr artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: decorated-window-jbr/src/main/resources/nucleus/native/
+          pattern: 'decorated-window-jbr-*'
+          merge-multiple: true
+
+      - name: Download decorated-window-jni artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: decorated-window-jni/src/main/resources/nucleus/native/
+          pattern: 'decorated-window-jni-*'
+          merge-multiple: true
+
+      - name: Download decorated-window-core artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: decorated-window-core/src/main/resources/nucleus/native/
+          pattern: 'decorated-window-core-*'
+          merge-multiple: true
+
+      - name: Download linux-hidpi artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: linux-hidpi/src/main/resources/nucleus/native/
+          pattern: 'linux-hidpi-*'
+          merge-multiple: true
+
+      - name: Download system-color artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: system-color/src/main/resources/nucleus/native/
+          pattern: 'system-color-*'
+          merge-multiple: true
+
+      - name: Download energy-manager artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: energy-manager/src/main/resources/nucleus/native/
+          pattern: 'energy-manager-*'
+          merge-multiple: true
+
+      - name: Download taskbar-progress artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: taskbar-progress/src/main/resources/nucleus/native/
+          pattern: 'taskbar-progress-*'
+          merge-multiple: true
+
+      - name: Download fs-watcher artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: fs-watcher/src/main/resources/nucleus/native/
+          pattern: 'fs-watcher-*'
+          merge-multiple: true
+
+      - name: Download notification-macos artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: notification-macos/src/main/resources/nucleus/native/
+          pattern: 'notification-macos*'
+          merge-multiple: true
+
+      - name: Download service-management-macos artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: service-management-macos/src/main/resources/nucleus/native/
+          pattern: 'service-management-macos*'
+          merge-multiple: true
+
+      - name: Download notification-linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: notification-linux/src/main/resources/nucleus/native/
+          pattern: 'notification-linux-*'
+          merge-multiple: true
+
+      - name: Download notification-windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: notification-windows/src/main/resources/nucleus/native/
+          pattern: 'notification-windows*'
+          merge-multiple: true
+
+      - name: Download autolaunch artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: autolaunch/src/main/resources/nucleus/native/
+          pattern: 'autolaunch*'
+          merge-multiple: true
+
+      - name: Download launcher-windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: launcher-windows/src/main/resources/nucleus/native/
+          pattern: 'launcher-windows*'
+          merge-multiple: true
+
+      - name: Download launcher-linux artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: launcher-linux/src/main/resources/nucleus/native/
+          pattern: 'launcher-linux-*'
+          merge-multiple: true
+
+      - name: Download launcher-macos artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: launcher-macos/src/main/resources/nucleus/native/
+          pattern: 'launcher-macos*'
+          merge-multiple: true
+
+      - name: Download global-hotkey artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: global-hotkey/src/main/resources/nucleus/native/
+          pattern: 'global-hotkey-*'
+          merge-multiple: true
+
+      - name: Download menu-macos artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: menu-macos/src/main/resources/nucleus/native/
+          pattern: 'menu-macos*'
+          merge-multiple: true
+
+      - name: Download system-info artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: system-info/src/main/resources/nucleus/native/
+          pattern: 'system-info-*'
+          merge-multiple: true
+
+      - name: Download scheduler artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: scheduler/src/main/resources/nucleus/native/
+          pattern: 'scheduler-*'
+          merge-multiple: true
+
+      - name: Download media-control artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: media-control/src/main/resources/nucleus/native/
+          pattern: 'media-control-*'
+          merge-multiple: true
+
+      - name: Download decorated-window-tao artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: decorated-window-tao/src/main/resources/nucleus/native/
+          pattern: 'decorated-window-tao-*'
+          merge-multiple: true
+
+      - name: Download graalvm-runtime artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: graalvm-runtime/src/main/resources/nucleus/native/
+          pattern: 'graalvm-runtime-*'
+          merge-multiple: true
 
       - name: Configure Linux GPG signing
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

- Add a dependency on the reusable `build-natives` workflow so all platform native libraries are built before packaging.
- Download every native artifact into the correct `src/main/resources/nucleus/native/` directory before running `:example:packageReleaseDistributionForCurrentOS`.
- Aligns `release-desktop.yaml` with `release-graalvm.yaml`, `publish-maven.yaml`, and `test-packaging.yaml`.
- Fixes packaged example app crashes on Windows caused by missing ANGLE DLLs (`libEGL.dll`, `libGLESv2.dll`) from `decorated-window-tao`.

## Test plan

- [ ] Run `release-desktop.yaml` on Windows.
- [ ] Verify the installed `app/decorated-window-tao-*.jar` contains `nucleus/native/win32-x64/libEGL.dll` and `libGLESv2.dll`.
- [ ] Launch the packaged app and confirm it reaches the main window without `Failed to create ANGLE render context`.
