### PR TITLE
feat(tao): standalone transparent popup panel + single-instance restore hook

### DIFF
--- a/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
+++ b/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
@@ -77,6 +77,10 @@ fun NucleusApplicationScope.MaterialDecoratedWindow(
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    // Materialise Compose Popup layers as native transparent windows
+    // (NSPanel / WS_POPUP HWND) so menus can extend past the window bounds.
+    // Honoured by the Tao backend on Windows/macOS; ignored elsewhere.
+    nativePopupLayers: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -105,6 +109,7 @@ fun NucleusApplicationScope.MaterialDecoratedWindow(
             enabled = enabled,
             focusable = focusable,
             alwaysOnTop = alwaysOnTop,
+            nativePopupLayers = nativePopupLayers,
             minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,

--- a/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
+++ b/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
@@ -90,6 +90,10 @@ fun NucleusApplicationScope.MaterialDecoratedWindow(
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    // Materialise Compose Popup layers as native transparent windows
+    // (NSPanel / WS_POPUP HWND) so menus can extend past the window bounds.
+    // Honoured by the Tao backend on Windows/macOS; ignored elsewhere.
+    nativePopupLayers: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -118,6 +122,7 @@ fun NucleusApplicationScope.MaterialDecoratedWindow(
             enabled = enabled,
             focusable = focusable,
             alwaysOnTop = alwaysOnTop,
+            nativePopupLayers = nativePopupLayers,
             minimumSize = minimumSize,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -112,6 +112,10 @@ internal fun ApplicationScope.openDecoratedWindow(
     popupFor: TaoWindow? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
+    // Materialise Compose Popup layers as native transparent windows
+    // (NSPanel / WS_POPUP HWND) instead of drawing them inline in this
+    // window's render target. Windows/macOS only; ignored on Linux.
+    nativePopupLayers: Boolean = false,
     macOSStyle: MacOSStyle = MacOSStyle.Classic,
     // Parent composition locals to bridge into this window's own ComposeScene
     // (applied above the scene's LocalComposeSceneContext so popups still route
@@ -159,6 +163,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             onPreviewKeyEvent,
             onKeyEvent,
             initialCompositionLocalContext,
+            nativePopupLayers,
             content,
         )
     }
@@ -184,6 +189,7 @@ internal fun ApplicationScope.openDecoratedWindow(
     }
 
     val host = TaoComposeSceneHost(window, macOSStyle = macOSStyle)
+    host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
     host.setSceneCompositionLocalContext(initialCompositionLocalContext)
@@ -723,9 +729,11 @@ private fun ApplicationScope.openDecoratedWindowWindows(
     onPreviewKeyEvent: (KeyEvent) -> Boolean,
     onKeyEvent: (KeyEvent) -> Boolean,
     initialCompositionLocalContext: CompositionLocalContext?,
+    nativePopupLayers: Boolean,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     val host = TaoComposeSceneHostWindows(window)
+    host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
     host.setSceneCompositionLocalContext(initialCompositionLocalContext)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -69,6 +69,12 @@ fun ApplicationScope.DecoratedWindow(
     popupFor: TaoWindow? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
+    /**
+     * Materialise Compose Popup layers as native transparent windows
+     * (NSPanel / WS_POPUP HWND) instead of drawing them inline in this
+     * window's render target. Windows/macOS only; ignored on Linux.
+     */
+    nativePopupLayers: Boolean = false,
     macOSStyle: MacOSStyle = MacOSStyle.Classic,
     // Parent composition locals bridged into this window's own ComposeScene from
     // the first composition (see [openDecoratedWindow]). Defaults to null for
@@ -139,6 +145,7 @@ fun ApplicationScope.DecoratedWindow(
                     popupFor = popupFor,
                     onPreviewKeyEvent = { latestPreview(it) },
                     onKeyEvent = { latestKey(it) },
+                    nativePopupLayers = nativePopupLayers,
                     macOSStyle = macOSStyle,
                     initialCompositionLocalContext = compositionLocalContext,
                     content = {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoGlBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoGlBridge.kt
@@ -99,4 +99,14 @@ internal object NativeTaoGlBridge {
 
     @JvmStatic
     external fun nativeHeight(handle: Long): Int
+
+    /**
+     * Bootstraps the shared ANGLE display/config/context against a 1x1
+     * pbuffer when no window host has attached yet. Standalone popup panels
+     * (see [TaoStandalonePopup]) need the shared context to exist before
+     * `nativeCreatePanel`; in apps that already opened a Tao window this is
+     * a cheap no-op. Returns `false` when ANGLE/D3D11 is unavailable.
+     */
+    @JvmStatic
+    external fun nativeEnsureHeadlessContext(): Boolean
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeViewOverlayController.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeViewOverlayController.kt
@@ -22,9 +22,8 @@ import dev.nucleusframework.window.tao.render.TaoComposeSceneContext
 import dev.nucleusframework.window.tao.render.TaoNativeWireFormat
 import dev.nucleusframework.window.tao.render.TaoPopupHost
 import dev.nucleusframework.window.tao.render.TaoRecordedSurface
-import dev.nucleusframework.window.tao.render.dispatchSyntheticKeyTyped
+import dev.nucleusframework.window.tao.render.dispatchNativeKeyEvent
 import dev.nucleusframework.window.tao.render.recordSceneToPicture
-import dev.nucleusframework.window.tao.render.taoKeyEvent
 import org.jetbrains.skia.DirectContext
 import kotlin.coroutines.CoroutineContext
 
@@ -179,26 +178,12 @@ internal class NativeViewOverlayController(
             codePoint: Int,
             modifiers: Int,
         ) {
-            val sc = scene ?: return
-            val isShift = modifiers and TaoNativeWireFormat.MOD_SHIFT != 0
-            val isCtrl = modifiers and TaoNativeWireFormat.MOD_CTRL != 0
-            val isAlt = modifiers and TaoNativeWireFormat.MOD_ALT != 0
-            val isMeta = modifiers and TaoNativeWireFormat.MOD_META != 0
-            sc.sendKeyEvent(
-                taoKeyEvent(
-                    keyDown = type == TaoNativeWireFormat.KEY_DOWN,
-                    vkCode = vkCode,
-                    keyLocation = 0,
-                    isShift = isShift,
-                    isCtrl = isCtrl,
-                    isAlt = isAlt,
-                    isMeta = isMeta,
-                    codePoint = codePoint,
-                ),
+            scene?.dispatchNativeKeyEvent(
+                type = type,
+                vkCode = vkCode,
+                codePoint = codePoint,
+                modifiers = modifiers,
             )
-            if (type == TaoNativeWireFormat.KEY_DOWN) {
-                sc.dispatchSyntheticKeyTyped(codePoint, isShift, isCtrl, isAlt, isMeta)
-            }
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridgeWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridgeWindows.kt
@@ -52,6 +52,10 @@ internal object PopupNativeBridgeWindows {
         )
     }
 
+    /**
+     * [parentHwnd] may be `0` for a standalone (ownerless) panel — [xPx]/[yPx]
+     * are then absolute screen coordinates instead of parent-client-relative.
+     */
     @JvmStatic
     external fun nativeCreatePanel(
         parentHwnd: Long,
@@ -60,6 +64,28 @@ internal object PopupNativeBridgeWindows {
         widthPx: Int,
         heightPx: Int,
     ): Long
+
+    /** Shows/hides the panel (SW_SHOWNOACTIVATE / SW_HIDE) without releasing it. */
+    @JvmStatic
+    external fun nativeSetPanelVisible(
+        panel: Long,
+        visible: Boolean,
+    )
+
+    /**
+     * Raises/restores the system timer resolution (timeBeginPeriod(1),
+     * refcounted). Required while pacing animations from JVM scheduled
+     * executors: the default ~15.6 ms quantum halves the frame rate.
+     */
+    @JvmStatic
+    external fun nativeSetHighResTimer(enable: Boolean)
+
+    /** Sets the client-area cursor from a [TaoCursorIcon] constant. */
+    @JvmStatic
+    external fun nativeSetPanelCursor(
+        panel: Long,
+        cursorIcon: Int,
+    )
 
     @JvmStatic
     external fun nativeSetFrameInWindow(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoScreenGeometry.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoScreenGeometry.kt
@@ -1,0 +1,78 @@
+package dev.nucleusframework.window.tao
+
+import dev.nucleusframework.core.runtime.Platform
+
+/**
+ * Public screen-geometry queries for the Tao backend. Gives external libraries
+ * (e.g. the system-tray popup) access to the primary monitor's work area and
+ * scale factor without going through AWT's `Toolkit`/`GraphicsEnvironment` —
+ * neither exists on a no-AWT Tao runtime.
+ *
+ * All values follow the same conventions as the native deco bridges: physical
+ * pixels, top-left origin, `[x, y, width, height]`.
+ */
+object TaoScreenGeometry {
+    /**
+     * The primary monitor's work area (full screen minus taskbar / menu bar /
+     * dock) as `[x, y, width, height]` in physical pixels, or `null` when the
+     * platform bridge is unavailable.
+     *
+     * On Linux the query is GDK-backed and needs a realized window: pass any
+     * open [TaoWindow] (e.g. the popup being positioned). Ignored on
+     * Windows/macOS.
+     */
+    fun primaryMonitorWorkAreaPx(window: TaoWindow? = null): LongArray? =
+        when (Platform.Current) {
+            Platform.Windows ->
+                if (NativeTaoWindowsDecoBridge.isLoaded) {
+                    NativeTaoWindowsDecoBridge.nativeGetPrimaryMonitorWorkArea()
+                } else {
+                    null
+                }
+            Platform.MacOS ->
+                if (NativeTaoMacOsDecoBridge.isLoaded) {
+                    NativeTaoMacOsDecoBridge.nativeGetPrimaryMonitorWorkArea()
+                } else {
+                    null
+                }
+            Platform.Linux ->
+                if (NativeTaoBridge.isLoaded && window != null) {
+                    NativeTaoBridge.nativeLinuxPrimaryMonitorWorkArea(window.handle)
+                } else {
+                    null
+                }
+            else -> null
+        }
+
+    /**
+     * The primary monitor's scale factor (`1.0` on non-HiDPI displays), or
+     * `1.0` when the platform bridge is unavailable. Same [window] contract as
+     * [primaryMonitorWorkAreaPx] on Linux.
+     */
+    @Suppress("MagicNumber")
+    fun primaryMonitorScaleFactor(window: TaoWindow? = null): Float {
+        val scaleMilli =
+            when (Platform.Current) {
+                Platform.Windows ->
+                    if (NativeTaoWindowsDecoBridge.isLoaded) {
+                        NativeTaoWindowsDecoBridge.nativeGetPrimaryMonitorScaleMilli()
+                    } else {
+                        1000
+                    }
+                Platform.MacOS ->
+                    if (NativeTaoMacOsDecoBridge.isLoaded) {
+                        NativeTaoMacOsDecoBridge.nativeGetPrimaryMonitorScaleMilli()
+                    } else {
+                        1000
+                    }
+                Platform.Linux ->
+                    if (NativeTaoBridge.isLoaded && window != null) {
+                        NativeTaoBridge.nativeLinuxPrimaryMonitorScaleMilli(window.handle)
+                    } else {
+                        1000
+                    }
+                else -> 1000
+            }
+        return scaleMilli.coerceAtLeast(1000) / 1000f
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
@@ -1,0 +1,111 @@
+package dev.nucleusframework.window.tao
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.currentCompositionLocalContext
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.window.WindowPosition
+import dev.nucleusframework.core.runtime.Platform
+import dev.nucleusframework.window.tao.render.TaoStandalonePopupHost
+
+/**
+ * Standalone transparent popup (Windows only): a top-level, ownerless,
+ * non-activating native panel with per-pixel transparency, hosting [content]
+ * in its own Compose scene. There is no backing "window" anywhere — nothing
+ * appears in the taskbar, Alt-Tab or the Start task view — and rendering is
+ * driven on demand (no owner window render loop). Built for system-tray
+ * popups.
+ *
+ * Must be called inside `taoApplication { }` (directly or through
+ * `nucleusApplication` on the Tao backend). On non-Windows platforms, or when
+ * the native pipeline is unavailable, the composable is a no-op.
+ *
+ * @param visible shows/hides the panel; the composition (and [content] state)
+ *   is retained while hidden.
+ * @param position top-left corner in logical (dp) screen coordinates.
+ * @param size panel size in dp.
+ * @param focusable whether the panel can take keyboard focus on click.
+ * @param onOutsideClick invoked when the user clicks anywhere outside the
+ *   panel while it is visible (native mouse-hook, fires on mouse-down).
+ */
+@Suppress("FunctionNaming", "LongParameterList")
+@Composable
+fun TaoStandalonePopup(
+    visible: Boolean,
+    position: WindowPosition.Absolute,
+    size: DpSize,
+    focusable: Boolean = true,
+    onOutsideClick: (() -> Unit)? = null,
+    onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null,
+    onKeyEvent: ((KeyEvent) -> Boolean)? = null,
+    content: @Composable () -> Unit,
+) {
+    if (Platform.Current != Platform.Windows) return
+
+    // Native resources are allocated inside remember{}: if the composition
+    // is abandoned before DisposableEffect registers, the panel leaks.
+    // Standard Compose caveat, negligible for an application-scoped popup.
+    val host = remember { TaoStandalonePopupHost() }
+    if (!host.isValid) return
+
+    DisposableEffect(Unit) {
+        onDispose { host.dispose() }
+    }
+
+    // Bridge the caller's composition locals into the panel's own scene
+    // (fresh scenes don't inherit locals), but keep the scene's density —
+    // the outer application composition runs with GlobalDensity(1f).
+    // Both the locals and the content go through State reads INSIDE the
+    // panel composition, so outer changes (dark mode, strings…) recompose
+    // the panel instead of freezing first-composition values.
+    val outerLocals = rememberUpdatedState(currentCompositionLocalContext)
+    val currentContent = rememberUpdatedState(content)
+    val sceneDensity = Density(host.scale)
+
+    SideEffect {
+        host.onPreviewKeyEvent = onPreviewKeyEvent
+        host.onKeyEvent = onKeyEvent
+    }
+
+    // All host mutations run AFTER the current composition pass: setContent
+    // composes the panel's own scene, which must never nest inside an active
+    // composition of the caller's composition.
+    LaunchedEffect(host) {
+        host.setContent {
+            CompositionLocalProvider(outerLocals.value) {
+                CompositionLocalProvider(LocalDensity provides sceneDensity) {
+                    currentContent.value()
+                }
+            }
+        }
+    }
+    LaunchedEffect(host, position, size) {
+        host.setFrame(
+            xDp = position.x.value,
+            yDp = position.y.value,
+            widthDp = size.width.value,
+            heightDp = size.height.value,
+        )
+    }
+    LaunchedEffect(host, focusable) { host.setFocusable(focusable) }
+    LaunchedEffect(host, visible) { host.setVisible(visible) }
+
+    val outsideClickState = rememberUpdatedState(onOutsideClick)
+    LaunchedEffect(host, onOutsideClick != null) {
+        host.setOutsideClickListener(
+            if (onOutsideClick != null) {
+                { outsideClickState.value?.invoke() }
+            } else {
+                null
+            },
+        )
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHost.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeScenePointer
+import androidx.compose.ui.scene.PlatformLayersComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
@@ -117,6 +118,14 @@ internal class TaoComposeSceneHost(
      * BaseComposeScene picks it up. Set once before [attach].
      */
     var semanticsOwnerListener: PlatformContext.SemanticsOwnerListener? = null
+
+    /**
+     * When true, Compose Popup / DropdownMenu / Tooltip layers materialise as
+     * native NSPanels ([TaoPopupSceneLayer]) instead of drawing inside this
+     * window's Metal render target. Opt-in — see the Windows counterpart.
+     * Set before [attach].
+     */
+    var nativePopupLayers: Boolean = false
 
     // Mirrors `PlatformWindowContext.desktop.kt` — Compose's `Popup` framework
     // reads `LocalWindowInfo.current.containerSize` to know how large the host
@@ -295,24 +304,45 @@ internal class TaoComposeSceneHost(
                 textToolbar = textToolbar,
             )
 
+        val hostPopupHost = if (nativePopupLayers) popupHost() else null
         scene =
-            // Match Windows and Linux for the main host scene: Compose
-            // Popup / DropdownMenu / Tooltip content stays in the same
-            // Metal render target instead of becoming a native NSPanel.
-            // NativeView overlay scenes still opt into TaoComposeSceneContext
-            // when their popups must float above an embedded AppKit view.
-            CanvasLayersComposeScene(
-                density = Density(scale),
-                layoutDirection = GlobalLayoutDirection,
-                size = IntSize(widthPx, heightPx),
-                coroutineContext = coroutineContext + frameClock + flushingDispatcher,
-                platformContext = taoPlatformContext,
-                invalidate = {
-                    // Schedule a frame on the render loop (coalesced); it renders
-                    // then waits for the next vsync. See startRenderLoop.
-                    frameDispatcher?.scheduleFrame()
-                },
-            ).apply { compositionLocalContext = pendingCompositionLocalContext }
+            if (hostPopupHost != null) {
+                // Opt-in path (e.g. tray popups): every Popup becomes a native
+                // NSPanel owned by this window, so popup content can extend
+                // beyond — and float independently of — the window bounds.
+                PlatformLayersComposeScene(
+                    density = Density(scale),
+                    layoutDirection = GlobalLayoutDirection,
+                    size = IntSize(widthPx, heightPx),
+                    coroutineContext = coroutineContext + frameClock + flushingDispatcher,
+                    composeSceneContext =
+                        TaoComposeSceneContext(
+                            platformContext = taoPlatformContext,
+                            popupHost = hostPopupHost,
+                        ),
+                    invalidate = {
+                        frameDispatcher?.scheduleFrame()
+                    },
+                ).apply { compositionLocalContext = pendingCompositionLocalContext }
+            } else {
+                // Match Windows and Linux for the main host scene: Compose
+                // Popup / DropdownMenu / Tooltip content stays in the same
+                // Metal render target instead of becoming a native NSPanel.
+                // NativeView overlay scenes still opt into TaoComposeSceneContext
+                // when their popups must float above an embedded AppKit view.
+                CanvasLayersComposeScene(
+                    density = Density(scale),
+                    layoutDirection = GlobalLayoutDirection,
+                    size = IntSize(widthPx, heightPx),
+                    coroutineContext = coroutineContext + frameClock + flushingDispatcher,
+                    platformContext = taoPlatformContext,
+                    invalidate = {
+                        // Schedule a frame on the render loop (coalesced); it renders
+                        // then waits for the next vsync. See startRenderLoop.
+                        frameDispatcher?.scheduleFrame()
+                    },
+                ).apply { compositionLocalContext = pendingCompositionLocalContext }
+            }
 
         registerInboundDnD()
     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
@@ -48,7 +48,6 @@ import org.jetbrains.skia.DirectContext
 import org.jetbrains.skia.FramebufferFormat
 import org.jetbrains.skia.GLAssembledInterface
 import org.jetbrains.skia.Paint
-import org.jetbrains.skia.Path
 import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathFillMode
 import org.jetbrains.skia.RRect

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeScenePointer
+import androidx.compose.ui.scene.PlatformLayersComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
@@ -87,6 +88,15 @@ internal class TaoComposeSceneHostWindows(
      * BaseComposeScene picks it up. Set once before [attach].
      */
     var semanticsOwnerListener: androidx.compose.ui.platform.PlatformContext.SemanticsOwnerListener? = null
+
+    /**
+     * When true, Compose Popup / DropdownMenu / Tooltip layers materialise as
+     * real per-pixel-transparent top-level HWNDs ([TaoPopupSceneLayerWindows])
+     * instead of drawing inside this window's render target. Opt-in because
+     * the inline default avoids Windows-only compositor artifacts in the
+     * custom title-bar path. Set before [attach].
+     */
+    var nativePopupLayers: Boolean = false
 
     private val windowInfo = WindowsTaoWindowInfo()
     private var currentKeyboardModifiers: PointerKeyboardModifiers = PointerKeyboardModifiers()
@@ -258,13 +268,32 @@ internal class TaoComposeSceneHostWindows(
                 textToolbar = textToolbar,
             )
         scene =
-            CanvasLayersComposeScene(
-                density = Density(scale),
-                layoutDirection = GlobalLayoutDirection,
-                coroutineContext = coroutineContext + frameClock + flushingDispatcher,
-                platformContext = platformContext,
-                invalidate = { window.requestRedraw() },
-            ).apply { compositionLocalContext = pendingCompositionLocalContext }
+            if (nativePopupLayers) {
+                // Opt-in path (e.g. tray popups): every Popup becomes a
+                // transparent WS_POPUP HWND owned by this window, so popup
+                // content can extend beyond — and float independently of —
+                // the window bounds. popupHost() is non-null here: hwnd and
+                // directContext were both set above.
+                PlatformLayersComposeScene(
+                    density = Density(scale),
+                    layoutDirection = GlobalLayoutDirection,
+                    coroutineContext = coroutineContext + frameClock + flushingDispatcher,
+                    composeSceneContext =
+                        TaoComposeSceneContextWindows(
+                            platformContext = platformContext,
+                            popupHost = requireNotNull(popupHost()),
+                        ),
+                    invalidate = { window.requestRedraw() },
+                ).apply { compositionLocalContext = pendingCompositionLocalContext }
+            } else {
+                CanvasLayersComposeScene(
+                    density = Density(scale),
+                    layoutDirection = GlobalLayoutDirection,
+                    coroutineContext = coroutineContext + frameClock + flushingDispatcher,
+                    platformContext = platformContext,
+                    invalidate = { window.requestRedraw() },
+                ).apply { compositionLocalContext = pendingCompositionLocalContext }
+            }
 
         registerInboundDnD()
         registerTouchInput()
@@ -1336,7 +1365,7 @@ internal class TaoComposeSceneHostWindows(
         }
     }
 
-    private companion object {
+    internal companion object {
         // Wire scales — must match Rust `CURSOR_FIXED_SCALE` and
         // `TOUCH_FORCE_FIXED_SCALE` in `events.rs`.
         private const val TOUCH_POSITION_SCALE: Float = 1024f
@@ -1374,8 +1403,12 @@ internal class TaoComposeSceneHostWindows(
          * back, so we resetGLAll on every frame entry in that regime.
          * The flag-gated path stays for the single-host case to keep the
          * single-window hot path cheap.
+         *
+         * internal: standalone popup hosts (TaoStandalonePopupHost) share
+         * the process EGL context too and register themselves here so window
+         * hosts re-sync their Skia GL state cache.
          */
-        private val attachedHostCount =
+        internal val attachedHostCount =
             java
                 .util
                 .concurrent

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupSceneLayer.kt
@@ -244,28 +244,14 @@ internal class TaoPopupSceneLayer(
             codePoint: Int,
             modifiers: Int,
         ) {
-            val isShift = modifiers and TaoNativeWireFormat.MOD_SHIFT != 0
-            val isCtrl = modifiers and TaoNativeWireFormat.MOD_CTRL != 0
-            val isAlt = modifiers and TaoNativeWireFormat.MOD_ALT != 0
-            val isMeta = modifiers and TaoNativeWireFormat.MOD_META != 0
-            val ev =
-                taoKeyEvent(
-                    keyDown = type == TaoNativeWireFormat.KEY_DOWN,
-                    vkCode = vkCode,
-                    keyLocation = 0,
-                    isShift = isShift,
-                    isCtrl = isCtrl,
-                    isAlt = isAlt,
-                    isMeta = isMeta,
-                    codePoint = codePoint,
-                )
-            if (onPreviewKeyEvent?.invoke(ev) == true) return
-            val consumed = innerScene.sendKeyEvent(ev)
-            if (type == TaoNativeWireFormat.KEY_DOWN) {
-                innerScene.dispatchSyntheticKeyTyped(codePoint, isShift, isCtrl, isAlt, isMeta)
-            }
-            if (consumed) return
-            onKeyEvent?.invoke(ev)
+            innerScene.dispatchNativeKeyEvent(
+                type = type,
+                vkCode = vkCode,
+                codePoint = codePoint,
+                modifiers = modifiers,
+                onPreviewKeyEvent = onPreviewKeyEvent,
+                onKeyEvent = onKeyEvent,
+            )
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupSceneLayerWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupSceneLayerWindows.kt
@@ -62,8 +62,12 @@ internal class TaoPopupSceneLayerWindows(
      */
     private var released = false
 
+    // Work-area sized (not parent-window sized) so a popup larger than its
+    // owner window lays out at full size — mirrors the macOS
+    // TaoPopupSceneLayer contract. Critical for tiny owner windows (e.g. the
+    // tray-popup anchor pattern) where the parent is only a few px.
     private val sceneLayoutSize: IntSize =
-        host.parentWindowSize.let {
+        host.workAreaSize.let {
             IntSize(it.width.coerceAtLeast(1), it.height.coerceAtLeast(1))
         }
     private var drawBounds: IntRect = IntRect(0, 0, 1, 1)
@@ -161,25 +165,14 @@ internal class TaoPopupSceneLayerWindows(
             codePoint: Int,
             modifiers: Int,
         ) {
-            val isShift = modifiers and TaoNativeWireFormat.MOD_SHIFT != 0
-            val isCtrl = modifiers and TaoNativeWireFormat.MOD_CTRL != 0
-            val isAlt = modifiers and TaoNativeWireFormat.MOD_ALT != 0
-            val isMeta = modifiers and TaoNativeWireFormat.MOD_META != 0
-            val ev =
-                taoKeyEvent(
-                    keyDown = type == TaoNativeWireFormat.KEY_DOWN,
-                    vkCode = vkCode,
-                    keyLocation = 0,
-                    isShift = isShift,
-                    isCtrl = isCtrl,
-                    isAlt = isAlt,
-                    isMeta = isMeta,
-                    codePoint = codePoint,
-                )
-            if (onPreviewKeyEvent?.invoke(ev) == true) return
-            val consumed = innerScene.sendKeyEvent(ev)
-            if (consumed) return
-            onKeyEvent?.invoke(ev)
+            innerScene.dispatchNativeKeyEvent(
+                type = type,
+                vkCode = vkCode,
+                codePoint = codePoint,
+                modifiers = modifiers,
+                onPreviewKeyEvent = onPreviewKeyEvent,
+                onKeyEvent = onKeyEvent,
+            )
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoStandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoStandalonePopupHost.kt
@@ -1,0 +1,433 @@
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.runtime.BroadcastFrameClock
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.asComposeCanvas
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.WindowInfo
+import androidx.compose.ui.scene.CanvasLayersComposeScene
+import androidx.compose.ui.scene.ComposeScene
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import dev.nucleusframework.window.tao.GlobalLayoutDirection
+import dev.nucleusframework.window.tao.NativeTaoGlBridge
+import dev.nucleusframework.window.tao.PopupNativeBridgeWindows
+import dev.nucleusframework.window.tao.TaoCursorIcon
+import dev.nucleusframework.window.tao.TaoMainDispatcher
+import dev.nucleusframework.window.tao.TaoScreenGeometry
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.GLAssembledInterface
+import org.jetbrains.skia.makeGLWithInterface
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.math.roundToInt
+
+/**
+ * Standalone transparent popup surface (Windows): a top-level, ownerless
+ * `WS_POPUP` HWND with `WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW` and a per-pixel
+ * transparent DComp-presented surface, driving its own Compose scene.
+ *
+ * Unlike [TaoPopupSceneLayerWindows] it has no owner window and no host render
+ * loop: rendering runs on demand on the Tao main thread whenever the scene
+ * invalidates (recomposition, animation frame, input). No `WM_PAINT` is
+ * involved, so the panel works without any visible window in the process —
+ * the backbone of tray-style popups.
+ *
+ * Threading: construction and every public method must run on the Tao main
+ * thread (the composable wrapper guarantees this). Rendering is scheduled
+ * through [TaoMainDispatcher] and paced at ~60 fps for self-invalidating
+ * content (animations).
+ */
+@OptIn(InternalComposeUiApi::class)
+internal class TaoStandalonePopupHost {
+    val isValid: Boolean
+
+    private var panel: Long = 0
+    private var directContext: DirectContext? = null
+    private var scene: ComposeScene? = null
+    private var disposed = false
+
+    /**
+     * Primary-monitor scale, captured once: a tray popup lives on the
+     * primary monitor by definition. Mixed-DPI multi-monitor setups and
+     * live DPI changes are NOT tracked (would need WM_DPICHANGED plumbing
+     * plus per-position monitor lookup).
+     */
+    val scale: Float = TaoScreenGeometry.primaryMonitorScaleFactor()
+
+    private var widthPx: Int = 1
+    private var heightPx: Int = 1
+
+    var onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null
+    var onKeyEvent: ((KeyEvent) -> Boolean)? = null
+
+    private val frameClock = BroadcastFrameClock { scheduleRender() }
+    private val flushingDispatcher = FlushingDispatcher()
+    private val windowInfo = StandalonePopupWindowInfo()
+
+    private val renderPending = AtomicBoolean(false)
+    private var nextFrameNs = 0L
+    private var visible = false
+
+    init {
+        var valid = false
+        if (!NativeTaoGlBridge.isLoaded || !PopupNativeBridgeWindows.isLoaded) {
+            logger.warning("Standalone popup unavailable: native bridges not loaded")
+        } else if (!runCatching { NativeTaoGlBridge.nativeEnsureHeadlessContext() }
+                .onFailure { logger.warning("Standalone popup unavailable: $it") }
+                .getOrDefault(false)
+        ) {
+            logger.warning("Standalone popup unavailable: headless EGL bootstrap failed")
+        } else {
+            panel =
+                PopupNativeBridgeWindows.nativeCreatePanel(
+                    parentHwnd = 0L,
+                    xPx = HIDDEN_X_PX,
+                    yPx = HIDDEN_Y_PX,
+                    widthPx = 1,
+                    heightPx = 1,
+                )
+            if (panel == 0L) {
+                logger.warning("Standalone popup unavailable: panel creation failed")
+            } else {
+                PopupNativeBridgeWindows.nativeSetPanelVisible(panel, false)
+                directContext =
+                    if (PopupNativeBridgeWindows.nativeMakeCurrent(panel)) {
+                        runCatching {
+                            val intf =
+                                GLAssembledInterface.createFromNativePointers(
+                                    0L,
+                                    NativeTaoGlBridge.nativeEglGetProcFn(),
+                                )
+                            DirectContext.makeGLWithInterface(intf)
+                        }.getOrNull()
+                    } else {
+                        null
+                    }
+                if (directContext != null) {
+                    scene =
+                        CanvasLayersComposeScene(
+                            density = Density(scale),
+                            layoutDirection = GlobalLayoutDirection,
+                            size = IntSize(1, 1),
+                            coroutineContext = flushingDispatcher + frameClock,
+                            platformContext = StandalonePopupPlatformContext(),
+                            invalidate = { scheduleRender() },
+                        )
+                    PopupNativeBridgeWindows.nativeSetEventCallback(panel, PanelEventCallback())
+                    // See TaoComposeSceneHostWindows: all contexts sharing the
+                    // process EGL context must resetGLAll when siblings exist.
+                    TaoComposeSceneHostWindows.attachedHostCount.incrementAndGet()
+                    valid = true
+                    logger.fine { "Standalone popup panel ready (panel=$panel, scale=$scale)" }
+                } else {
+                    logger.warning("Standalone popup unavailable: Skia DirectContext creation failed")
+                    PopupNativeBridgeWindows.nativeRelease(panel)
+                    panel = 0
+                }
+            }
+        }
+        isValid = valid
+    }
+
+    fun setContent(content: @Composable () -> Unit) {
+        scene?.setContent(content)
+        scheduleRender()
+    }
+
+    /** Logical (dp) screen position and size of the panel. */
+    fun setFrame(
+        xDp: Float,
+        yDp: Float,
+        widthDp: Float,
+        heightDp: Float,
+    ) {
+        if (!isValid) return
+        val x = (xDp * scale).roundToInt()
+        val y = (yDp * scale).roundToInt()
+        val w = (widthDp * scale).roundToInt().coerceAtLeast(1)
+        val h = (heightDp * scale).roundToInt().coerceAtLeast(1)
+        PopupNativeBridgeWindows.nativeSetFrameInWindow(
+            panel = panel,
+            xPx = x,
+            yPx = y,
+            widthPx = w,
+            heightPx = h,
+            contentXPx = 0,
+            contentYPx = 0,
+            contentWidthPx = w,
+            contentHeightPx = h,
+        )
+        if (w != widthPx || h != heightPx) {
+            widthPx = w
+            heightPx = h
+            scene?.size = IntSize(w, h)
+            windowInfo.containerSizeState = IntSize(w, h)
+        }
+        scheduleRender()
+    }
+
+    fun setVisible(visible: Boolean) {
+        if (!isValid || visible == this.visible) return
+        this.visible = visible
+        PopupNativeBridgeWindows.nativeSetPanelVisible(panel, visible)
+        // High-resolution timers only while animating on screen: the frame
+        // pacer relies on ~1 ms scheduling accuracy for a steady 60 fps.
+        PopupNativeBridgeWindows.nativeSetHighResTimer(visible)
+        if (visible) scheduleRender()
+    }
+
+    fun setFocusable(focusable: Boolean) {
+        if (!isValid) return
+        PopupNativeBridgeWindows.nativeSetFocusable(panel, focusable)
+    }
+
+    fun setOutsideClickListener(listener: (() -> Unit)?) {
+        if (!isValid) return
+        if (listener != null) {
+            PopupNativeBridgeWindows.nativeInstallOutsideClickMonitor(panel, PanelOutsideClickListener(listener))
+        } else {
+            PopupNativeBridgeWindows.nativeUninstallOutsideClickMonitor(panel)
+        }
+    }
+
+    /**
+     * Named inner class so GraalVM JNI reachability metadata can register
+     * the implementor (same pattern as [TaoPopupSceneLayerWindows]).
+     */
+    private class PanelOutsideClickListener(
+        private val listener: () -> Unit,
+    ) : PopupNativeBridgeWindows.OutsideClickListener {
+        override fun onOutsideClick(
+            type: Int,
+            button: Int,
+        ) {
+            listener()
+        }
+    }
+
+    fun dispose() {
+        if (!isValid || disposed) return
+        disposed = true
+        if (visible) {
+            visible = false
+            PopupNativeBridgeWindows.nativeSetHighResTimer(false)
+        }
+        TaoComposeSceneHostWindows.attachedHostCount.decrementAndGet()
+        PopupNativeBridgeWindows.nativeUninstallOutsideClickMonitor(panel)
+        PopupNativeBridgeWindows.nativeSetEventCallback(panel, null)
+        scene?.close()
+        scene = null
+        directContext?.close()
+        directContext = null
+        PopupNativeBridgeWindows.nativeRelease(panel)
+        panel = 0
+    }
+
+    // ── Rendering ─────────────────────────────────────────────────────────
+
+    private fun scheduleRender() {
+        if (disposed) return
+        if (!renderPending.compareAndSet(false, true)) return
+        TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() }
+    }
+
+    private fun renderNow() {
+        renderPending.set(false)
+        if (disposed) return
+        val ctx = directContext ?: return
+        val sc = scene ?: return
+        if (widthPx <= 0 || heightPx <= 0) return
+
+        // Pace self-invalidating content (animations): DComp presents don't
+        // block on vsync, so an unthrottled invalidate->render loop would
+        // spin the Tao thread at 100%. Pacing runs on an ABSOLUTE deadline
+        // (nextFrameNs) so scheduling latency doesn't accumulate as drift,
+        // and the frame clock is fed evenly spaced timestamps — presents
+        // latch at vsync, so even *timestamps*, not even render moments,
+        // are what makes an animation look smooth.
+        val now = System.nanoTime()
+        if (now < nextFrameNs) {
+            if (renderPending.compareAndSet(false, true)) {
+                pacer.schedule(
+                    { TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() } },
+                    nextFrameNs - now,
+                    TimeUnit.NANOSECONDS,
+                )
+            }
+            return
+        }
+        // Resynchronize after an idle gap; otherwise stay on the fixed grid.
+        val frameNs = if (now - nextFrameNs > FRAME_INTERVAL_NS) now else nextFrameNs
+        nextFrameNs = frameNs + FRAME_INTERVAL_NS
+
+        // Tick the frame clock before rendering (same ordering as the window
+        // hosts) so withFrameNanos-driven animation state is current.
+        flushingDispatcher.drain()
+        frameClock.sendFrame(frameNs)
+        flushingDispatcher.drain()
+
+        if (!PopupNativeBridgeWindows.nativeMakeCurrent(panel)) return
+        // The process EGL context is shared with window hosts and popup
+        // layers; our surface switch invalidates Skia's GL state cache.
+        ctx.resetGLAll()
+        renderGlFrame(
+            widthPx = widthPx,
+            heightPx = heightPx,
+            directContext = ctx,
+            clearColorArgb = 0x00000000,
+            present = { PopupNativeBridgeWindows.nativeSwapBuffers(panel) },
+        ) { canvas, nanoTime ->
+            sc.render(canvas.asComposeCanvas(), nanoTime)
+        }
+    }
+
+    // ── Input ─────────────────────────────────────────────────────────────
+
+    private inner class PanelEventCallback : PopupNativeBridgeWindows.EventCallback {
+        override fun onPointerEvent(
+            type: Int,
+            x: Float,
+            y: Float,
+            button: Int,
+            modifiers: Int,
+        ) {
+            val sc = scene ?: return
+            val pointerButton =
+                when (button) {
+                    TaoNativeWireFormat.BUTTON_PRIMARY -> PointerButton.Primary
+                    TaoNativeWireFormat.BUTTON_SECONDARY -> PointerButton.Secondary
+                    else -> null
+                }
+            val eventType =
+                when (type) {
+                    TaoNativeWireFormat.PTR_DOWN -> PointerEventType.Press
+                    TaoNativeWireFormat.PTR_UP -> PointerEventType.Release
+                    else -> PointerEventType.Move
+                }
+            sc.sendPointerEvent(
+                eventType = eventType,
+                position = Offset(x, y),
+                type = PointerType.Mouse,
+                button = pointerButton,
+            )
+        }
+
+        override fun onScroll(
+            x: Float,
+            y: Float,
+            dx: Float,
+            dy: Float,
+        ) {
+            scene?.sendPointerEvent(
+                eventType = PointerEventType.Scroll,
+                position = Offset(x, y),
+                scrollDelta = Offset(dx, dy),
+                type = PointerType.Mouse,
+            )
+        }
+
+        override fun onKeyEvent(
+            type: Int,
+            vkCode: Int,
+            codePoint: Int,
+            modifiers: Int,
+        ) {
+            scene?.dispatchNativeKeyEvent(
+                type = type,
+                vkCode = vkCode,
+                codePoint = codePoint,
+                modifiers = modifiers,
+                onPreviewKeyEvent = onPreviewKeyEvent,
+                onKeyEvent = onKeyEvent,
+            )
+        }
+    }
+
+    // ── Platform plumbing ─────────────────────────────────────────────────
+
+    private inner class StandalonePopupPlatformContext : PlatformContext.Empty() {
+        override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHost.windowInfo
+
+        override fun setPointerIcon(pointerIcon: PointerIcon) {
+            if (!isValid) return
+            PopupNativeBridgeWindows.nativeSetPanelCursor(panel, mapPointerIcon(pointerIcon))
+        }
+    }
+
+    private fun mapPointerIcon(icon: PointerIcon): Int {
+        when {
+            icon === PointerIcon.Default -> return TaoCursorIcon.DEFAULT
+            icon === PointerIcon.Text -> return TaoCursorIcon.TEXT
+            icon === PointerIcon.Hand -> return TaoCursorIcon.HAND
+            icon === PointerIcon.Crosshair -> return TaoCursorIcon.CROSSHAIR
+        }
+        return runCatching {
+            val cursor = icon.javaClass.getMethod("getCursor").invoke(icon) as? java.awt.Cursor
+            when (cursor?.type) {
+                java.awt.Cursor.TEXT_CURSOR -> TaoCursorIcon.TEXT
+                java.awt.Cursor.HAND_CURSOR -> TaoCursorIcon.HAND
+                java.awt.Cursor.CROSSHAIR_CURSOR -> TaoCursorIcon.CROSSHAIR
+                java.awt.Cursor.WAIT_CURSOR -> TaoCursorIcon.WAIT
+                java.awt.Cursor.MOVE_CURSOR -> TaoCursorIcon.MOVE
+                java.awt.Cursor.E_RESIZE_CURSOR, java.awt.Cursor.W_RESIZE_CURSOR -> TaoCursorIcon.EW_RESIZE
+                java.awt.Cursor.N_RESIZE_CURSOR, java.awt.Cursor.S_RESIZE_CURSOR -> TaoCursorIcon.NS_RESIZE
+                java.awt.Cursor.NE_RESIZE_CURSOR, java.awt.Cursor.SW_RESIZE_CURSOR -> TaoCursorIcon.NESW_RESIZE
+                java.awt.Cursor.NW_RESIZE_CURSOR, java.awt.Cursor.SE_RESIZE_CURSOR -> TaoCursorIcon.NWSE_RESIZE
+                else -> TaoCursorIcon.DEFAULT
+            }
+        }.getOrDefault(TaoCursorIcon.DEFAULT)
+    }
+
+    private inner class FlushingDispatcher : kotlinx.coroutines.CoroutineDispatcher() {
+        private val queue = ConcurrentLinkedQueue<Runnable>()
+
+        override fun dispatch(
+            context: CoroutineContext,
+            block: Runnable,
+        ) {
+            queue.add(block)
+            scheduleRender()
+        }
+
+        fun drain() {
+            var remaining = queue.size
+            while (remaining-- > 0) {
+                val runnable = queue.poll() ?: break
+                runnable.run()
+            }
+        }
+    }
+
+    private class StandalonePopupWindowInfo : WindowInfo {
+        var containerSizeState: IntSize = IntSize(1, 1)
+        override val isWindowFocused: Boolean get() = true
+        override val containerSize: IntSize get() = containerSizeState
+    }
+
+    private companion object {
+        val logger: java.util.logging.Logger =
+            java.util.logging.Logger
+                .getLogger(TaoStandalonePopupHost::class.java.simpleName)
+
+        const val HIDDEN_X_PX: Int = -32_000
+        const val HIDDEN_Y_PX: Int = -32_000
+        const val FRAME_INTERVAL_NS: Long = 1_000_000_000L / 60
+
+        val pacer =
+            Executors.newSingleThreadScheduledExecutor { r ->
+                Thread(r, "TaoStandalonePopupPacer").apply { isDaemon = true }
+            }
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoSyntheticKey.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoSyntheticKey.kt
@@ -122,6 +122,51 @@ private fun awtModifierMask(
         (if (isAlt) InputEvent.ALT_DOWN_MASK else 0) or
         (if (isMeta) InputEvent.META_DOWN_MASK else 0)
 
+/**
+ * Full key dispatch for a scene fed straight from a native popup/overlay
+ * callback (popup layers, standalone panels, native-view overlays):
+ * preview handler → scene → synthetic KEY_TYPED insertion on key-down →
+ * fallback handler. Window hosts keep their own richer pipeline (modifier
+ * tracking, popup handler chains).
+ *
+ * Native callbacks don't report a key location, and desktop `Key.*`
+ * constants are declared with `KEY_LOCATION_STANDARD` — since `Key`
+ * equality encodes the location, anything else (e.g. UNKNOWN) makes every
+ * non-character key (Backspace, Enter, arrows…) unmatchable.
+ */
+@OptIn(InternalComposeUiApi::class)
+internal fun ComposeScene.dispatchNativeKeyEvent(
+    type: Int,
+    vkCode: Int,
+    codePoint: Int,
+    modifiers: Int,
+    onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null,
+    onKeyEvent: ((KeyEvent) -> Boolean)? = null,
+) {
+    val isShift = modifiers and TaoNativeWireFormat.MOD_SHIFT != 0
+    val isCtrl = modifiers and TaoNativeWireFormat.MOD_CTRL != 0
+    val isAlt = modifiers and TaoNativeWireFormat.MOD_ALT != 0
+    val isMeta = modifiers and TaoNativeWireFormat.MOD_META != 0
+    val ev =
+        taoKeyEvent(
+            keyDown = type == TaoNativeWireFormat.KEY_DOWN,
+            vkCode = vkCode,
+            keyLocation = java.awt.event.KeyEvent.KEY_LOCATION_STANDARD,
+            isShift = isShift,
+            isCtrl = isCtrl,
+            isAlt = isAlt,
+            isMeta = isMeta,
+            codePoint = codePoint,
+        )
+    if (onPreviewKeyEvent?.invoke(ev) == true) return
+    val consumed = sendKeyEvent(ev)
+    if (type == TaoNativeWireFormat.KEY_DOWN) {
+        dispatchSyntheticKeyTyped(codePoint, isShift, isCtrl, isAlt, isMeta)
+    }
+    if (consumed) return
+    onKeyEvent?.invoke(ev)
+}
+
 /** Heuristic: ASCII control range and Cmd/Ctrl combos are not text input. */
 internal fun Int.isPrintableTextInput(
     isCtrl: Boolean,

--- a/decorated-window-tao/src/main/native/windows/build.bat
+++ b/decorated-window-tao/src/main/native/windows/build.bat
@@ -183,7 +183,7 @@ cl /LD /O1 /GS- /nologo ^
     "%NV_SRC%" "%OVERLAY_SRC%" "%POPUP_SRC%" "%OVERLAY_DCOMP_SRC%" ^
     /Fe:"%OUT_DIR_X64%\nucleus_tao_windows_native_view.dll" ^
     /link /NODEFAULTLIB /ENTRY:DllMain ^
-    kernel32.lib user32.lib gdi32.lib dwmapi.lib
+    kernel32.lib user32.lib gdi32.lib dwmapi.lib winmm.lib
 if errorlevel 1 (
     echo ERROR: x64 native_view compilation failed >&2
     exit /b 1
@@ -257,7 +257,7 @@ cl /LD /O1 /GS- /nologo ^
     "%NV_SRC%" "%OVERLAY_SRC%" "%POPUP_SRC%" "%OVERLAY_DCOMP_SRC%" ^
     /Fe:"%OUT_DIR_ARM64%\nucleus_tao_windows_native_view.dll" ^
     /link /ENTRY:DllMain ^
-    kernel32.lib user32.lib gdi32.lib dwmapi.lib
+    kernel32.lib user32.lib gdi32.lib dwmapi.lib winmm.lib
 if errorlevel 1 (
     echo WARNING: ARM64 native_view compilation failed >&2
     endlocal

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_gl.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_gl.c
@@ -511,3 +511,80 @@ Java_dev_nucleusframework_window_tao_NativeTaoGlBridge_nativeHeight(
     GlAttachment *att = (GlAttachment *)(uintptr_t)handle;
     return att ? (jint)att->heightPx : 0;
 }
+
+/* Headless bootstrap: creates the shared ANGLE display/config/context bound
+ * to a 1x1 pbuffer when no window host has attached yet. Lets standalone
+ * popup surfaces (overlay_dcomp) run in apps without any Tao window — e.g.
+ * a tray-only app whose UI lives entirely in a transparent popup panel.
+ * NOT thread-safe (check-then-init on the shared EGL statics): call only
+ * from the Tao main thread, like every entry point touching the process
+ * EGL context. */
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_NativeTaoGlBridge_nativeEnsureHeadlessContext(
+    JNIEnv *env, jclass clazz)
+{
+    (void)env; (void)clazz;
+    if (sHostEglContext != EGL_NO_CONTEXT) return JNI_TRUE;
+    loadEgl();
+    if (!eglAvailable || !pEglGetPlatformDisplayEXT) return JNI_FALSE;
+
+    const EGLint deviceTypes[] = {
+        EGL_PLATFORM_ANGLE_DEVICE_TYPE_HARDWARE_ANGLE,
+        EGL_PLATFORM_ANGLE_DEVICE_TYPE_D3D_WARP_ANGLE,
+    };
+    EGLDisplay dpy = EGL_NO_DISPLAY;
+    EGLint major = 0, minor = 0;
+    int i;
+    for (i = 0; i < 2; ++i) {
+        EGLDisplay d = angleD3D11Display(deviceTypes[i]);
+        if (d != EGL_NO_DISPLAY && pEglInitialize(d, &major, &minor)) { dpy = d; break; }
+    }
+    if (dpy == EGL_NO_DISPLAY) return JNI_FALSE;
+    if (pEglBindAPI) pEglBindAPI(EGL_OPENGL_ES_API);
+
+    /* Same config attribs as attachEgl so overlay/popup pbuffers stay
+     * config-compatible with this context. */
+    const EGLint cfgAttribs[] = {
+        EGL_SURFACE_TYPE,    EGL_WINDOW_BIT | EGL_PBUFFER_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_RED_SIZE,    8,
+        EGL_GREEN_SIZE,  8,
+        EGL_BLUE_SIZE,   8,
+        EGL_ALPHA_SIZE,  8,
+        EGL_DEPTH_SIZE,  0,
+        EGL_STENCIL_SIZE, 8,
+        EGL_NONE
+    };
+    EGLConfig config = NULL;
+    EGLint numConfig = 0;
+    if (!pEglChooseConfig(dpy, cfgAttribs, &config, 1, &numConfig) || numConfig == 0) {
+        return JNI_FALSE;
+    }
+
+    PFNEGLCREATEPBUFFERSURFACEPROC pCreatePbuffer =
+        (PFNEGLCREATEPBUFFERSURFACEPROC)GetProcAddress(sLibEGL, "eglCreatePbufferSurface");
+    if (!pCreatePbuffer) return JNI_FALSE;
+    const EGLint pbAttribs[] = { EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE };
+    EGLSurface surface = pCreatePbuffer(dpy, config, pbAttribs);
+    if (surface == EGL_NO_SURFACE) return JNI_FALSE;
+
+    const EGLint ctxAttribs3[] = { EGL_CONTEXT_MAJOR_VERSION, 3, EGL_NONE };
+    const EGLint ctxAttribs2[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE };
+    EGLContext ctx = pEglCreateContext(dpy, config, EGL_NO_CONTEXT, ctxAttribs3);
+    if (ctx == EGL_NO_CONTEXT) {
+        ctx = pEglCreateContext(dpy, config, EGL_NO_CONTEXT, ctxAttribs2);
+    }
+    if (ctx == EGL_NO_CONTEXT) {
+        pEglDestroySurface(dpy, surface);
+        return JNI_FALSE;
+    }
+    if (!pEglMakeCurrent(dpy, surface, surface, ctx)) {
+        pEglDestroyContext(dpy, ctx);
+        pEglDestroySurface(dpy, surface);
+        return JNI_FALSE;
+    }
+    sHostEglDisplay = dpy;
+    sHostEglContext = ctx;
+    sHostEglConfig  = config;
+    return JNI_TRUE;
+}

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_popup.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_popup.c
@@ -33,6 +33,11 @@
 #include <jni.h>
 #include <windows.h>
 #include <dwmapi.h>
+#include <timeapi.h>
+
+/* Posted by the WH_MOUSE_LL proc to defer the outside-click JNI upcall to
+ * the panel's WndProc (a low-level hook must never block). wParam = button. */
+#define WM_APP_OUTSIDE_CLICK (WM_APP + 0x51)
 #include "nucleus_tao_windows_overlay_internal.h"
 
 #define EVT_PTR_DOWN  1
@@ -56,6 +61,9 @@ struct PopupState {
     HWND parent;
     GlSurface gl;
     BOOL focusable;
+
+    /* Client-area cursor, applied on WM_SETCURSOR. NULL = arrow. */
+    HCURSOR cursor;
 
     /* JNI callbacks (jobject global refs). */
     jobject eventCb;
@@ -312,8 +320,11 @@ static LRESULT CALLBACK mouseHookProc(int code, WPARAM w, LPARAM l) {
     return CallNextHookEx(NULL, code, w, l);
 }
 
+/* Refcount counts install REQUESTS; the hook itself is (re)tried whenever
+ * absent, so a failed SetWindowsHookExW doesn't poison later installs. */
 static void installMouseHookIfNeeded(void) {
-    if (InterlockedIncrement(&sMouseHookRefcount) == 1) {
+    InterlockedIncrement(&sMouseHookRefcount);
+    if (sMouseHook == NULL) {
         sMouseHook = SetWindowsHookExW(WH_MOUSE, mouseHookProc,
                                        NULL, GetCurrentThreadId());
     }
@@ -325,6 +336,99 @@ static void uninstallMouseHookIfLast(void) {
             UnhookWindowsHookEx(sMouseHook);
             sMouseHook = NULL;
         }
+    }
+}
+
+/* Global (low-level) variant for OWNERLESS panels: a thread-local WH_MOUSE
+ * hook only observes messages dispatched to this thread's windows, so it
+ * never sees clicks landing on other applications or the desktop — exactly
+ * the clicks a standalone tray popup must dismiss on. WH_MOUSE_LL is
+ * system-wide; its callback runs on the installing thread's message loop
+ * (the Tao event loop, which pumps continuously). */
+static HHOOK sMouseHookLL = NULL;
+static volatile LONG sMouseHookLLRefcount = 0;
+
+static LRESULT CALLBACK mouseHookLLProc(int code, WPARAM w, LPARAM l) {
+    if (code != HC_ACTION) return CallNextHookEx(NULL, code, w, l);
+    UINT msg = (UINT)w;
+    if (msg != WM_LBUTTONDOWN && msg != WM_RBUTTONDOWN && msg != WM_MBUTTONDOWN) {
+        return CallNextHookEx(NULL, code, w, l);
+    }
+    MSLLHOOKSTRUCT *m = (MSLLHOOKSTRUCT *)l;
+    if (!m) return CallNextHookEx(NULL, code, w, l);
+    int btn = (msg == WM_LBUTTONDOWN) ? BTN_PRIMARY :
+              (msg == WM_RBUTTONDOWN) ? BTN_SECONDARY : BTN_MIDDLE;
+
+    /* Only ownerless popups: owner-based ones are covered by the thread
+     * hook and would double-fire otherwise. Fixed-size snapshot: more than
+     * 16 simultaneous ownerless popups silently drop the tail — far above
+     * any real usage (one tray popup). */
+    PopupState *snapshot[16];
+    int n = 0;
+    EnterCriticalSection(&sOpenListLock);
+    for (PopupState *q = sOpenChainHead; q && n < 16; q = q->nextOpen) {
+        if (q->parent == NULL) snapshot[n++] = q;
+    }
+    HWND target = WindowFromPoint(m->pt);
+    PopupState *targetPopup = target ? findPopupByHwndLocked(target) : NULL;
+    BOOL targetIsKnownPopup = targetPopup && pointInsideContentScreen(targetPopup, m->pt);
+    LeaveCriticalSection(&sOpenListLock);
+    if (targetIsKnownPopup) return CallNextHookEx(NULL, code, w, l);
+
+    for (int i = 0; i < n; i++) {
+        PopupState *q = snapshot[i];
+        if (!q->outsideMonitorActive || !q->outsideListener) continue;
+        if (pointInsideContentScreen(q, m->pt)) continue;
+        if (!IsWindowVisible(q->gl.hwnd)) continue;
+        /* NEVER call into Java from a low-level hook: the callback can
+         * trigger a recomposition, and a WH_MOUSE_LL proc that exceeds
+         * LowLevelHooksTimeout (~300 ms) gets silently unhooked by Windows
+         * while stalling the system-wide mouse. Defer to the WndProc. */
+        PostMessageW(q->gl.hwnd, WM_APP_OUTSIDE_CLICK, (WPARAM)btn, 0);
+    }
+    return CallNextHookEx(NULL, code, w, l);
+}
+
+/* Same request-count/retry-if-absent contract as installMouseHookIfNeeded. */
+static void installMouseHookLLIfNeeded(void) {
+    InterlockedIncrement(&sMouseHookLLRefcount);
+    if (sMouseHookLL == NULL) {
+        sMouseHookLL = SetWindowsHookExW(WH_MOUSE_LL, mouseHookLLProc,
+                                         GetModuleHandleW(NULL), 0);
+    }
+}
+
+static void uninstallMouseHookLLIfLast(void) {
+    if (InterlockedDecrement(&sMouseHookLLRefcount) == 0) {
+        if (sMouseHookLL) {
+            UnhookWindowsHookEx(sMouseHookLL);
+            sMouseHookLL = NULL;
+        }
+    }
+}
+
+/* Moves the keyboard focus (and the foreground slot) to hwnd. GetFocus()
+ * only describes the calling thread's queue, so it can still report hwnd
+ * while another application is foreground and receiving all keys — always
+ * compare against GetForegroundWindow(). When another thread is foreground,
+ * SetForegroundWindow is subject to the foreground lock; briefly attaching
+ * to that thread's input queue bypasses it (classic tray-popup pattern). */
+static void takeKeyboardFocus(HWND hwnd) {
+    HWND fg = GetForegroundWindow();
+    if (fg == hwnd) {
+        if (GetFocus() != hwnd) SetFocus(hwnd);
+        return;
+    }
+    DWORD fgThread = fg ? GetWindowThreadProcessId(fg, NULL) : 0;
+    DWORD myThread = GetCurrentThreadId();
+    if (fgThread != 0 && fgThread != myThread) {
+        AttachThreadInput(myThread, fgThread, TRUE);
+        SetForegroundWindow(hwnd);
+        SetFocus(hwnd);
+        AttachThreadInput(myThread, fgThread, FALSE);
+    } else {
+        SetForegroundWindow(hwnd);
+        SetFocus(hwnd);
     }
 }
 
@@ -350,6 +454,13 @@ static LRESULT CALLBACK popupWndProc(HWND hwnd, UINT msg, WPARAM w, LPARAM l) {
     case WM_MOUSEACTIVATE:
         return p && p->focusable ? MA_ACTIVATE : MA_NOACTIVATE;
 
+    case WM_SETCURSOR:
+        if (p && LOWORD(l) == HTCLIENT) {
+            SetCursor(p->cursor ? p->cursor : LoadCursorW(NULL, (LPCWSTR)IDC_ARROW));
+            return TRUE;
+        }
+        break;
+
     case WM_NCHITTEST: {
         if (!p) return HTCLIENT;
         POINT pt;
@@ -363,6 +474,12 @@ static LRESULT CALLBACK popupWndProc(HWND hwnd, UINT msg, WPARAM w, LPARAM l) {
     case WM_RBUTTONDOWN:
     case WM_MBUTTONDOWN: {
         if (!p) break;
+        /* Focusable standalone panel: take keyboard focus explicitly — the
+         * WS_EX_NOACTIVATE style suppresses mouse activation, and there is
+         * no owner window to route keys through. */
+        if (p->focusable && p->parent == NULL) {
+            takeKeyboardFocus(hwnd);
+        }
         /* Outside-click handling moved to the WH_MOUSE hook
          * (mouseHookProc). Any click that reaches the WndProc here is
          * by definition inside the popup's rect — dispatch straight to
@@ -372,6 +489,53 @@ static LRESULT CALLBACK popupWndProc(HWND hwnd, UINT msg, WPARAM w, LPARAM l) {
         dispatchPointer(p, EVT_PTR_DOWN, btn, l);
         return 0;
     }
+
+    case WM_KEYDOWN:
+    case WM_SYSKEYDOWN:
+    case WM_KEYUP:
+    case WM_SYSKEYUP: {
+        /* Standalone panels receive keyboard input directly (owner-based
+         * popups get keys forwarded from the focused host window instead). */
+        if (!p || !p->eventCb || !sOnKeyMethod) break;
+        int type = (msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN) ? 1 : 2;
+        int vk = (int)w;
+        int mods = 0;
+        if (GetKeyState(VK_SHIFT)   & 0x8000) mods |= 0x1;
+        if (GetKeyState(VK_CONTROL) & 0x8000) mods |= 0x2;
+        if (GetKeyState(VK_MENU)    & 0x8000) mods |= 0x4;
+        if ((GetKeyState(VK_LWIN) | GetKeyState(VK_RWIN)) & 0x8000) mods |= 0x8;
+        /* AltGr == right Alt + a synthesized left Ctrl on Windows. Report it
+         * as plain text input, not as a Ctrl+Alt chord (mirrors tao's
+         * filter_out_altgr for the window key path). */
+        if ((GetKeyState(VK_RMENU) & 0x8000) && (mods & 0x2)) mods &= ~(0x2 | 0x4);
+        int codePoint = 0;
+        if (type == 1 && !(mods & 0x2) && !(mods & 0x4)) {
+            BYTE ks[256];
+            if (GetKeyboardState(ks)) {
+                WCHAR buf[4];
+                UINT sc = (UINT)((l >> 16) & 0xFF);
+                /* 0x4 = don't mutate kernel keyboard state (Win10 1607+),
+                 * keeps dead-key handling intact. */
+                int r = ToUnicode((UINT)vk, sc, ks, buf, 4, 0x4);
+                if (r >= 2 && IS_SURROGATE_PAIR(buf[0], buf[1])) {
+                    codePoint = 0x10000 + (((buf[0] - 0xD800) << 10) | (buf[1] - 0xDC00));
+                } else if (r >= 1 && buf[0] >= 0x20) {
+                    codePoint = (int)buf[0];
+                }
+            }
+        }
+        JNIEnv *envK = attachThread();
+        if (envK) {
+            (*envK)->CallVoidMethod(envK, p->eventCb, sOnKeyMethod,
+                (jint)type, (jint)vk, (jint)codePoint, (jint)mods);
+            if ((*envK)->ExceptionCheck(envK)) (*envK)->ExceptionClear(envK);
+        }
+        return 0;
+    }
+    case WM_APP_OUTSIDE_CLICK:
+        if (p) fireOutsideClick(p, (int)w);
+        return 0;
+
     case WM_LBUTTONUP:   if (p) dispatchPointer(p, EVT_PTR_UP,   BTN_PRIMARY, l);   return 0;
     case WM_RBUTTONUP:   if (p) dispatchPointer(p, EVT_PTR_UP,   BTN_SECONDARY, l); return 0;
     case WM_MBUTTONUP:   if (p) dispatchPointer(p, EVT_PTR_UP,   BTN_MIDDLE, l);    return 0;
@@ -432,26 +596,34 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeCreatePanel(
     JNIEnv *env, jclass clazz, jlong parentHwnd, jint xPx, jint yPx, jint widthPx, jint heightPx) {
     (void)clazz;
     if (sJVM == NULL) (*env)->GetJavaVM(env, &sJVM);
+    /* parentHwnd == 0: standalone (ownerless) panel. Coordinates are then
+     * absolute screen coordinates and the panel has no owner window. */
     HWND parent = (HWND)(uintptr_t)parentHwnd;
-    if (!IsWindow(parent)) return 0;
+    if (parentHwnd != 0 && !IsWindow(parent)) return 0;
+    if (parentHwnd == 0) parent = NULL;
     ensureGlobalsInit();
     ensurePopupClassRegistered();
 
     if (widthPx < 1) widthPx = 1;
     if (heightPx < 1) heightPx = 1;
 
-    /* Resolve parent client → screen for initial placement. */
+    /* Resolve parent client → screen for initial placement (coordinates are
+     * already screen-absolute for ownerless panels). */
     POINT origin = {0, 0};
-    ClientToScreen(parent, &origin);
+    if (parent) ClientToScreen(parent, &origin);
 
     DPI_AWARENESS_CONTEXT prevDpi = NULL;
     if (pSetThreadDpiAwarenessContext) {
         prevDpi = pSetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
     }
 
-    /* WS_EX_NOREDIRECTIONBITMAP: see the matching comment in overlay.c. */
+    /* WS_EX_NOREDIRECTIONBITMAP: see the matching comment in overlay.c.
+     * Ownerless panels are topmost: with no owner window there is nothing
+     * keeping them above other applications' windows. */
+    DWORD exStyle = WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW | WS_EX_NOREDIRECTIONBITMAP;
+    if (parent == NULL) exStyle |= WS_EX_TOPMOST;
     HWND hwnd = CreateWindowExW(
-        WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW | WS_EX_NOREDIRECTIONBITMAP,
+        exStyle,
         kPopupClassName, L"",
         WS_POPUP,
         origin.x + xPx, origin.y + yPx, widthPx, heightPx,
@@ -493,7 +665,8 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeSetFrameInWi
     jint contentXPx, jint contentYPx, jint contentWidthPx, jint contentHeightPx) {
     (void)env; (void)clazz;
     PopupState *p = (PopupState *)(uintptr_t)panel;
-    if (!p || !IsWindow(p->gl.hwnd) || !IsWindow(p->parent)) return;
+    if (!p || !IsWindow(p->gl.hwnd)) return;
+    if (p->parent && !IsWindow(p->parent)) return;
     if (widthPx < 1) widthPx = 1;
     if (heightPx < 1) heightPx = 1;
     if (contentWidthPx < 1) contentWidthPx = 1;
@@ -503,7 +676,7 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeSetFrameInWi
     p->contentWidth = (int)contentWidthPx;
     p->contentHeight = (int)contentHeightPx;
     POINT origin = {0, 0};
-    ClientToScreen(p->parent, &origin);
+    if (p->parent) ClientToScreen(p->parent, &origin);
     SetWindowPos(p->gl.hwnd, NULL,
         origin.x + xPx, origin.y + yPx, widthPx, heightPx,
         SWP_NOACTIVATE | SWP_NOZORDER);
@@ -575,7 +748,11 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeInstallOutsi
      * as inactive. */
     if (!p->outsideMonitorActive) {
         p->outsideMonitorActive = TRUE;
-        installMouseHookIfNeeded();
+        if (p->parent == NULL) {
+            installMouseHookLLIfNeeded();
+        } else {
+            installMouseHookIfNeeded();
+        }
     }
 }
 
@@ -587,7 +764,11 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeUninstallOut
     if (!p) return;
     if (p->outsideMonitorActive) {
         p->outsideMonitorActive = FALSE;
-        uninstallMouseHookIfLast();
+        if (p->parent == NULL) {
+            uninstallMouseHookLLIfLast();
+        } else {
+            uninstallMouseHookIfLast();
+        }
     }
     if (p->outsideListener) {
         (*env)->DeleteGlobalRef(env, p->outsideListener);
@@ -605,7 +786,11 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeRelease(
      * before release (e.g., layer torn down without flushing). */
     if (p->outsideMonitorActive) {
         p->outsideMonitorActive = FALSE;
-        uninstallMouseHookIfLast();
+        if (p->parent == NULL) {
+            uninstallMouseHookLLIfLast();
+        } else {
+            uninstallMouseHookIfLast();
+        }
     }
     chainRemove(p);
     nucleus_tao_overlay_gl_destroy(&p->gl);
@@ -616,4 +801,78 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeRelease(
     if (p->eventCb) { (*env)->DeleteGlobalRef(env, p->eventCb); p->eventCb = NULL; }
     if (p->outsideListener) { (*env)->DeleteGlobalRef(env, p->outsideListener); p->outsideListener = NULL; }
     HeapFree(GetProcessHeap(), 0, p);
+}
+
+/* Maps a TaoCursorIcon constant (NativeTaoBridge.kt) to a system cursor for
+ * the panel's client area (consumed by WM_SETCURSOR above). */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeSetPanelCursor(
+    JNIEnv *env, jclass clazz, jlong panel, jint kind)
+{
+    (void)env; (void)clazz;
+    PopupState *p = (PopupState *)(uintptr_t)panel;
+    if (!p) return;
+    LPCWSTR id;
+    switch (kind) {
+        case 1:  id = (LPCWSTR)IDC_IBEAM;       break; /* TEXT */
+        case 2:  id = (LPCWSTR)IDC_HAND;        break; /* HAND */
+        case 3:  id = (LPCWSTR)IDC_CROSS;       break; /* CROSSHAIR */
+        case 4:  id = (LPCWSTR)IDC_WAIT;        break; /* WAIT */
+        case 5:  id = (LPCWSTR)IDC_SIZEALL;     break; /* MOVE */
+        case 6:  id = (LPCWSTR)IDC_NO;          break; /* NOT_ALLOWED */
+        case 7:  id = (LPCWSTR)IDC_HELP;        break; /* HELP */
+        case 8:  id = (LPCWSTR)IDC_APPSTARTING; break; /* PROGRESS */
+        case 9:  id = (LPCWSTR)IDC_SIZEWE;      break; /* EW_RESIZE */
+        case 10: id = (LPCWSTR)IDC_SIZENS;      break; /* NS_RESIZE */
+        case 11: id = (LPCWSTR)IDC_SIZENESW;    break; /* NESW_RESIZE */
+        case 12: id = (LPCWSTR)IDC_SIZENWSE;    break; /* NWSE_RESIZE */
+        default: id = (LPCWSTR)IDC_ARROW;       break; /* DEFAULT */
+    }
+    p->cursor = LoadCursorW(NULL, id);
+    /* Refresh immediately when the pointer is already over the panel. */
+    POINT pt;
+    if (GetCursorPos(&pt) && IsWindow(p->gl.hwnd)
+        && WindowFromPoint(pt) == p->gl.hwnd) {
+        SetCursor(p->cursor);
+    }
+}
+
+/* System timer resolution, refcounted. Without timeBeginPeriod(1) the JVM's
+ * scheduled executors wake on the default ~15.6 ms quantum, so a 16.7 ms
+ * frame pace degenerates to ~30 fps with visible stutter. Enabled only
+ * while an animated panel is visible (power cost when idle). */
+static LONG sHighResTimerRefcount = 0;
+
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeSetHighResTimer(
+    JNIEnv *env, jclass clazz, jboolean enable)
+{
+    (void)env; (void)clazz;
+    if (enable) {
+        if (InterlockedIncrement(&sHighResTimerRefcount) == 1) timeBeginPeriod(1);
+    } else {
+        if (InterlockedDecrement(&sHighResTimerRefcount) == 0) timeEndPeriod(1);
+    }
+}
+
+/* Shows/hides the panel without releasing it. SW_SHOWNOACTIVATE keeps the
+ * non-activating contract. */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeSetPanelVisible(
+    JNIEnv *env, jclass clazz, jlong panel, jboolean visible)
+{
+    (void)env; (void)clazz;
+    PopupState *p = (PopupState *)(uintptr_t)panel;
+    if (!p || !IsWindow(p->gl.hwnd)) return;
+    ShowWindow(p->gl.hwnd, visible ? SW_SHOWNOACTIVATE : SW_HIDE);
+    /* Re-assert the topmost slot on show: focus round-trips through other
+     * applications can leave the panel below newer topmost windows. */
+    if (visible && p->parent == NULL) {
+        SetWindowPos(p->gl.hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        /* Focusable tray-style popups take keyboard focus on show, so the
+         * user can type without clicking inside first (same behavior as the
+         * Windows clock/network flyouts). */
+        if (p->focusable) takeKeyboardFocus(p->gl.hwnd);
+    }
 }

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -239,6 +239,22 @@
             ]
         },
         {
+            "type": "dev.nucleusframework.window.tao.render.TaoStandalonePopupHost$PanelEventCallback",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onPointerEvent", "parameterTypes": ["int","float","float","int","int"] },
+                { "name": "onScroll",       "parameterTypes": ["float","float","float","float"] },
+                { "name": "onKeyEvent",     "parameterTypes": ["int","int","int","int"] }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.render.TaoStandalonePopupHost$PanelOutsideClickListener",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onOutsideClick", "parameterTypes": ["int","int"] }
+            ]
+        },
+        {
             "type": "dev.nucleusframework.window.tao.render.TaoPopupSceneLayer$PopupEventCallback",
             "jniAccessible": true,
             "methods": [

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelNativeSmokeTest.kt
@@ -1,0 +1,53 @@
+package dev.nucleusframework.window.tao
+
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.GLAssembledInterface
+import org.jetbrains.skia.makeGLWithInterface
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the native chain behind the standalone popup panel without any
+ * Tao event loop: headless EGL context bootstrap, ownerless panel creation,
+ * context binding and Skia DirectContext creation. Windows-only.
+ */
+class StandalonePanelNativeSmokeTest {
+    @Test
+    fun standalonePanelPipelineInitializes() {
+        if (!System.getProperty("os.name", "").lowercase().contains("win")) return
+
+        assertTrue(NativeTaoGlBridge.isLoaded, "nucleus_tao_gl failed to load")
+        assertTrue(PopupNativeBridgeWindows.isLoaded, "nucleus_tao_windows_native_view failed to load")
+        assertTrue(
+            NativeTaoGlBridge.nativeEnsureHeadlessContext(),
+            "headless EGL context bootstrap failed",
+        )
+
+        val panel =
+            PopupNativeBridgeWindows.nativeCreatePanel(
+                parentHwnd = 0L,
+                xPx = -32_000,
+                yPx = -32_000,
+                widthPx = 300,
+                heightPx = 200,
+            )
+        assertNotEquals(0L, panel, "ownerless panel creation failed")
+
+        try {
+            assertTrue(
+                PopupNativeBridgeWindows.nativeMakeCurrent(panel),
+                "nativeMakeCurrent failed on standalone panel",
+            )
+            val intf =
+                GLAssembledInterface.createFromNativePointers(
+                    0L,
+                    NativeTaoGlBridge.nativeEglGetProcFn(),
+                )
+            val ctx = DirectContext.makeGLWithInterface(intf)
+            ctx.close()
+        } finally {
+            PopupNativeBridgeWindows.nativeRelease(panel)
+        }
+    }
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -39,6 +39,11 @@ fun NucleusApplicationScope.DecoratedWindow(
     // parent-relative). For cursor-following overlays such as drag ghosts.
     // Ignored by the AWT backend and on macOS/Windows.
     popupFor: NucleusWindow? = null,
+    // Materialise Compose Popup layers as native transparent windows
+    // (NSPanel / WS_POPUP HWND) instead of drawing them inline in this
+    // window's render target. Honoured by the Tao backend on Windows/macOS;
+    // ignored by AWT and on Linux.
+    nativePopupLayers: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -92,6 +97,7 @@ fun NucleusApplicationScope.DecoratedWindow(
                 alwaysOnTop = alwaysOnTop,
                 undecorated = undecorated,
                 popupFor = popupFor,
+                nativePopupLayers = nativePopupLayers,
                 minimumSize = minimumSize,
                 onPreviewKeyEvent = onPreviewKeyEvent,
                 onKeyEvent = onKeyEvent,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/SingleInstanceRestoreBus.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/SingleInstanceRestoreBus.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import dev.nucleusframework.core.runtime.DeepLinkHandler
 import dev.nucleusframework.core.runtime.SingleInstanceManager
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,6 +26,24 @@ internal object SingleInstanceRestoreBus {
 
     fun fire() {
         _signal.value = _signal.value + 1
+    }
+}
+
+/**
+ * Runs [onRestore] whenever a second instance of the application attempts to
+ * launch while this process holds the single-instance lock (requires
+ * `nucleusApplication(enableSingleInstance = true)`).
+ *
+ * Windows created through [DecoratedWindow] already restore themselves
+ * (shown, un-minimized, focused); use this hook when the app's main surface
+ * is something else — typically a tray application re-opening its popup.
+ */
+@Composable
+fun SingleInstanceRestoreEffect(onRestore: () -> Unit) {
+    val signal by SingleInstanceRestoreBus.signal.collectAsState()
+    val currentOnRestore = rememberUpdatedState(onRestore)
+    LaunchedEffect(signal) {
+        if (signal != 0) currentOnRestore.value()
     }
 }
 

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -44,6 +44,7 @@ internal object TaoDecoratedWindowAdapter {
         alwaysOnTop: Boolean,
         undecorated: Boolean,
         popupFor: NucleusWindow?,
+        nativePopupLayers: Boolean,
         minimumSize: DpSize?,
         onPreviewKeyEvent: (KeyEvent) -> Boolean,
         onKeyEvent: (KeyEvent) -> Boolean,
@@ -70,6 +71,7 @@ internal object TaoDecoratedWindowAdapter {
                 alwaysOnTop = alwaysOnTop,
                 undecorated = undecorated,
                 popupFor = popupFor?.unsafe?.taoWindow,
+                nativePopupLayers = nativePopupLayers,
                 onPreviewKeyEvent = onPreviewKeyEvent,
                 onKeyEvent = onKeyEvent,
             ) {


### PR DESCRIPTION
## What

Infrastructure for tray-style applications on the Tao backend: a popup that renders in a **top-level, ownerless, per-pixel transparent native panel** — no backing window (nothing in taskbar / Alt-Tab / task view), no host render loop. Built for and consumed by ComposeNativeTray's `TrayApp`.

## New public API

- **`TaoStandalonePopup`** (Windows, no-op elsewhere): visibility, absolute dp positioning, focusability, outside-click + key handlers; bridges the caller's composition locals into the panel's scene (reactively — dark-mode switches propagate).
- **`TaoScreenGeometry`**: primary-monitor work area / scale factor without needing a `TaoWindow`.
- **`DecoratedWindow(nativePopupLayers = true)`**: opt-in `PlatformLayersComposeScene` so regular Compose `Popup`s materialize as native transparent panels.
- **`SingleInstanceRestoreEffect`** (nucleus-application): fires when a second instance attempts to launch — for apps whose main surface is not a decorated window (tray apps re-opening their popup).

## Implementation notes

- **Rendering**: ownerless `WS_POPUP` + `NOACTIVATE|TOOLWINDOW|NOREDIRECTIONBITMAP|TOPMOST`, DComp premultiplied alpha, own `CanvasLayersComposeScene`, on-demand rendering on the Tao main thread. Pacing runs on an absolute 60 fps grid with evenly spaced frame-clock timestamps; `timeBeginPeriod(1)` (refcounted) only while a panel is visible — without it the JVM scheduler's ~15.6 ms quantum halves the frame rate.
- **Headless EGL bootstrap** (`nativeEnsureHeadlessContext`): creates the shared ANGLE context before any window host exists, so tray-only apps work.
- **Outside-click**: global `WH_MOUSE_LL` for ownerless panels (a thread-local `WH_MOUSE` never sees clicks on other apps). The LL hook never calls into Java — it `PostMessage`s to the panel and the WndProc does the JNI upcall (LowLevelHooksTimeout safety). Hook refcounts count requests and retry on failed installs.
- **Keyboard**: focus acquisition on click and on show (`GetForegroundWindow` comparison + `AttachThreadInput` to bypass the foreground lock), AltGr filtered as text input (mirrors tao's `filter_out_altgr`), surrogate-pair code points.
- **Key dispatch factored** into `ComposeScene.dispatchNativeKeyEvent` (used by both popup layers, the macOS overlay and the standalone panel). Fixes `keyLocation = UNKNOWN` making `Key.*` constants (Backspace/Enter/arrows) unmatchable, and adds the missing synthetic KEY_TYPED to the Windows popup-layer path.
- **GraalVM**: reachability metadata for the new JNI callbacks (named inner classes).

## Testing

- `StandalonePanelNativeSmokeTest`: headless EGL bootstrap → ownerless panel → EGL make-current → Skia DirectContext, without a Tao event loop.
- Validated end-to-end by ComposeNativeTray's TrayApp demo on Windows 11 (JVM + GraalVM native image): display, animations, outside-click on other apps/desktop, text input incl. AZERTY AltGr, Backspace/arrows, I-beam cursor, topmost.