### PR TITLE
fix(detekt): drop removed Deprecation.excludeImportStatements property

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -434,7 +434,6 @@ potential-bugs:
   Deprecation:
     active: false
     aliases: ['DEPRECATION']
-    excludeImportStatements: false
   DontDowncastCollectionTypes:
     active: false
   DoubleMutabilityForCollection:


### PR DESCRIPTION
## Summary
- The detekt bump to 2.0.0-alpha.5 (PR #298) fails config validation: the `Deprecation` rule no longer accepts `excludeImportStatements` (allowed keys are now `active`, `aliases`).
- Removes the stale property from `config/detekt/detekt.yml`.

Fixes the failing `preMerge` detekt tasks in run 29100238600.

## Test plan
- [ ] `./gradlew detekt` passes config validation