### PR TITLE
feat(tao): macOS standalone transparent popup panel

### DIFF
--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -97,6 +97,25 @@ tasks.configureEach {
     }
 }
 
+// ── macOS standalone-popup smoke check ──────────────────────────────────────
+// AppKit requires the NSPanel to be created on the macOS main thread. Gradle's
+// test worker runs tests off the main thread, so the macOS smoke check runs as
+// a main() via JavaExec (process main thread = macOS main thread). Windows uses
+// the in-process JUnit test in StandalonePanelNativeSmokeTest.
+
+val smokeStandalonePanelMac by tasks.registering(JavaExec::class) {
+    description = "Smoke-checks the macOS standalone-popup native chain (ownerless NSPanel + Metal)"
+    group = "verification"
+    onlyIf { Os.isFamily(Os.FAMILY_MAC) }
+    classpath = sourceSets.test.get().runtimeClasspath
+    mainClass.set("dev.nucleusframework.window.tao.StandalonePanelMacSmokeMain")
+    // Run main() on thread 0 (the macOS main thread). The JVM normally runs
+    // main() on a spawned pthread, but AppKit only permits NSWindow/NSPanel
+    // creation on the true main thread. -XstartOnFirstThread is the same flag
+    // LWJGL/GLFW use on macOS.
+    jvmArgs("-XstartOnFirstThread")
+}
+
 // ── Maven publication ──────────────────────────────────────────────────────
 
 mavenPublishing {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridge.kt
@@ -58,6 +58,21 @@ internal object PopupNativeBridge {
         heightPx: Int,
     )
 
+    /**
+     * Repositions an ownerless (standalone) panel on the primary screen using
+     * top-left-origin physical pixels. The standalone counterpart of
+     * [nativeSetFrameInWindow]: no parent window, AppKit Y is flipped against
+     * the full screen frame (menu bar included) on the native side.
+     */
+    @JvmStatic
+    external fun nativeSetFrameOnScreen(
+        panel: Long,
+        xPx: Int,
+        yPx: Int,
+        widthPx: Int,
+        heightPx: Int,
+    )
+
     /** Brings the panel front (regardless of activation state). */
     @JvmStatic
     external fun nativeOrderFront(panel: Long)
@@ -151,6 +166,17 @@ internal object PopupNativeBridge {
     external fun nativeSetIgnoresMouseEvents(
         panel: Long,
         ignore: Boolean,
+    )
+
+    /**
+     * Applies a [TaoCursorIcon] code to the panel: stored on the content view
+     * (re-asserted by AppKit's `cursorUpdate:`) and set immediately while the
+     * panel is visible.
+     */
+    @JvmStatic
+    external fun nativeSetPanelCursor(
+        panel: Long,
+        iconCode: Int,
     )
 
     /** Installs the JNI [EventCallback] on the panel's content view. Pass `null` to remove. */

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridgeWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridgeWindows.kt
@@ -12,6 +12,7 @@ import dev.nucleusframework.core.runtime.NativeLibraryLoader
  * side compares clicks against the logical content rect, not the inflated
  * draw-bounds HWND used for Compose-drawn elevation.
  */
+@Suppress("TooManyFunctions")
 internal object PopupNativeBridgeWindows {
     private const val LIBRARY_NAME = "nucleus_tao_windows_native_view"
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
@@ -14,19 +14,24 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.window.WindowPosition
 import dev.nucleusframework.core.runtime.Platform
+import dev.nucleusframework.window.tao.render.StandalonePopupHost
 import dev.nucleusframework.window.tao.render.TaoStandalonePopupHost
+import dev.nucleusframework.window.tao.render.TaoStandalonePopupHostMac
 
 /**
- * Standalone transparent popup (Windows only): a top-level, ownerless,
+ * Standalone transparent popup (Windows + macOS): a top-level, ownerless,
  * non-activating native panel with per-pixel transparency, hosting [content]
  * in its own Compose scene. There is no backing "window" anywhere — nothing
- * appears in the taskbar, Alt-Tab or the Start task view — and rendering is
- * driven on demand (no owner window render loop). Built for system-tray
- * popups.
+ * appears in the taskbar/Dock or the app switcher — and rendering is driven on
+ * demand (no owner window render loop). Built for system-tray popups.
+ *
+ * Windows uses an ownerless `WS_POPUP` + DComp surface; macOS uses an ownerless
+ * non-activating `NSPanel` + `CAMetalLayer`. Linux has no equivalent that works
+ * across WMs, so on Linux (or when the native pipeline is unavailable) the
+ * composable is a no-op.
  *
  * Must be called inside `taoApplication { }` (directly or through
- * `nucleusApplication` on the Tao backend). On non-Windows platforms, or when
- * the native pipeline is unavailable, the composable is a no-op.
+ * `nucleusApplication` on the Tao backend).
  *
  * @param visible shows/hides the panel; the composition (and [content] state)
  *   is retained while hidden.
@@ -34,7 +39,8 @@ import dev.nucleusframework.window.tao.render.TaoStandalonePopupHost
  * @param size panel size in dp.
  * @param focusable whether the panel can take keyboard focus on click.
  * @param onOutsideClick invoked when the user clicks anywhere outside the
- *   panel while it is visible (native mouse-hook, fires on mouse-down).
+ *   panel while it is visible (native mouse-hook / NSEvent monitor, fires on
+ *   mouse-down).
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
@@ -48,12 +54,19 @@ fun TaoStandalonePopup(
     onKeyEvent: ((KeyEvent) -> Boolean)? = null,
     content: @Composable () -> Unit,
 ) {
-    if (Platform.Current != Platform.Windows) return
+    // Linux has no cross-WM transparency equivalent — no-op there.
+    if (Platform.Current != Platform.Windows && Platform.Current != Platform.MacOS) return
 
     // Native resources are allocated inside remember{}: if the composition
     // is abandoned before DisposableEffect registers, the panel leaks.
     // Standard Compose caveat, negligible for an application-scoped popup.
-    val host = remember { TaoStandalonePopupHost() }
+    val host: StandalonePopupHost =
+        remember {
+            when (Platform.Current) {
+                Platform.MacOS -> TaoStandalonePopupHostMac()
+                else -> TaoStandalonePopupHost()
+            }
+        }
     if (!host.isValid) return
 
     DisposableEffect(Unit) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/StandalonePopupHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/StandalonePopupHost.kt
@@ -1,0 +1,37 @@
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.key.KeyEvent
+
+/**
+ * Platform-agnostic surface for a standalone transparent popup panel.
+ * Implemented per-platform: [TaoStandalonePopupHost] (Windows, EGL/DComp) and
+ * [TaoStandalonePopupHostMac] (macOS, Metal/CAMetalLayer). Lets
+ * `dev.nucleusframework.window.tao.TaoStandalonePopup` route per platform
+ * without a per-platform composable.
+ */
+internal interface StandalonePopupHost {
+    val isValid: Boolean
+    val scale: Float
+
+    var onPreviewKeyEvent: ((KeyEvent) -> Boolean)?
+    var onKeyEvent: ((KeyEvent) -> Boolean)?
+
+    fun setContent(content: @Composable () -> Unit)
+
+    /** Logical (dp) screen position and size of the panel. */
+    fun setFrame(
+        xDp: Float,
+        yDp: Float,
+        widthDp: Float,
+        heightDp: Float,
+    )
+
+    fun setVisible(visible: Boolean)
+
+    fun setFocusable(focusable: Boolean)
+
+    fun setOutsideClickListener(listener: (() -> Unit)?)
+
+    fun dispose()
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoKeyMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoKeyMac.kt
@@ -1,0 +1,167 @@
+@file:Suppress("MagicNumber")
+
+package dev.nucleusframework.window.tao.render
+
+/**
+ * Maps macOS hardware virtual key codes (`NSEvent.keyCode`, the Carbon
+ * `kVK_*` values) to the AWT `KeyEvent.VK_*` codes + key location that
+ * Compose's desktop `Key` constants are declared with.
+ *
+ * Needed by every scene fed straight from an AppKit event callback
+ * (popup panels, standalone panels, native-view overlays): the window host
+ * path gets this translation from the Rust side (`keymap.rs`), but the
+ * ObjC popup callbacks forward `NSEvent.keyCode` raw. Without translation
+ * every non-character key is unmatchable (Backspace = 51 = AWT '3') and
+ * Cmd shortcuts hit the wrong keys (kVK_ANSI_C = 8 = AWT Backspace).
+ *
+ * Letter and digit keys are resolved from the produced character when
+ * available so the mapping follows the active keyboard layout (AZERTY,
+ * Dvorak…); the physical-position table is the fallback for combos whose
+ * character is a control char (e.g. Ctrl+letter).
+ */
+@Suppress("CyclomaticComplexMethod", "LongMethod") // flat lookup table, not logic
+internal fun macNativeKeyToAwt(
+    vkCode: Int,
+    codePoint: Int,
+): Pair<Int, Int> {
+    // Layout-aware fast path: the character the key produced.
+    if (codePoint in LOWER_A..LOWER_Z) return (codePoint - CASE_OFFSET) to LOC_STANDARD
+    if (codePoint in UPPER_A..UPPER_Z) return codePoint to LOC_STANDARD
+    if (codePoint in DIGIT_0..DIGIT_9 && !isMacKeypadKey(vkCode)) return codePoint to LOC_STANDARD
+
+    return when (vkCode) {
+        // ── Editing / whitespace / escape ──
+        36 -> 10 to LOC_STANDARD // Return → VK_ENTER
+        48 -> 9 to LOC_STANDARD // Tab
+        49 -> 32 to LOC_STANDARD // Space
+        51 -> 8 to LOC_STANDARD // Delete → VK_BACK_SPACE
+        53 -> 27 to LOC_STANDARD // Escape
+        117 -> 127 to LOC_STANDARD // ForwardDelete → VK_DELETE
+
+        // ── Modifiers ──
+        55 -> 157 to LOC_LEFT // Command → VK_META
+        54 -> 157 to LOC_RIGHT
+        56 -> 16 to LOC_LEFT // Shift
+        60 -> 16 to LOC_RIGHT
+        58 -> 18 to LOC_LEFT // Option → VK_ALT
+        61 -> 18 to LOC_RIGHT
+        59 -> 17 to LOC_LEFT // Control
+        62 -> 17 to LOC_RIGHT
+        57 -> 20 to LOC_STANDARD // CapsLock
+
+        // ── Navigation ──
+        115 -> 36 to LOC_STANDARD // Home
+        119 -> 35 to LOC_STANDARD // End
+        116 -> 33 to LOC_STANDARD // PageUp
+        121 -> 34 to LOC_STANDARD // PageDown
+        123 -> 37 to LOC_STANDARD // Left
+        124 -> 39 to LOC_STANDARD // Right
+        125 -> 40 to LOC_STANDARD // Down
+        126 -> 38 to LOC_STANDARD // Up
+        114 -> 156 to LOC_STANDARD // Help
+
+        // ── Function keys ──
+        122 -> 112 to LOC_STANDARD // F1
+        120 -> 113 to LOC_STANDARD // F2
+        99 -> 114 to LOC_STANDARD // F3
+        118 -> 115 to LOC_STANDARD // F4
+        96 -> 116 to LOC_STANDARD // F5
+        97 -> 117 to LOC_STANDARD // F6
+        98 -> 118 to LOC_STANDARD // F7
+        100 -> 119 to LOC_STANDARD // F8
+        101 -> 120 to LOC_STANDARD // F9
+        109 -> 121 to LOC_STANDARD // F10
+        103 -> 122 to LOC_STANDARD // F11
+        111 -> 123 to LOC_STANDARD // F12
+
+        // ── Keypad ──
+        82 -> 96 to LOC_NUMPAD // 0
+        83 -> 97 to LOC_NUMPAD
+        84 -> 98 to LOC_NUMPAD
+        85 -> 99 to LOC_NUMPAD
+        86 -> 100 to LOC_NUMPAD
+        87 -> 101 to LOC_NUMPAD
+        88 -> 102 to LOC_NUMPAD
+        89 -> 103 to LOC_NUMPAD
+        91 -> 104 to LOC_NUMPAD
+        92 -> 105 to LOC_NUMPAD // 9
+        65 -> 110 to LOC_NUMPAD // Decimal
+        67 -> 106 to LOC_NUMPAD // Multiply
+        69 -> 107 to LOC_NUMPAD // Plus → VK_ADD
+        78 -> 109 to LOC_NUMPAD // Minus → VK_SUBTRACT
+        75 -> 111 to LOC_NUMPAD // Divide
+        76 -> 10 to LOC_NUMPAD // KeypadEnter
+        71 -> 12 to LOC_NUMPAD // Clear
+        81 -> 61 to LOC_NUMPAD // Equals
+
+        // ── ANSI punctuation (physical positions) ──
+        24 -> 61 to LOC_STANDARD // Equal
+        27 -> 45 to LOC_STANDARD // Minus
+        30 -> 93 to LOC_STANDARD // RightBracket
+        33 -> 91 to LOC_STANDARD // LeftBracket
+        39 -> 222 to LOC_STANDARD // Quote
+        41 -> 59 to LOC_STANDARD // Semicolon
+        42 -> 92 to LOC_STANDARD // Backslash
+        43 -> 44 to LOC_STANDARD // Comma
+        44 -> 47 to LOC_STANDARD // Slash
+        47 -> 46 to LOC_STANDARD // Period
+        50 -> 192 to LOC_STANDARD // Grave
+
+        // ── ANSI letters/digits (fallback when the character is a control char) ──
+        0 -> 'A'.code to LOC_STANDARD
+        1 -> 'S'.code to LOC_STANDARD
+        2 -> 'D'.code to LOC_STANDARD
+        3 -> 'F'.code to LOC_STANDARD
+        4 -> 'H'.code to LOC_STANDARD
+        5 -> 'G'.code to LOC_STANDARD
+        6 -> 'Z'.code to LOC_STANDARD
+        7 -> 'X'.code to LOC_STANDARD
+        8 -> 'C'.code to LOC_STANDARD
+        9 -> 'V'.code to LOC_STANDARD
+        11 -> 'B'.code to LOC_STANDARD
+        12 -> 'Q'.code to LOC_STANDARD
+        13 -> 'W'.code to LOC_STANDARD
+        14 -> 'E'.code to LOC_STANDARD
+        15 -> 'R'.code to LOC_STANDARD
+        16 -> 'Y'.code to LOC_STANDARD
+        17 -> 'T'.code to LOC_STANDARD
+        31 -> 'O'.code to LOC_STANDARD
+        32 -> 'U'.code to LOC_STANDARD
+        34 -> 'I'.code to LOC_STANDARD
+        35 -> 'P'.code to LOC_STANDARD
+        37 -> 'L'.code to LOC_STANDARD
+        38 -> 'J'.code to LOC_STANDARD
+        40 -> 'K'.code to LOC_STANDARD
+        45 -> 'N'.code to LOC_STANDARD
+        46 -> 'M'.code to LOC_STANDARD
+        18 -> '1'.code to LOC_STANDARD
+        19 -> '2'.code to LOC_STANDARD
+        20 -> '3'.code to LOC_STANDARD
+        21 -> '4'.code to LOC_STANDARD
+        23 -> '5'.code to LOC_STANDARD
+        22 -> '6'.code to LOC_STANDARD
+        26 -> '7'.code to LOC_STANDARD
+        28 -> '8'.code to LOC_STANDARD
+        25 -> '9'.code to LOC_STANDARD
+        29 -> '0'.code to LOC_STANDARD
+
+        else -> 0 to LOC_STANDARD // Key.Unknown
+    }
+}
+
+private fun isMacKeypadKey(vkCode: Int): Boolean = vkCode in 82..92 || vkCode in KEYPAD_OPERATORS
+
+private val KEYPAD_OPERATORS = setOf(65, 67, 69, 71, 75, 76, 78, 81)
+
+private const val LOC_STANDARD = java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
+private const val LOC_LEFT = java.awt.event.KeyEvent.KEY_LOCATION_LEFT
+private const val LOC_RIGHT = java.awt.event.KeyEvent.KEY_LOCATION_RIGHT
+private const val LOC_NUMPAD = java.awt.event.KeyEvent.KEY_LOCATION_NUMPAD
+
+private const val LOWER_A = 'a'.code
+private const val LOWER_Z = 'z'.code
+private const val UPPER_A = 'A'.code
+private const val UPPER_Z = 'Z'.code
+private const val DIGIT_0 = '0'.code
+private const val DIGIT_9 = '9'.code
+private const val CASE_OFFSET = 32

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupSceneLayer.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupSceneLayer.kt
@@ -162,11 +162,19 @@ internal class TaoPopupSceneLayer(
      * default (false) leaves text fields uneditable. We always say "yes,
      * focused" because the popup, by virtue of being on screen via Compose
      * intent, is logically focused from the app's perspective.
+     *
+     * `containerSize` MUST be the work-area-sized [sceneLayoutSize], not the
+     * owner window (or popup) size: `Popup.skiko.kt` composes its measure
+     * policy inside this layer's scene and, with `clippingEnabled` (the
+     * default), clamps the popup position into `LocalWindowInfo.containerSize`
+     * (`clipPosition`). Reporting the owner window size here pins every popup
+     * inside the window — the whole point of native popup layers is to escape
+     * it. Same contract as [TaoPopupSceneLayerWindows]'s popupWindowInfo.
      */
     private val popupWindowInfo: androidx.compose.ui.platform.WindowInfo =
         object : androidx.compose.ui.platform.WindowInfo {
             override val isWindowFocused: Boolean = true
-            override val containerSize: IntSize get() = IntSize(widthPx, heightPx)
+            override val containerSize: IntSize get() = sceneLayoutSize
         }
 
     private val innerScene: ComposeScene =

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoStandalonePopupHostMac.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoStandalonePopupHostMac.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
@@ -17,15 +16,16 @@ import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
-import dev.nucleusframework.window.tao.NativeTaoGlBridge
-import dev.nucleusframework.window.tao.PopupNativeBridgeWindows
+import dev.nucleusframework.window.tao.NativeMetalBridge
+import dev.nucleusframework.window.tao.PopupNativeBridge
 import dev.nucleusframework.window.tao.TaoCursorIcon
 import dev.nucleusframework.window.tao.TaoMainDispatcher
 import dev.nucleusframework.window.tao.TaoScreenGeometry
+import dev.nucleusframework.window.tao.toTaoCursorIconCode
 import org.jetbrains.skia.DirectContext
-import org.jetbrains.skia.GLAssembledInterface
-import org.jetbrains.skia.makeGLWithInterface
+import java.util.concurrent.Callable
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -34,15 +34,21 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.roundToInt
 
 /**
- * Standalone transparent popup surface (Windows): a top-level, ownerless
- * `WS_POPUP` HWND with `WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW` and a per-pixel
- * transparent DComp-presented surface, driving its own Compose scene.
+ * Standalone transparent popup surface (macOS): an ownerless, non-activating
+ * `NSPanel` with a per-pixel transparent `CAMetalLayer`, driving its own Compose
+ * scene. The macOS counterpart of [TaoStandalonePopupHost] (Windows): same
+ * public surface so [dev.nucleusframework.window.tao.TaoStandalonePopup] can
+ * route per platform without a per-platform composable.
  *
- * Unlike [TaoPopupSceneLayerWindows] it has no owner window and no host render
- * loop: rendering runs on demand on the Tao main thread whenever the scene
- * invalidates (recomposition, animation frame, input). No `WM_PAINT` is
- * involved, so the panel works without any visible window in the process —
- * the backbone of tray-style popups.
+ * Differences from the Windows host:
+ *  - No headless EGL bootstrap and no `WM_PAINT`; the panel is ownerless and
+ *    rendering is driven purely on demand (scene invalidate → scheduleRender).
+ *  - Metal, not OpenGL: the Skia [DirectContext] is created on — and only ever
+ *    used on — a dedicated render thread (Skia's Metal context is thread-affine,
+ *    and `[CAMetalLayer nextDrawable]` can block, so the Tao main loop stays
+ *    free). Each frame is **recorded** into a Skia `Picture` on the main thread
+ *    (Compose state lives there) then **replayed + presented** on the render
+ *    thread, reusing [recordSceneToPicture] / [replayPictureToFrame].
  *
  * Threading: construction and every public method must run on the Tao main
  * thread (the composable wrapper guarantees this). Rendering is scheduled
@@ -50,19 +56,18 @@ import kotlin.math.roundToInt
  * content (animations).
  */
 @OptIn(InternalComposeUiApi::class)
-internal class TaoStandalonePopupHost : StandalonePopupHost {
+internal class TaoStandalonePopupHostMac : StandalonePopupHost {
     override val isValid: Boolean
 
     private var panel: Long = 0
+    private var attachmentHandle: Long = 0
     private var directContext: DirectContext? = null
     private var scene: ComposeScene? = null
     private var disposed = false
 
     /**
-     * Primary-monitor scale, captured once: a tray popup lives on the
-     * primary monitor by definition. Mixed-DPI multi-monitor setups and
-     * live DPI changes are NOT tracked (would need WM_DPICHANGED plumbing
-     * plus per-position monitor lookup).
+     * Primary-monitor scale, captured once: a tray popup lives on the primary
+     * monitor by definition. Live DPI changes are NOT tracked.
      */
     override val scale: Float = TaoScreenGeometry.primaryMonitorScaleFactor()
 
@@ -77,45 +82,52 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     private val windowInfo = StandalonePopupWindowInfo()
 
     private val renderPending = AtomicBoolean(false)
+    private val replayInFlight = AtomicBoolean(false)
     private var nextFrameNs = 0L
     private var visible = false
 
+    // Declared before the init block: the init block calls runOnRenderThread to
+    // create the Skia DirectContext, and Kotlin runs property initializers +
+    // init blocks in declaration order — a later-declared executor would be
+    // null at that point. (Skia's Metal context is thread-affine, so it is owned
+    // by this single-thread executor for the lifetime of the host.)
+    private val renderExecutor: ExecutorService =
+        Executors.newSingleThreadExecutor { r ->
+            Thread(r, "TaoStandalonePopupMetalRender").apply { isDaemon = true }
+        }
+
     init {
         var valid = false
-        if (!NativeTaoGlBridge.isLoaded || !PopupNativeBridgeWindows.isLoaded) {
+        if (!NativeMetalBridge.isLoaded || !PopupNativeBridge.isLoaded) {
             logger.warning("Standalone popup unavailable: native bridges not loaded")
-        } else if (!runCatching { NativeTaoGlBridge.nativeEnsureHeadlessContext() }
-                .onFailure { logger.warning("Standalone popup unavailable: $it") }
-                .getOrDefault(false)
-        ) {
-            logger.warning("Standalone popup unavailable: headless EGL bootstrap failed")
         } else {
+            // Ownerless panel: parentNsView = 0 → native takes the screen-coord
+            // ownerless branch (no parent window, no addChildWindow).
             panel =
-                PopupNativeBridgeWindows.nativeCreatePanel(
-                    parentHwnd = 0L,
+                PopupNativeBridge.nativeCreatePanel(
+                    parentNsView = 0L,
                     xPx = HIDDEN_X_PX,
                     yPx = HIDDEN_Y_PX,
                     widthPx = 1,
                     heightPx = 1,
                 )
             if (panel == 0L) {
-                logger.warning("Standalone popup unavailable: panel creation failed")
+                logger.warning("Standalone popup unavailable: ownerless panel creation failed")
             } else {
-                PopupNativeBridgeWindows.nativeSetPanelVisible(panel, false)
-                directContext =
-                    if (PopupNativeBridgeWindows.nativeMakeCurrent(panel)) {
-                        runCatching {
-                            val intf =
-                                GLAssembledInterface.createFromNativePointers(
-                                    0L,
-                                    NativeTaoGlBridge.nativeEglGetProcFn(),
-                                )
-                            DirectContext.makeGLWithInterface(intf)
-                        }.getOrNull()
-                    } else {
-                        null
-                    }
-                if (directContext != null) {
+                val contentNsView = PopupNativeBridge.nativeContentNsView(panel)
+                attachmentHandle = NativeMetalBridge.nativeAttachOverlay(contentNsView)
+                if (attachmentHandle == 0L) {
+                    logger.warning("Standalone popup unavailable: CAMetalLayer attach failed")
+                    PopupNativeBridge.nativeRelease(panel)
+                    panel = 0
+                } else {
+                    NativeMetalBridge.nativeResize(attachmentHandle, 1, 1, scale)
+                    // Skia's Metal DirectContext is thread-affine: create it on
+                    // the render thread that will use it for every frame's replay.
+                    val devicePtr = NativeMetalBridge.nativeDevicePtr(attachmentHandle)
+                    val queuePtr = NativeMetalBridge.nativeQueuePtr(attachmentHandle)
+                    directContext =
+                        runOnRenderThread { DirectContext.makeMetal(devicePtr, queuePtr) }
                     scene =
                         CanvasLayersComposeScene(
                             density = Density(scale),
@@ -125,16 +137,10 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
                             platformContext = StandalonePopupPlatformContext(),
                             invalidate = { scheduleRender() },
                         )
-                    PopupNativeBridgeWindows.nativeSetEventCallback(panel, PanelEventCallback())
-                    // See TaoComposeSceneHostWindows: all contexts sharing the
-                    // process EGL context must resetGLAll when siblings exist.
-                    TaoComposeSceneHostWindows.attachedHostCount.incrementAndGet()
+                    PopupNativeBridge.nativeSetEventCallback(panel, PanelEventCallback())
+                    PopupNativeBridge.nativeOrderOut(panel) // hidden until first setVisible(true)
                     valid = true
                     logger.fine { "Standalone popup panel ready (panel=$panel, scale=$scale)" }
-                } else {
-                    logger.warning("Standalone popup unavailable: Skia DirectContext creation failed")
-                    PopupNativeBridgeWindows.nativeRelease(panel)
-                    panel = 0
                 }
             }
         }
@@ -158,20 +164,17 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
         val y = (yDp * scale).roundToInt()
         val w = (widthDp * scale).roundToInt().coerceAtLeast(1)
         val h = (heightDp * scale).roundToInt().coerceAtLeast(1)
-        PopupNativeBridgeWindows.nativeSetFrameInWindow(
+        PopupNativeBridge.nativeSetFrameOnScreen(
             panel = panel,
             xPx = x,
             yPx = y,
             widthPx = w,
             heightPx = h,
-            contentXPx = 0,
-            contentYPx = 0,
-            contentWidthPx = w,
-            contentHeightPx = h,
         )
         if (w != widthPx || h != heightPx) {
             widthPx = w
             heightPx = h
+            NativeMetalBridge.nativeResize(attachmentHandle, w, h, scale)
             scene?.size = IntSize(w, h)
             windowInfo.containerSizeState = IntSize(w, h)
         }
@@ -181,34 +184,47 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     override fun setVisible(visible: Boolean) {
         if (!isValid || visible == this.visible) return
         this.visible = visible
-        PopupNativeBridgeWindows.nativeSetPanelVisible(panel, visible)
-        // High-resolution timers only while animating on screen: the frame
-        // pacer relies on ~1 ms scheduling accuracy for a steady 60 fps.
-        PopupNativeBridgeWindows.nativeSetHighResTimer(visible)
-        if (visible) scheduleRender()
+        if (visible) {
+            PopupNativeBridge.nativeOrderFront(panel)
+            // Render + present the first frame synchronously before returning:
+            // the very first real frame pays Metal pipeline compilation and
+            // glyph shaping (potentially longer than the caller's enter
+            // animation), so warming it up while the caller is still delaying
+            // its animation start keeps the animation's early frames from
+            // being swallowed by the warm-up.
+            renderFrameBlocking()
+            scheduleRender()
+        } else {
+            // Restore the arrow before ordering out so a text-field I-beam
+            // doesn't linger over whatever ends up under the pointer.
+            PopupNativeBridge.nativeSetPanelCursor(panel, TaoCursorIcon.DEFAULT)
+            PopupNativeBridge.nativeOrderOut(panel)
+        }
     }
 
     override fun setFocusable(focusable: Boolean) {
         if (!isValid) return
-        PopupNativeBridgeWindows.nativeSetFocusable(panel, focusable)
+        // For a standalone panel the native side takes key focus (makeKeyWindow)
+        // when focusable becomes true — see popup_panel.m's nativeSetFocusable.
+        PopupNativeBridge.nativeSetFocusable(panel, focusable)
     }
 
     override fun setOutsideClickListener(listener: (() -> Unit)?) {
         if (!isValid) return
         if (listener != null) {
-            PopupNativeBridgeWindows.nativeInstallOutsideClickMonitor(panel, PanelOutsideClickListener(listener))
+            PopupNativeBridge.nativeInstallOutsideClickMonitor(panel, PanelOutsideClickListener(listener))
         } else {
-            PopupNativeBridgeWindows.nativeUninstallOutsideClickMonitor(panel)
+            PopupNativeBridge.nativeUninstallOutsideClickMonitor(panel)
         }
     }
 
     /**
-     * Named inner class so GraalVM JNI reachability metadata can register
-     * the implementor (same pattern as [TaoPopupSceneLayerWindows]).
+     * Named inner class so GraalVM JNI reachability metadata can register the
+     * implementor (same pattern as [TaoPopupSceneLayer.PopupOutsideListener]).
      */
     private class PanelOutsideClickListener(
         private val listener: () -> Unit,
-    ) : PopupNativeBridgeWindows.OutsideClickListener {
+    ) : PopupNativeBridge.OutsideClickListener {
         override fun onOutsideClick(
             type: Int,
             button: Int,
@@ -220,19 +236,19 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     override fun dispose() {
         if (!isValid || disposed) return
         disposed = true
-        if (visible) {
-            visible = false
-            PopupNativeBridgeWindows.nativeSetHighResTimer(false)
-        }
-        TaoComposeSceneHostWindows.attachedHostCount.decrementAndGet()
-        PopupNativeBridgeWindows.nativeUninstallOutsideClickMonitor(panel)
-        PopupNativeBridgeWindows.nativeSetEventCallback(panel, null)
+        PopupNativeBridge.nativeUninstallOutsideClickMonitor(panel)
+        PopupNativeBridge.nativeSetEventCallback(panel, null)
         scene?.close()
         scene = null
-        directContext?.close()
+        val ctx = directContext
         directContext = null
-        PopupNativeBridgeWindows.nativeRelease(panel)
+        if (ctx != null) runCatching { runOnRenderThread { ctx.close() } }
+        val handle = attachmentHandle
+        attachmentHandle = 0
+        if (handle != 0L) NativeMetalBridge.nativeDetach(handle)
+        PopupNativeBridge.nativeRelease(panel)
         panel = 0
+        renderExecutor.shutdown()
     }
 
     // ── Rendering ─────────────────────────────────────────────────────────
@@ -246,56 +262,99 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     private fun renderNow() {
         renderPending.set(false)
         if (disposed) return
-        val ctx = directContext ?: return
         val sc = scene ?: return
-        if (widthPx <= 0 || heightPx <= 0) return
+        val ctx = directContext ?: return
+        val handle = attachmentHandle
+        if (handle == 0L || widthPx <= 0 || heightPx <= 0) return
 
-        // Pace self-invalidating content (animations): DComp presents don't
-        // block on vsync, so an unthrottled invalidate->render loop would
-        // spin the Tao thread at 100%. Pacing runs on an ABSOLUTE deadline
-        // (nextFrameNs) so scheduling latency doesn't accumulate as drift,
-        // and the frame clock is fed evenly spaced timestamps — presents
-        // latch at vsync, so even *timestamps*, not even render moments,
-        // are what makes an animation look smooth.
-        val now = System.nanoTime()
-        if (now < nextFrameNs) {
+        // Keep the scene's coroutine work (recomposer steps, effects) moving
+        // even while hidden — only the GPU part is skipped below.
+        flushingDispatcher.drain()
+
+        // On-demand rendering: no frames while the panel is hidden. Pending
+        // frame-clock awaiters stay parked; setVisible(true) renders a fresh
+        // frame synchronously and re-arms the paced loop.
+        if (!visible) return
+
+        // Serialize record/replay: never record frame N+1 while frame N is
+        // still on the render thread. `nextDrawable` blocks at the display
+        // rate, so an unserialized 60 fps record loop slowly builds a replay
+        // backlog and presents drift behind the animation timestamps.
+        val retryNs =
+            if (replayInFlight.get()) {
+                REPLAY_RETRY_NS
+            } else {
+                // Pace self-invalidating content (animations) on an absolute
+                // deadline so scheduling latency doesn't accumulate as drift and
+                // the frame clock is fed evenly spaced timestamps.
+                val now = System.nanoTime()
+                if (now < nextFrameNs) nextFrameNs - now else 0L
+            }
+        if (retryNs > 0L) {
             if (renderPending.compareAndSet(false, true)) {
                 pacer.schedule(
                     { TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() } },
-                    nextFrameNs - now,
+                    retryNs,
                     TimeUnit.NANOSECONDS,
                 )
             }
             return
         }
-        // Resynchronize after an idle gap; otherwise stay on the fixed grid.
+        val now = System.nanoTime()
         val frameNs = if (now - nextFrameNs > FRAME_INTERVAL_NS) now else nextFrameNs
         nextFrameNs = frameNs + FRAME_INTERVAL_NS
 
-        // Tick the frame clock before rendering (same ordering as the window
-        // hosts) so withFrameNanos-driven animation state is current.
-        flushingDispatcher.drain()
+        // Record on the main thread (Compose state lives here). The Picture is
+        // a thread-safe snapshot — safe to hand to the render thread for replay.
         frameClock.sendFrame(frameNs)
         flushingDispatcher.drain()
+        val picture = recordSceneToPicture(sc, widthPx, heightPx, frameNs)
+        replayInFlight.set(true)
+        renderExecutor.submit {
+            try {
+                if (!disposed && attachmentHandle != 0L) {
+                    replayPictureToFrame(handle, ctx, picture, clearColor = 0x00000000)
+                }
+            } finally {
+                picture.close()
+                replayInFlight.set(false)
+            }
+        }
+    }
 
-        if (!PopupNativeBridgeWindows.nativeMakeCurrent(panel)) return
-        // The process EGL context is shared with window hosts and popup
-        // layers; our surface switch invalidates Skia's GL state cache.
-        ctx.resetGLAll()
-        renderGlFrame(
-            widthPx = widthPx,
-            heightPx = heightPx,
-            directContext = ctx,
-            clearColorArgb = 0x00000000,
-            present = { PopupNativeBridgeWindows.nativeSwapBuffers(panel) },
-        ) { canvas, nanoTime ->
-            sc.render(canvas.asComposeCanvas(), nanoTime)
+    /**
+     * Records + replays one frame, blocking until the present is queued. Used
+     * on the show path only: guarantees a fresh frame is on screen (and the
+     * Metal pipelines are compiled) before the caller starts its enter
+     * animation. Runs on the Tao main thread; the blocking hop to the render
+     * thread is safe because frames are serialized ([replayInFlight]) and the
+     * render thread never blocks back on the main thread (see
+     * `NativeMetalBridge.nativeBeginFrame` / `nativePresent`).
+     */
+    private fun renderFrameBlocking() {
+        if (disposed) return
+        val sc = scene ?: return
+        val ctx = directContext ?: return
+        val handle = attachmentHandle
+        if (handle == 0L || widthPx <= 0 || heightPx <= 0) return
+        flushingDispatcher.drain()
+        val frameNs = System.nanoTime()
+        nextFrameNs = frameNs + FRAME_INTERVAL_NS
+        frameClock.sendFrame(frameNs)
+        flushingDispatcher.drain()
+        val picture = recordSceneToPicture(sc, widthPx, heightPx, frameNs)
+        runOnRenderThread {
+            try {
+                replayPictureToFrame(handle, ctx, picture, clearColor = 0x00000000)
+            } finally {
+                picture.close()
+            }
         }
     }
 
     // ── Input ─────────────────────────────────────────────────────────────
 
-    private inner class PanelEventCallback : PopupNativeBridgeWindows.EventCallback {
+    private inner class PanelEventCallback : PopupNativeBridge.EventCallback {
         override fun onPointerEvent(
             type: Int,
             x: Float,
@@ -358,36 +417,12 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
     // ── Platform plumbing ─────────────────────────────────────────────────
 
     private inner class StandalonePopupPlatformContext : PlatformContext.Empty() {
-        override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHost.windowInfo
+        override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostMac.windowInfo
 
         override fun setPointerIcon(pointerIcon: PointerIcon) {
-            if (!isValid) return
-            PopupNativeBridgeWindows.nativeSetPanelCursor(panel, mapPointerIcon(pointerIcon))
+            if (!isValid || disposed) return
+            PopupNativeBridge.nativeSetPanelCursor(panel, pointerIcon.toTaoCursorIconCode())
         }
-    }
-
-    private fun mapPointerIcon(icon: PointerIcon): Int {
-        when {
-            icon === PointerIcon.Default -> return TaoCursorIcon.DEFAULT
-            icon === PointerIcon.Text -> return TaoCursorIcon.TEXT
-            icon === PointerIcon.Hand -> return TaoCursorIcon.HAND
-            icon === PointerIcon.Crosshair -> return TaoCursorIcon.CROSSHAIR
-        }
-        return runCatching {
-            val cursor = icon.javaClass.getMethod("getCursor").invoke(icon) as? java.awt.Cursor
-            when (cursor?.type) {
-                java.awt.Cursor.TEXT_CURSOR -> TaoCursorIcon.TEXT
-                java.awt.Cursor.HAND_CURSOR -> TaoCursorIcon.HAND
-                java.awt.Cursor.CROSSHAIR_CURSOR -> TaoCursorIcon.CROSSHAIR
-                java.awt.Cursor.WAIT_CURSOR -> TaoCursorIcon.WAIT
-                java.awt.Cursor.MOVE_CURSOR -> TaoCursorIcon.MOVE
-                java.awt.Cursor.E_RESIZE_CURSOR, java.awt.Cursor.W_RESIZE_CURSOR -> TaoCursorIcon.EW_RESIZE
-                java.awt.Cursor.N_RESIZE_CURSOR, java.awt.Cursor.S_RESIZE_CURSOR -> TaoCursorIcon.NS_RESIZE
-                java.awt.Cursor.NE_RESIZE_CURSOR, java.awt.Cursor.SW_RESIZE_CURSOR -> TaoCursorIcon.NESW_RESIZE
-                java.awt.Cursor.NW_RESIZE_CURSOR, java.awt.Cursor.SE_RESIZE_CURSOR -> TaoCursorIcon.NWSE_RESIZE
-                else -> TaoCursorIcon.DEFAULT
-            }
-        }.getOrDefault(TaoCursorIcon.DEFAULT)
     }
 
     private inner class FlushingDispatcher : kotlinx.coroutines.CoroutineDispatcher() {
@@ -416,14 +451,21 @@ internal class TaoStandalonePopupHost : StandalonePopupHost {
         override val containerSize: IntSize get() = containerSizeState
     }
 
+    // ── Render thread (Skia Metal DirectContext thread-affinity) ───────────
+
+    private fun <T> runOnRenderThread(block: () -> T): T = renderExecutor.submit(Callable { block() }).get()
+
     private companion object {
         val logger: java.util.logging.Logger =
             java.util.logging.Logger
-                .getLogger(TaoStandalonePopupHost::class.java.simpleName)
+                .getLogger(TaoStandalonePopupHostMac::class.java.simpleName)
 
         const val HIDDEN_X_PX: Int = -32_000
         const val HIDDEN_Y_PX: Int = -32_000
         const val FRAME_INTERVAL_NS: Long = 1_000_000_000L / 60
+
+        /** Re-check cadence while a frame's replay is still on the render thread. */
+        const val REPLAY_RETRY_NS: Long = 2_000_000L
 
         val pacer =
             Executors.newSingleThreadScheduledExecutor { r ->

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoSyntheticKey.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoSyntheticKey.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.scene.ComposeScene
+import dev.nucleusframework.core.runtime.Platform
 import java.awt.Component
 import java.awt.event.InputEvent
 
@@ -133,6 +134,10 @@ private fun awtModifierMask(
  * constants are declared with `KEY_LOCATION_STANDARD` — since `Key`
  * equality encodes the location, anything else (e.g. UNKNOWN) makes every
  * non-character key (Backspace, Enter, arrows…) unmatchable.
+ *
+ * [vkCode] is the platform's native virtual-key code: Windows `VK_*` values
+ * match the AWT codes Compose's `Key` constants use, but macOS `NSEvent.keyCode`
+ * (`kVK_*`) values do not and are translated via [macNativeKeyToAwt].
  */
 @OptIn(InternalComposeUiApi::class)
 internal fun ComposeScene.dispatchNativeKeyEvent(
@@ -147,11 +152,17 @@ internal fun ComposeScene.dispatchNativeKeyEvent(
     val isCtrl = modifiers and TaoNativeWireFormat.MOD_CTRL != 0
     val isAlt = modifiers and TaoNativeWireFormat.MOD_ALT != 0
     val isMeta = modifiers and TaoNativeWireFormat.MOD_META != 0
+    val (awtVkCode, keyLocation) =
+        if (Platform.Current == Platform.MacOS) {
+            macNativeKeyToAwt(vkCode, codePoint)
+        } else {
+            vkCode to java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
+        }
     val ev =
         taoKeyEvent(
             keyDown = type == TaoNativeWireFormat.KEY_DOWN,
-            vkCode = vkCode,
-            keyLocation = java.awt.event.KeyEvent.KEY_LOCATION_STANDARD,
+            vkCode = awtVkCode,
+            keyLocation = keyLocation,
             isShift = isShift,
             isCtrl = isCtrl,
             isAlt = isAlt,
@@ -167,11 +178,16 @@ internal fun ComposeScene.dispatchNativeKeyEvent(
     onKeyEvent?.invoke(ev)
 }
 
-/** Heuristic: ASCII control range and Cmd/Ctrl combos are not text input. */
+/**
+ * Heuristic: ASCII control range, Cmd/Ctrl combos and Apple's function-key
+ * Unicode range are not text input. macOS reports arrows/F-keys/Home… as
+ * PUA code points (`NSEvent.characters` = U+F700–U+F8FF) which would
+ * otherwise be inserted into text fields as tofu glyphs.
+ */
 internal fun Int.isPrintableTextInput(
     isCtrl: Boolean,
     isMeta: Boolean,
-): Boolean = this >= 0x20 && this != 0x7F && !isCtrl && !isMeta
+): Boolean = this >= 0x20 && this != 0x7F && this !in 0xF700..0xF8FF && !isCtrl && !isMeta
 
 /**
  * AWT requires a non-null `Component` as the source of every key event.

--- a/decorated-window-tao/src/main/native/macos/popup_panel.m
+++ b/decorated-window-tao/src/main/native/macos/popup_panel.m
@@ -109,6 +109,7 @@ static const char kCallbackEnableKey = 2; // BOOL — flipped to NO on release
 static const char kRegionEnableKey   = 3; // BOOL — region-based hitTest mode
 static const char kRegionDataKey     = 4; // NSData with float[count*4] (x, y, w, h) in pixels
 static const char kRegionCountKey    = 5; // NSNumber<int>
+static const char kCursorKey         = 6; // NSCursor — set via nativeSetPanelCursor
 
 // Forward declaration: the panel class is defined further down but the
 // content view's `maybeBecomeKey:` needs to refer to it.
@@ -183,6 +184,7 @@ static const char kRegionCountKey    = 5; // NSNumber<int>
     }
     NSTrackingAreaOptions opts = NSTrackingMouseMoved
                                | NSTrackingMouseEnteredAndExited
+                               | NSTrackingCursorUpdate
                                | NSTrackingActiveInKeyWindow
                                | NSTrackingActiveAlways
                                | NSTrackingInVisibleRect;
@@ -192,6 +194,20 @@ static const char kRegionCountKey    = 5; // NSNumber<int>
                owner:self
             userInfo:nil];
     [self addTrackingArea:ta];
+}
+
+/* Re-asserts the Compose-requested cursor whenever AppKit decides the
+ * cursor needs refreshing (entering the view, window ordering changes).
+ * Only active once `nativeSetPanelCursor` stored a cursor — owner-based
+ * popups that route cursor changes through their host window keep the
+ * default responder behaviour. */
+- (void)cursorUpdate:(NSEvent *)event {
+    NSCursor *cursor = objc_getAssociatedObject(self, &kCursorKey);
+    if (cursor != nil) {
+        [cursor set];
+    } else {
+        [super cursorUpdate:event];
+    }
 }
 
 - (jobject)takeCallbackOrNil {
@@ -294,8 +310,12 @@ static const char kRegionCountKey    = 5; // NSNumber<int>
 @interface NucleusTaoPopupPanel : NSPanel
 @property (nonatomic, weak) NSWindow *parentHostWindow;
 @property (nonatomic) BOOL canKey;
-@property (nonatomic, strong) id outsideMonitor;        // NSEvent monitor token
-@property (nonatomic, strong) NSValue *outsideListenerVal; // jobject global ref boxed
+// YES for an ownerless (standalone) panel: no parent window, screen-coord
+// positioning, global outside-click monitor, and makeKeyWindow on focusable.
+@property (nonatomic) BOOL isStandalone;
+@property (nonatomic, strong) id outsideMonitor;           // local NSEvent monitor token
+@property (nonatomic, strong) id outsideGlobalMonitor;       // global NSEvent monitor token (standalone only)
+@property (nonatomic, strong) NSValue *outsideListenerVal;  // jobject global ref boxed
 @end
 
 @implementation NucleusTaoPopupPanel
@@ -374,6 +394,28 @@ static NSRect to_screen_frame(NSWindow *parent, jint xPx, jint yPx, jint wPx, ji
                       wPt, hPt);
 }
 
+/* Ownerless variant: positions the panel on the primary screen using
+ * top-left-origin physical-pixel coordinates (the space the Kotlin host
+ * works in). AppKit's screen coords are bottom-left points, so we flip Y
+ * against the full screen frame (includes the menu bar — the tray icon sits
+ * at the very top, so the menu-bar height must NOT be subtracted). */
+static NSRect to_screen_frame_ownerless(jint xPx, jint yPx, jint wPx, jint hPx) {
+    NSScreen *screen = [NSScreen mainScreen];
+    if (screen == nil) {
+        return NSMakeRect((CGFloat)xPx, (CGFloat)yPx, (CGFloat)wPx, (CGFloat)hPx);
+    }
+    CGFloat scale = screen.backingScaleFactor;
+    if (scale <= 0) scale = 1.0;
+    NSRect screenFrame = screen.frame;
+    CGFloat xPt = (CGFloat)xPx / scale;
+    CGFloat yTopPt = (CGFloat)yPx / scale;
+    CGFloat wPt = (CGFloat)wPx / scale;
+    CGFloat hPt = (CGFloat)hPx / scale;
+    return NSMakeRect(screenFrame.origin.x + xPt,
+                      screenFrame.origin.y + screenFrame.size.height - yTopPt - hPt,
+                      wPt, hPt);
+}
+
 /* ================================================================== */
 /*  JNI exports                                                        */
 /*  Package: dev.nucleusframework.window.tao                 */
@@ -387,6 +429,45 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeCreatePanel(
     jint xPx, jint yPx, jint widthPx, jint heightPx)
 {
     (void)env; (void)clazz;
+
+    // Ownerless (standalone) panel: no parent window. Positioned on the
+    // primary screen in top-left-origin physical pixels. Used by tray-style
+    // popups that must float with no backing window in the process.
+    if (parentNsViewPtr == 0) {
+        NSRect frame = to_screen_frame_ownerless(xPx, yPx, widthPx, heightPx);
+        NSWindowStyleMask mask = NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel;
+
+        NucleusTaoPopupPanel *panel =
+            [[NucleusTaoPopupPanel alloc] initWithContentRect:frame
+                                                    styleMask:mask
+                                                      backing:NSBackingStoreBuffered
+                                                        defer:NO];
+        panel.parentHostWindow = nil;
+        panel.isStandalone = YES;
+        panel.canKey = NO; // toggled via nativeSetFocusable
+        panel.opaque = NO;
+        panel.backgroundColor = [NSColor clearColor];
+        panel.hasShadow = YES;
+        panel.level = NSPopUpMenuWindowLevel;
+        panel.hidesOnDeactivate = NO;
+        panel.animationBehavior = NSWindowAnimationBehaviorNone;
+        panel.movableByWindowBackground = NO;
+        panel.releasedWhenClosed = NO;
+        // Standalone tray popups need keyboard focus without activating the
+        // app: `becomesKeyOnlyIfNeeded` + the explicit makeKeyWindow we trigger
+        // from nativeSetFocusable (no host window to lose its active look).
+        [panel setBecomesKeyOnlyIfNeeded:YES];
+
+        NucleusTaoPopupContent *contentView =
+            [[NucleusTaoPopupContent alloc] initWithFrame:NSMakeRect(0, 0, frame.size.width, frame.size.height)];
+        contentView.wantsLayer = YES;
+        panel.contentView = contentView;
+
+        // Not added as a child window — ownerless by design.
+        void *retained = (__bridge_retained void *)panel;
+        return (jlong)(uintptr_t)retained;
+    }
+
     NSWindow *parent = window_from_view(parentNsViewPtr);
     if (parent == nil) return 0;
 
@@ -399,6 +480,7 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeCreatePanel(
                                                   backing:NSBackingStoreBuffered
                                                     defer:NO];
     panel.parentHostWindow = parent;
+    panel.isStandalone = NO;
     panel.canKey = NO; // toggled via nativeSetFocusable
     panel.opaque = NO;
     panel.backgroundColor = [NSColor clearColor];
@@ -428,6 +510,21 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeCreatePanel(
     return (jlong)(uintptr_t)retained;
 }
 
+/* Ownerless screen-coord setter: repositions a standalone panel on the
+ * primary screen using top-left-origin physical pixels. */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeSetFrameOnScreen(
+    JNIEnv *env, jclass clazz,
+    jlong panelPtr,
+    jint xPx, jint yPx, jint widthPx, jint heightPx)
+{
+    (void)env; (void)clazz;
+    if (panelPtr == 0) return;
+    NucleusTaoPopupPanel *panel = (__bridge NucleusTaoPopupPanel *)(void *)(uintptr_t)panelPtr;
+    NSRect frame = to_screen_frame_ownerless(xPx, yPx, widthPx, heightPx);
+    [panel setFrame:frame display:YES];
+}
+
 JNIEXPORT void JNICALL
 Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeSetFrameInWindow(
     JNIEnv *env, jclass clazz,
@@ -451,6 +548,13 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeOrderFront(
     if (panelPtr == 0) return;
     NucleusTaoPopupPanel *panel = (__bridge NucleusTaoPopupPanel *)(void *)(uintptr_t)panelPtr;
     [panel orderFrontRegardless];
+    // Standalone tray popups take key focus on show: a makeKeyWindow issued
+    // while the panel was still ordered out (e.g. from nativeSetFocusable at
+    // setup time) is a no-op, so it must be (re)applied here. Non-activating
+    // panel style keeps the previously active app unactivated.
+    if (panel.isStandalone && panel.canKey && !panel.isKeyWindow) {
+        [panel makeKeyWindow];
+    }
 }
 
 JNIEXPORT void JNICALL
@@ -471,6 +575,14 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeSetFocusable(
     if (panelPtr == 0) return;
     NucleusTaoPopupPanel *panel = (__bridge NucleusTaoPopupPanel *)(void *)(uintptr_t)panelPtr;
     panel.canKey = focusable ? YES : NO;
+    // Standalone (ownerless) tray popups have no host window whose "active"
+    // appearance could be disrupted, so it's safe — and necessary — to take
+    // key focus immediately when the panel becomes focusable: an ownerless
+    // non-activating panel otherwise never receives keyDown events. The owner
+    // -based path keeps the original "only on demand" behaviour.
+    if (panel.isStandalone && focusable && !panel.isKeyWindow) {
+        [panel makeKeyWindow];
+    }
     // Deliberately NOT calling `[panel makeKeyWindow]` here. With
     // `becomesKeyOnlyIfNeeded = YES` (set in nativeCreatePanel), AppKit
     // grants the panel key status only when the user clicks on a
@@ -495,6 +607,42 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeSetIgnoresMouseEven
     if (panelPtr == 0) return;
     NucleusTaoPopupPanel *panel = (__bridge NucleusTaoPopupPanel *)(void *)(uintptr_t)panelPtr;
     [panel setIgnoresMouseEvents:ignore ? YES : NO];
+}
+
+/* Maps the shared TaoCursorIcon wire codes (NativeTaoBridge.kt) to AppKit
+ * cursors. Codes without a public NSCursor equivalent (WAIT, HELP, the
+ * diagonal resizes) fall back to the arrow. */
+static NSCursor *cursorForCode(jint code) {
+    switch (code) {
+        case 1:  return [NSCursor IBeamCursor];               // TEXT
+        case 2:  return [NSCursor pointingHandCursor];        // HAND
+        case 3:  return [NSCursor crosshairCursor];           // CROSSHAIR
+        case 5:  return [NSCursor openHandCursor];            // MOVE
+        case 6:  return [NSCursor operationNotAllowedCursor]; // NOT_ALLOWED
+        case 9:  return [NSCursor resizeLeftRightCursor];     // EW_RESIZE
+        case 10: return [NSCursor resizeUpDownCursor];        // NS_RESIZE
+        default: return [NSCursor arrowCursor];
+    }
+}
+
+/* Applies a Compose-requested cursor to the panel. Stores the cursor on the
+ * content view (re-asserted by `cursorUpdate:` on enter/window changes) and
+ * sets it immediately — Compose only calls this while the pointer is over
+ * the panel, so an instant [set] is always appropriate. */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeSetPanelCursor(
+    JNIEnv *env, jclass clazz, jlong panelPtr, jint iconCode)
+{
+    (void)env; (void)clazz;
+    if (panelPtr == 0) return;
+    NucleusTaoPopupPanel *panel = (__bridge NucleusTaoPopupPanel *)(void *)(uintptr_t)panelPtr;
+    NucleusTaoPopupContent *content = (NucleusTaoPopupContent *)panel.contentView;
+    if (content == nil) return;
+    NSCursor *cursor = cursorForCode(iconCode);
+    objc_setAssociatedObject(content, &kCursorKey, cursor, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (panel.isVisible) {
+        [cursor set];
+    }
 }
 
 /* Toggles region-based hit-testing. Used by `NativeView`'s overlay
@@ -574,13 +722,24 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeSetEventCallback(
     objc_setAssociatedObject(content, &kCallbackEnableKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-/* Installs a process-wide NSEvent monitor that fires for every left/right
- * mouseDown anywhere in the app. When the click does NOT target this
- * panel, calls back into Java's `OutsideClickListener.onOutsideClick`
- * which Compose's Popup framework wires to `dismissOnClickOutside`.
+/* Installs an NSEvent monitor that fires for every left/right/other
+ * mouseDown and calls back into Java's `OutsideClickListener.onOutsideClick`
+ * (wired to Compose's `dismissOnClickOutside`) when the click does NOT target
+ * this panel.
  *
- * The monitor returns the event unchanged so AppKit dispatches it
- * normally (we observe; we don't consume). */
+ * Two scopes:
+ *  - A **local** monitor always installed: sees events delivered to *this
+ *    app*. Same-window clicks (inside the popup) are skipped; any other
+ *    in-app click (e.g. on the tray status item, or another window of the
+ *    app) fires the listener. This is what owner-based popups need.
+ *  - A **global** monitor installed only for standalone (ownerless) panels:
+ *    sees mouseDowns delivered to *other* applications (global monitors never
+ *    receive events for our own app). A tray popup with no backing window
+ *    must also dismiss when the user clicks the desktop or another app, which
+ *    the local monitor can't observe.
+ *
+ * Both monitors return the event unchanged so AppKit dispatches it normally
+ * (we observe; we don't consume). */
 JNIEXPORT void JNICALL
 Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeInstallOutsideClickMonitor(
     JNIEnv *env, jclass clazz, jlong panelPtr, jobject listener)
@@ -591,6 +750,10 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeInstallOutsideClick
     if (panel.outsideMonitor != nil) {
         [NSEvent removeMonitor:panel.outsideMonitor];
         panel.outsideMonitor = nil;
+    }
+    if (panel.outsideGlobalMonitor != nil) {
+        [NSEvent removeMonitor:panel.outsideGlobalMonitor];
+        panel.outsideGlobalMonitor = nil;
     }
     if (panel.outsideListenerVal != nil) {
         jobject prev = (jobject)panel.outsideListenerVal.pointerValue;
@@ -604,6 +767,8 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeInstallOutsideClick
     __weak NucleusTaoPopupPanel *weakPanel = panel;
     NSEventMask mask = NSEventMaskLeftMouseDown | NSEventMaskRightMouseDown |
                        NSEventMaskOtherMouseDown;
+
+    // Local monitor — in-app clicks not on this panel.
     panel.outsideMonitor = [NSEvent
         addLocalMonitorForEventsMatchingMask:mask
                                      handler:^NSEvent *(NSEvent *e) {
@@ -627,6 +792,32 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeInstallOutsideClick
         if ((*jenv)->ExceptionCheck(jenv)) (*jenv)->ExceptionClear(jenv);
         return e;
     }];
+
+    // Global monitor — clicks in OTHER apps. Only needed for standalone
+    // (ownerless) panels: an owner-based popup dismisses via its host window's
+    // focus loss, and installing a global monitor would change that working
+    // path's behaviour. Global monitors never receive events for our own app,
+    // so no window filtering is required here.
+    if (panel.isStandalone) {
+        panel.outsideGlobalMonitor = [NSEvent
+            addGlobalMonitorForEventsMatchingMask:mask
+                                           handler:^(NSEvent *e) {
+            NucleusTaoPopupPanel *p = weakPanel;
+            if (p == nil) return;
+            NSValue *box = p.outsideListenerVal;
+            if (box == nil) return;
+            jobject cb = (jobject)box.pointerValue;
+            if (cb == NULL) return;
+            JNIEnv *jenv = attachThread();
+            if (jenv == NULL) return;
+            jint type = EVT_PTR_DOWN;
+            jint btn = 1;
+            if (e.type == NSEventTypeRightMouseDown) btn = 2;
+            else if (e.type == NSEventTypeOtherMouseDown) btn = 3;
+            (*jenv)->CallVoidMethod(jenv, cb, sOutsideOnClickMethod, type, btn);
+            if ((*jenv)->ExceptionCheck(jenv)) (*jenv)->ExceptionClear(jenv);
+        }];
+    }
 }
 
 JNIEXPORT void JNICALL
@@ -639,6 +830,10 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeUninstallOutsideCli
     if (panel.outsideMonitor != nil) {
         [NSEvent removeMonitor:panel.outsideMonitor];
         panel.outsideMonitor = nil;
+    }
+    if (panel.outsideGlobalMonitor != nil) {
+        [NSEvent removeMonitor:panel.outsideGlobalMonitor];
+        panel.outsideGlobalMonitor = nil;
     }
     if (panel.outsideListenerVal != nil) {
         jobject prev = (jobject)panel.outsideListenerVal.pointerValue;
@@ -667,10 +862,14 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeRelease(
         }
     }
 
-    // Drop outside monitor + listener global ref.
+    // Drop outside monitors + listener global ref.
     if (panel.outsideMonitor != nil) {
         [NSEvent removeMonitor:panel.outsideMonitor];
         panel.outsideMonitor = nil;
+    }
+    if (panel.outsideGlobalMonitor != nil) {
+        [NSEvent removeMonitor:panel.outsideGlobalMonitor];
+        panel.outsideGlobalMonitor = nil;
     }
     if (panel.outsideListenerVal != nil) {
         jobject prev = (jobject)panel.outsideListenerVal.pointerValue;

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -255,6 +255,22 @@
             ]
         },
         {
+            "type": "dev.nucleusframework.window.tao.render.TaoStandalonePopupHostMac$PanelEventCallback",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onPointerEvent", "parameterTypes": ["int","float","float","int","int"] },
+                { "name": "onScroll",       "parameterTypes": ["float","float","float","float"] },
+                { "name": "onKeyEvent",     "parameterTypes": ["int","int","int","int"] }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.render.TaoStandalonePopupHostMac$PanelOutsideClickListener",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onOutsideClick", "parameterTypes": ["int","int"] }
+            ]
+        },
+        {
             "type": "dev.nucleusframework.window.tao.render.TaoPopupSceneLayer$PopupEventCallback",
             "jniAccessible": true,
             "methods": [

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelMacSmokeMain.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelMacSmokeMain.kt
@@ -1,0 +1,63 @@
+package dev.nucleusframework.window.tao
+
+import org.jetbrains.skia.DirectContext
+
+/**
+ * macOS standalone-popup native-chain smoke check, run as `main()` via the
+ * `smokeStandalonePanelMac` JavaExec task.
+ *
+ * Why a `main()` and not a JUnit `@Test`: AppKit requires an `NSWindow`/
+ * `NSPanel` to be instantiated on the macOS main thread. Gradle's test worker
+ * runs tests off the main thread, and the process main thread isn't in a run
+ * loop, so dispatching back to it would deadlock — the panel cannot be
+ * created there. A `main()` runs on the process main thread (which *is* the
+ * macOS main thread), so the panel can be instantiated directly. No event
+ * loop is entered; creation + attach + Metal `DirectContext` + close is
+ * enough to validate the JNI symbols resolve and the Metal pipeline boots.
+ *
+ * Run with: `./gradlew :decorated-window-tao:smokeStandalonePanelMac`
+ */
+object StandalonePanelMacSmokeMain {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        check(NativeMetalBridge.isLoaded) { "nucleus_tao_metal failed to load" }
+        check(PopupNativeBridge.isLoaded) { "nucleus_tao_macos_popup failed to load" }
+
+        // Ownerless panel (parentNsView = 0) → native takes the screen-coord
+        // ownerless branch. Offscreen so nothing is shown during the check.
+        val panel =
+            PopupNativeBridge.nativeCreatePanel(
+                parentNsView = 0L,
+                xPx = -32_000,
+                yPx = -32_000,
+                widthPx = 300,
+                heightPx = 200,
+            )
+        check(panel != 0L) { "ownerless panel creation failed" }
+
+        var attachment = 0L
+        try {
+            val contentNsView = PopupNativeBridge.nativeContentNsView(panel)
+            check(contentNsView != 0L) { "panel content NSView is null" }
+
+            attachment = NativeMetalBridge.nativeAttachOverlay(contentNsView)
+            check(attachment != 0L) { "CAMetalLayer attach failed" }
+
+            NativeMetalBridge.nativeResize(attachment, 300, 200, 1f)
+
+            // Skia Metal DirectContext from the attachment's device/queue.
+            // Created and closed here on the main thread (the sole owner — in
+            // the real host it lives on a dedicated render thread for affinity).
+            val ctx =
+                DirectContext.makeMetal(
+                    NativeMetalBridge.nativeDevicePtr(attachment),
+                    NativeMetalBridge.nativeQueuePtr(attachment),
+                )
+            ctx.close()
+            println("standalonePanelMacSmoke: OK (panel=$panel, attachment=$attachment)")
+        } finally {
+            if (attachment != 0L) NativeMetalBridge.nativeDetach(attachment)
+            PopupNativeBridge.nativeRelease(panel)
+        }
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelNativeSmokeTest.kt
@@ -9,8 +9,11 @@ import kotlin.test.assertTrue
 
 /**
  * Verifies the native chain behind the standalone popup panel without any
- * Tao event loop: headless EGL context bootstrap, ownerless panel creation,
- * context binding and Skia DirectContext creation. Windows-only.
+ * Tao event loop: ownerless panel creation, surface attach and Skia
+ * DirectContext creation. Windows-only — see [StandalonePanelMacSmokeMain]
+ * for the macOS equivalent (AppKit requires the NSPanel be created on the
+ * main thread, so it runs as a `main()` via the `smokeStandalonePanelMac`
+ * JavaExec task, not as a JUnit test in the off-main test worker).
  */
 class StandalonePanelNativeSmokeTest {
     @Test


### PR DESCRIPTION
## Summary

Ports the standalone popup panel (`TaoStandalonePopup`) to macOS — the Windows-only transparent tray popup now has a native macOS equivalent: an ownerless, non-activating `NSPanel` with a per-pixel transparent `CAMetalLayer`. Tray-style popups float with no backing window anywhere (nothing in the Dock or the app switcher). Linux stays a no-op.

### Native (`popup_panel.m`)
- Ownerless branch in `nativeCreatePanel` (`parentNsView == 0`): screen-coordinate positioning (top-left-origin physical px, flipped against the full screen frame), no `addChildWindow`
- `nativeSetFrameOnScreen` for repositioning standalone panels
- Global `NSEvent` monitor (standalone only) so outside-click dismissal also fires for clicks in **other** apps — the local monitor can't see those
- `makeKeyWindow` applied on `orderFront` for focusable standalone panels (a make-key while ordered out is a no-op)
- Compose-driven cursor: `nativeSetPanelCursor` + `cursorUpdate:` re-assertion, gated on an explicitly stored cursor so owner-based popups keep their host-window routing

### Metal host (`TaoStandalonePopupHostMac`)
- Skia `DirectContext` is thread-affine → owned by a dedicated render thread; each frame is **recorded** into a `Picture` on the Tao main thread and **replayed/presented** on the render thread (reuses `recordSceneToPicture` / `replayPictureToFrame`)
- Frames serialized (never record N+1 while N is in flight), paced at ~60 fps on an absolute deadline, no GPU work while hidden
- `setVisible(true)` presents one synchronous frame before returning so Metal pipeline compilation + glyph shaping don't swallow the caller's enter animation
- `StandalonePopupHost` interface added so the composable routes per platform without a per-platform composable (Windows host now implements it)

### Key input (`TaoKeyMac`)
The ObjC popup callbacks forward raw `NSEvent.keyCode` (`kVK_*`), but Compose `Key` constants use AWT VK codes (only Windows VKs match). Backspace was seen as '3', Cmd+C as Backspace. New kVK→AWT translation in `dispatchNativeKeyEvent` (layout-aware for letters/digits, proper left/right/numpad locations) — also fixes owner-based popup layers and native-view overlays. Apple's U+F700–F8FF function-key characters are excluded from synthetic KEY_TYPED insertion.

### Tooling
- macOS native-chain smoke check as a JavaExec `main()` (`smokeStandalonePanelMac`): AppKit requires `NSPanel` creation on the process main thread, which Gradle test workers don't provide
- GraalVM JNI reachability metadata for the new host callbacks
- Pre-existing detekt failure on `PopupNativeBridgeWindows` (TooManyFunctions, introduced in #301) suppressed like its macOS counterpart

## Test plan
- [x] `:decorated-window-tao:compileKotlin` / `compileTestKotlin`
- [x] `:decorated-window-tao:detekt` + `ktlintCheck`
- [x] `:decorated-window-tao:smokeStandalonePanelMac` (ownerless panel → CAMetalLayer attach → Metal DirectContext)
- [x] Windows smoke test unchanged (`StandalonePanelNativeSmokeTest` is Windows-only)
- [x] Validated end-to-end on macOS via ComposeNativeTray's TrayApp demo (includeBuild): positioning under the menu bar, fade enter/exit animation, outside-click dismissal (in-app + other apps), text-field typing incl. Backspace/arrows/Cmd shortcuts, I-beam cursor

### Fix: native popup layers couldn't escape the owner window on macOS
`Popup.skiko.kt` composes its measure policy inside the layer's inner scene and, with `clippingEnabled` (the default), clamps the popup position into `LocalWindowInfo.containerSize` (`clipPosition`). The macOS `TaoPopupSceneLayer` reported the owner-window size there, so with `nativePopupLayers = true` every Popup/DropdownMenu stayed pinned inside the window. Now reports the work-area-sized `sceneLayoutSize`, matching `TaoPopupSceneLayerWindows`.