### PR TITLE
feat(tao): Linux standalone transparent popup panel (X11/XWayland)

### DIFF
--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -1035,7 +1035,8 @@ jobs:
           for f in \
             decorated-window-tao/src/main/resources/nucleus/native/linux-${{ matrix.arch }}/libnucleus_tao.so \
             decorated-window-tao/src/main/resources/nucleus/native/linux-${{ matrix.arch }}/libnucleus_tao_egl.so \
-            decorated-window-tao/src/main/resources/nucleus/native/linux-${{ matrix.arch }}/libnucleus_tao_linux_widget.so; do
+            decorated-window-tao/src/main/resources/nucleus/native/linux-${{ matrix.arch }}/libnucleus_tao_linux_widget.so \
+            decorated-window-tao/src/main/resources/nucleus/native/linux-${{ matrix.arch }}/libnucleus_tao_linux_popup.so; do
             if [ ! -f "$f" ]; then echo "MISSING: $f" >&2; exit 1; fi
             echo "OK: $f ($(wc -c < "$f") bytes)"
           done

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -326,6 +326,8 @@ jobs:
             "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_egl.so"
             "decorated-window-tao/src/main/resources/nucleus/native/linux-x64/libnucleus_tao_linux_widget.so"
             "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_widget.so"
+            "decorated-window-tao/src/main/resources/nucleus/native/linux-x64/libnucleus_tao_linux_popup.so"
+            "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_popup.so"
             "graalvm-runtime/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_locale.dylib"
             "graalvm-runtime/src/main/resources/nucleus/native/darwin-x64/libnucleus_locale.dylib"
           )

--- a/.github/workflows/publish-maven.yaml
+++ b/.github/workflows/publish-maven.yaml
@@ -333,6 +333,8 @@ jobs:
             "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_egl.so"
             "decorated-window-tao/src/main/resources/nucleus/native/linux-x64/libnucleus_tao_linux_widget.so"
             "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_widget.so"
+            "decorated-window-tao/src/main/resources/nucleus/native/linux-x64/libnucleus_tao_linux_popup.so"
+            "decorated-window-tao/src/main/resources/nucleus/native/linux-aarch64/libnucleus_tao_linux_popup.so"
             "graalvm-runtime/src/main/resources/nucleus/native/darwin-aarch64/libnucleus_locale.dylib"
             "graalvm-runtime/src/main/resources/nucleus/native/darwin-x64/libnucleus_locale.dylib"
           )

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridgeLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridgeLinux.kt
@@ -55,10 +55,21 @@ internal object PopupNativeBridgeLinux {
     /**
      * `Xft.dpi / 96` from the X resource database, 1.0 when unset. X clients
      * live in the X coordinate space (logical under XWayland), so GDK's
-     * Wayland monitor scale must NOT be used for panel geometry.
+     * Wayland monitor scale must NOT be used for panel geometry. Uses its own
+     * short-lived connection — callable from any thread.
      */
     @JvmStatic
     external fun nativeScale(): Float
+
+    /**
+     * Primary-monitor work area `[x, y, width, height]` in X11 pixels (XRandR
+     * primary intersected with EWMH `_NET_WORKAREA`), or `null` when no X
+     * server is reachable. Backs `TaoScreenGeometry.primaryMonitorWorkAreaPx`
+     * when no realized Tao window exists (panel-only tray apps). Uses its own
+     * short-lived connection — callable from any thread.
+     */
+    @JvmStatic
+    external fun nativePrimaryWorkArea(): LongArray?
 
     /**
      * Creates the hidden override-redirect ARGB32 panel window and starts

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridgeLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/PopupNativeBridgeLinux.kt
@@ -1,0 +1,198 @@
+@file:Suppress("MagicNumber")
+
+package dev.nucleusframework.window.tao
+
+import dev.nucleusframework.core.runtime.NativeLibraryLoader
+
+/**
+ * JNI bridge to the Linux standalone popup panel helper
+ * (`linux/nucleus_tao_linux_popup.c`, shipped as
+ * `libnucleus_tao_linux_popup.so`).
+ *
+ * The Linux twin of [PopupNativeBridgeWindows] / [PopupNativeBridge]
+ * (macOS), standalone panels only — there is no owner-based variant on
+ * Linux. The native side creates a top-level, ownerless, override-redirect
+ * ARGB32 X11 window on its own `XOpenDisplay` connection: an independent
+ * X client that works even while the app itself is a native Wayland client
+ * (through XWayland). [nativeIsAvailable] reports whether an X server is
+ * reachable; without one (rare Wayland-only setups) callers must fall back
+ * to a regular window.
+ *
+ * Rendering is NOT handled here: the Kotlin host feeds [nativeDisplayPtr] +
+ * [nativeWindowXid] to `NativeTaoEglBridge.nativeAttachX11`, which resolves
+ * the same `EGLDisplay` and matches the ARGB config the panel's visual was
+ * derived from.
+ *
+ * Threading: every entry point must run on the Tao main thread (the
+ * composable wrapper guarantees this) — it owns the native command
+ * connection. Input callbacks arrive on the panel's own X event thread.
+ *
+ * Wire format: coordinates are physical pixels in the X11 coordinate
+ * space, top-left origin. Global screen coordinates for the frame,
+ * panel-local for pointer events.
+ */
+@Suppress("TooManyFunctions")
+internal object PopupNativeBridgeLinux {
+    private const val LIBRARY_NAME = "nucleus_tao_linux_popup"
+
+    val isLoaded: Boolean = NativeLibraryLoader.load(LIBRARY_NAME, PopupNativeBridgeLinux::class.java)
+
+    /**
+     * Whether a standalone panel can be created: an X server (native X11 or
+     * XWayland) must be reachable through `DISPLAY`. Cached natively after
+     * the first probe.
+     */
+    @JvmStatic
+    external fun nativeIsAvailable(): Boolean
+
+    /**
+     * The command connection's `Display*` — pass to
+     * `NativeTaoEglBridge.nativeAttachX11` together with [nativeWindowXid].
+     */
+    @JvmStatic
+    external fun nativeDisplayPtr(): Long
+
+    /**
+     * `Xft.dpi / 96` from the X resource database, 1.0 when unset. X clients
+     * live in the X coordinate space (logical under XWayland), so GDK's
+     * Wayland monitor scale must NOT be used for panel geometry.
+     */
+    @JvmStatic
+    external fun nativeScale(): Float
+
+    /**
+     * Creates the hidden override-redirect ARGB32 panel window and starts
+     * its event thread. Coordinates are global screen pixels. Returns an
+     * opaque handle owning the panel, or 0 when unavailable; release via
+     * [nativeRelease].
+     */
+    @JvmStatic
+    external fun nativeCreatePanel(
+        xPx: Int,
+        yPx: Int,
+        widthPx: Int,
+        heightPx: Int,
+    ): Long
+
+    /** The panel's X11 window XID, for `NativeTaoEglBridge.nativeAttachX11`. */
+    @JvmStatic
+    external fun nativeWindowXid(panel: Long): Long
+
+    /** Moves/resizes the panel in global screen pixels (top-left origin). */
+    @JvmStatic
+    external fun nativeSetFrameOnScreen(
+        panel: Long,
+        xPx: Int,
+        yPx: Int,
+        widthPx: Int,
+        heightPx: Int,
+    )
+
+    /** Maps (raised) or unmaps the panel. */
+    @JvmStatic
+    external fun nativeSetPanelVisible(
+        panel: Long,
+        visible: Boolean,
+    )
+
+    /**
+     * While focusable, a click inside the panel calls
+     * `XSetInputFocus(RevertToParent)` — override-redirect windows never
+     * receive focus from the WM, so the panel takes it explicitly (the
+     * Windows `takeKeyboardFocus()` equivalent).
+     */
+    @JvmStatic
+    external fun nativeSetFocusable(
+        panel: Long,
+        focusable: Boolean,
+    )
+
+    /** Applies a [TaoCursorIcon] code to the panel window. */
+    @JvmStatic
+    external fun nativeSetPanelCursor(
+        panel: Long,
+        iconCode: Int,
+    )
+
+    /**
+     * Receives raw X11 events forwarded by the panel's event thread when
+     * the user interacts inside the panel's bounds. Coordinates are
+     * panel-local pixels (top-left origin) — matches what
+     * `ComposeScene.sendPointerEvent` expects. Same shape as the macOS /
+     * Windows popup callbacks ([TaoNativeWireFormat] codes).
+     */
+    interface EventCallback {
+        /** [type] = 1 down, 2 up, 3 move. [button] = 0 none, 1 primary, 2 secondary. */
+        @Suppress("FunctionParameterNaming")
+        fun onPointerEvent(
+            type: Int,
+            x: Float,
+            y: Float,
+            button: Int,
+            modifiers: Int,
+        )
+
+        /** One line per wheel click; positive Y scrolls the content down. */
+        @Suppress("FunctionParameterNaming")
+        fun onScroll(
+            x: Float,
+            y: Float,
+            dx: Float,
+            dy: Float,
+        )
+
+        /**
+         * [type] = 1 down, 2 up. [vkCode] is an X11 keysym (Latin one when
+         * the active layout has none — see `vk_keysym_for` in the C side);
+         * translated by `linuxNativeKeyToAwt`.
+         */
+        @Suppress("FunctionParameterNaming")
+        fun onKeyEvent(
+            type: Int,
+            vkCode: Int,
+            codePoint: Int,
+            modifiers: Int,
+        )
+    }
+
+    /**
+     * Receives a callback whenever a mouse press lands outside the visible
+     * panel. Backed by XI2 raw ButtonPress on the root window — the X11
+     * analog of the Windows `WH_MOUSE_LL` hook (observe-only, nothing is
+     * consumed). Fully global on X11 sessions; under XWayland raw events
+     * only fire while X11 surfaces have input focus.
+     */
+    interface OutsideClickListener {
+        /** [type] = 1 (always Press). [button] = 1 primary, 2 secondary, 3 other. */
+        fun onOutsideClick(
+            type: Int,
+            button: Int,
+        )
+    }
+
+    /** Installs the JNI [EventCallback] on the panel. Pass `null` to remove. */
+    @JvmStatic
+    external fun nativeSetEventCallback(
+        panel: Long,
+        callback: EventCallback?,
+    )
+
+    /** Installs the outside-click monitor (see [OutsideClickListener]). */
+    @JvmStatic
+    external fun nativeInstallOutsideClickMonitor(
+        panel: Long,
+        listener: OutsideClickListener,
+    )
+
+    /** Removes any previously installed outside-click monitor for this panel. */
+    @JvmStatic
+    external fun nativeUninstallOutsideClickMonitor(panel: Long)
+
+    /**
+     * Stops the event thread, destroys the X window and frees the panel.
+     * The EGL attachment must have been detached first
+     * (`NativeTaoEglBridge.nativeDetach`).
+     */
+    @JvmStatic
+    external fun nativeRelease(panel: Long)
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoScreenGeometry.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoScreenGeometry.kt
@@ -18,8 +18,10 @@ object TaoScreenGeometry {
      * platform bridge is unavailable.
      *
      * On Linux the query is GDK-backed and needs a realized window: pass any
-     * open [TaoWindow] (e.g. the popup being positioned). Ignored on
-     * Windows/macOS.
+     * open [TaoWindow] (e.g. the popup being positioned). Without one
+     * (panel-only tray apps) it falls back to the standalone-popup helper's
+     * X11-side query (XRandR primary ∩ `_NET_WORKAREA`) — the same coordinate
+     * space the standalone panel is positioned in. Ignored on Windows/macOS.
      */
     fun primaryMonitorWorkAreaPx(window: TaoWindow? = null): LongArray? =
         when (Platform.Current) {
@@ -38,6 +40,8 @@ object TaoScreenGeometry {
             Platform.Linux ->
                 if (NativeTaoBridge.isLoaded && window != null) {
                     NativeTaoBridge.nativeLinuxPrimaryMonitorWorkArea(window.handle)
+                } else if (PopupNativeBridgeLinux.isLoaded) {
+                    PopupNativeBridgeLinux.nativePrimaryWorkArea()
                 } else {
                     null
                 }
@@ -68,6 +72,10 @@ object TaoScreenGeometry {
                 Platform.Linux ->
                     if (NativeTaoBridge.isLoaded && window != null) {
                         NativeTaoBridge.nativeLinuxPrimaryMonitorScaleMilli(window.handle)
+                    } else if (PopupNativeBridgeLinux.isLoaded) {
+                        // Xft.dpi-based: the X11 coordinate space the panel
+                        // (and this work-area fallback) lives in.
+                        (PopupNativeBridgeLinux.nativeScale() * 1000).toInt()
                     } else {
                         1000
                     }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoStandalonePopup.kt
@@ -16,19 +16,39 @@ import androidx.compose.ui.window.WindowPosition
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.tao.render.StandalonePopupHost
 import dev.nucleusframework.window.tao.render.TaoStandalonePopupHost
+import dev.nucleusframework.window.tao.render.TaoStandalonePopupHostLinux
 import dev.nucleusframework.window.tao.render.TaoStandalonePopupHostMac
 
 /**
- * Standalone transparent popup (Windows + macOS): a top-level, ownerless,
- * non-activating native panel with per-pixel transparency, hosting [content]
- * in its own Compose scene. There is no backing "window" anywhere — nothing
- * appears in the taskbar/Dock or the app switcher — and rendering is driven on
+ * Whether [TaoStandalonePopup] can actually show a panel on this system.
+ *
+ * Always true on Windows and macOS (modulo native library loading). On
+ * Linux the panel is a raw X11 window and needs a reachable X server —
+ * native X11 sessions or XWayland (present on effectively all Wayland
+ * desktops). Returns false on the rare Wayland-only setups; callers should
+ * then fall back to a regular window.
+ */
+fun isTaoStandalonePopupAvailable(): Boolean =
+    when (Platform.Current) {
+        Platform.Windows, Platform.MacOS -> true
+        Platform.Linux ->
+            PopupNativeBridgeLinux.isLoaded && PopupNativeBridgeLinux.nativeIsAvailable()
+        else -> false
+    }
+
+/**
+ * Standalone transparent popup: a top-level, ownerless, non-activating
+ * native panel with per-pixel transparency, hosting [content] in its own
+ * Compose scene. There is no backing "window" anywhere — nothing appears
+ * in the taskbar/Dock or the app switcher — and rendering is driven on
  * demand (no owner window render loop). Built for system-tray popups.
  *
- * Windows uses an ownerless `WS_POPUP` + DComp surface; macOS uses an ownerless
- * non-activating `NSPanel` + `CAMetalLayer`. Linux has no equivalent that works
- * across WMs, so on Linux (or when the native pipeline is unavailable) the
- * composable is a no-op.
+ * Windows uses an ownerless `WS_POPUP` + DComp surface; macOS an ownerless
+ * non-activating `NSPanel` + `CAMetalLayer`; Linux an override-redirect
+ * ARGB32 X11 window (through XWayland on Wayland sessions — see
+ * [isTaoStandalonePopupAvailable] for the fallback signal when no X server
+ * is reachable). When the native pipeline is unavailable the composable is
+ * a no-op.
  *
  * Must be called inside `taoApplication { }` (directly or through
  * `nucleusApplication` on the Tao backend).
@@ -39,8 +59,8 @@ import dev.nucleusframework.window.tao.render.TaoStandalonePopupHostMac
  * @param size panel size in dp.
  * @param focusable whether the panel can take keyboard focus on click.
  * @param onOutsideClick invoked when the user clicks anywhere outside the
- *   panel while it is visible (native mouse-hook / NSEvent monitor, fires on
- *   mouse-down).
+ *   panel while it is visible (native mouse-hook / NSEvent monitor / XI2 raw
+ *   button monitor, fires on mouse-down).
  */
 @Suppress("FunctionNaming", "LongParameterList")
 @Composable
@@ -54,8 +74,12 @@ fun TaoStandalonePopup(
     onKeyEvent: ((KeyEvent) -> Boolean)? = null,
     content: @Composable () -> Unit,
 ) {
-    // Linux has no cross-WM transparency equivalent — no-op there.
-    if (Platform.Current != Platform.Windows && Platform.Current != Platform.MacOS) return
+    if (Platform.Current != Platform.Windows &&
+        Platform.Current != Platform.MacOS &&
+        Platform.Current != Platform.Linux
+    ) {
+        return
+    }
 
     // Native resources are allocated inside remember{}: if the composition
     // is abandoned before DisposableEffect registers, the panel leaks.
@@ -64,6 +88,7 @@ fun TaoStandalonePopup(
         remember {
             when (Platform.Current) {
                 Platform.MacOS -> TaoStandalonePopupHostMac()
+                Platform.Linux -> TaoStandalonePopupHostLinux()
                 else -> TaoStandalonePopupHost()
             }
         }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoKeyLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoKeyLinux.kt
@@ -1,0 +1,151 @@
+@file:Suppress("MagicNumber")
+
+package dev.nucleusframework.window.tao.render
+
+/**
+ * Maps X11 keysyms (`XK_*` values, forwarded as vkCode by
+ * `nucleus_tao_linux_popup.c`) to the AWT `KeyEvent.VK_*` codes + key
+ * location that Compose's desktop `Key` constants are declared with.
+ *
+ * The Linux twin of [macNativeKeyToAwt], needed by scenes fed straight from
+ * the standalone panel's X event thread (the window host path gets this
+ * translation from the Rust side instead). The native side already scans
+ * XKB groups for a Latin keysym so shortcuts land on the right key under
+ * non-Latin layouts (Ctrl+C while typing Hebrew); layout-aware letter and
+ * digit resolution from the produced character stays the fast path, same
+ * as on macOS.
+ *
+ * Latin-1 keysyms are numerically equal to their ASCII/Latin-1 character
+ * (XK_a = 0x61), so letters, digits and most US punctuation map almost
+ * 1:1 onto the AWT codes; the exceptions (quote, grave) and the whole
+ * 0xFFxx function-key block are handled explicitly.
+ */
+@Suppress("CyclomaticComplexMethod", "LongMethod") // flat lookup table, not logic
+internal fun linuxNativeKeyToAwt(
+    vkCode: Int,
+    codePoint: Int,
+): Pair<Int, Int> {
+    // Layout-aware fast path: the character the key produced.
+    if (codePoint in LINUX_LOWER_A..LINUX_LOWER_Z) return (codePoint - LINUX_CASE_OFFSET) to LINUX_LOC_STANDARD
+    if (codePoint in LINUX_UPPER_A..LINUX_UPPER_Z) return codePoint to LINUX_LOC_STANDARD
+    if (codePoint in LINUX_DIGIT_0..LINUX_DIGIT_9 && !isLinuxKeypadKeysym(vkCode)) {
+        return codePoint to LINUX_LOC_STANDARD
+    }
+
+    // Latin keysyms from the native group scan (a-z / A-Z / 0-9).
+    if (vkCode in LINUX_LOWER_A..LINUX_LOWER_Z) return (vkCode - LINUX_CASE_OFFSET) to LINUX_LOC_STANDARD
+    if (vkCode in LINUX_UPPER_A..LINUX_UPPER_Z) return vkCode to LINUX_LOC_STANDARD
+    if (vkCode in LINUX_DIGIT_0..LINUX_DIGIT_9) return vkCode to LINUX_LOC_STANDARD
+
+    return when (vkCode) {
+        // ── Editing / whitespace / escape ──
+        0xFF0D -> 10 to LINUX_LOC_STANDARD // XK_Return → VK_ENTER
+        0xFF09 -> 9 to LINUX_LOC_STANDARD // XK_Tab
+        0xFE20 -> 9 to LINUX_LOC_STANDARD // XK_ISO_Left_Tab (Shift+Tab)
+        0x0020 -> 32 to LINUX_LOC_STANDARD // XK_space
+        0xFF08 -> 8 to LINUX_LOC_STANDARD // XK_BackSpace
+        0xFF1B -> 27 to LINUX_LOC_STANDARD // XK_Escape
+        0xFFFF -> 127 to LINUX_LOC_STANDARD // XK_Delete
+        0xFF63 -> 155 to LINUX_LOC_STANDARD // XK_Insert
+
+        // ── Modifiers ──
+        0xFFE1 -> 16 to LINUX_LOC_LEFT // XK_Shift_L
+        0xFFE2 -> 16 to LINUX_LOC_RIGHT // XK_Shift_R
+        0xFFE3 -> 17 to LINUX_LOC_LEFT // XK_Control_L
+        0xFFE4 -> 17 to LINUX_LOC_RIGHT // XK_Control_R
+        0xFFE9 -> 18 to LINUX_LOC_LEFT // XK_Alt_L
+        0xFFEA -> 18 to LINUX_LOC_RIGHT // XK_Alt_R
+        0xFE03 -> 18 to LINUX_LOC_RIGHT // XK_ISO_Level3_Shift (AltGr)
+        0xFFEB -> 157 to LINUX_LOC_LEFT // XK_Super_L → VK_META
+        0xFFEC -> 157 to LINUX_LOC_RIGHT // XK_Super_R
+        0xFFE5 -> 20 to LINUX_LOC_STANDARD // XK_Caps_Lock
+        0xFF67 -> 525 to LINUX_LOC_STANDARD // XK_Menu → VK_CONTEXT_MENU
+
+        // ── Navigation ──
+        0xFF50 -> 36 to LINUX_LOC_STANDARD // XK_Home
+        0xFF57 -> 35 to LINUX_LOC_STANDARD // XK_End
+        0xFF55 -> 33 to LINUX_LOC_STANDARD // XK_Page_Up
+        0xFF56 -> 34 to LINUX_LOC_STANDARD // XK_Page_Down
+        0xFF51 -> 37 to LINUX_LOC_STANDARD // XK_Left
+        0xFF52 -> 38 to LINUX_LOC_STANDARD // XK_Up
+        0xFF53 -> 39 to LINUX_LOC_STANDARD // XK_Right
+        0xFF54 -> 40 to LINUX_LOC_STANDARD // XK_Down
+
+        // ── Function keys ──
+        0xFFBE -> 112 to LINUX_LOC_STANDARD // XK_F1
+        0xFFBF -> 113 to LINUX_LOC_STANDARD
+        0xFFC0 -> 114 to LINUX_LOC_STANDARD
+        0xFFC1 -> 115 to LINUX_LOC_STANDARD
+        0xFFC2 -> 116 to LINUX_LOC_STANDARD
+        0xFFC3 -> 117 to LINUX_LOC_STANDARD
+        0xFFC4 -> 118 to LINUX_LOC_STANDARD
+        0xFFC5 -> 119 to LINUX_LOC_STANDARD
+        0xFFC6 -> 120 to LINUX_LOC_STANDARD
+        0xFFC7 -> 121 to LINUX_LOC_STANDARD
+        0xFFC8 -> 122 to LINUX_LOC_STANDARD
+        0xFFC9 -> 123 to LINUX_LOC_STANDARD // XK_F12
+
+        // ── Keypad (NumLock on) ──
+        0xFFB0 -> 96 to LINUX_LOC_NUMPAD // XK_KP_0
+        0xFFB1 -> 97 to LINUX_LOC_NUMPAD
+        0xFFB2 -> 98 to LINUX_LOC_NUMPAD
+        0xFFB3 -> 99 to LINUX_LOC_NUMPAD
+        0xFFB4 -> 100 to LINUX_LOC_NUMPAD
+        0xFFB5 -> 101 to LINUX_LOC_NUMPAD
+        0xFFB6 -> 102 to LINUX_LOC_NUMPAD
+        0xFFB7 -> 103 to LINUX_LOC_NUMPAD
+        0xFFB8 -> 104 to LINUX_LOC_NUMPAD
+        0xFFB9 -> 105 to LINUX_LOC_NUMPAD // XK_KP_9
+        0xFF8D -> 10 to LINUX_LOC_NUMPAD // XK_KP_Enter
+        0xFFAA -> 106 to LINUX_LOC_NUMPAD // XK_KP_Multiply
+        0xFFAB -> 107 to LINUX_LOC_NUMPAD // XK_KP_Add
+        0xFFAC -> 108 to LINUX_LOC_NUMPAD // XK_KP_Separator
+        0xFFAD -> 109 to LINUX_LOC_NUMPAD // XK_KP_Subtract
+        0xFFAE -> 110 to LINUX_LOC_NUMPAD // XK_KP_Decimal
+        0xFFAF -> 111 to LINUX_LOC_NUMPAD // XK_KP_Divide
+        0xFFBD -> 61 to LINUX_LOC_NUMPAD // XK_KP_Equal
+
+        // ── Keypad (NumLock off) ──
+        0xFF95 -> 36 to LINUX_LOC_NUMPAD // XK_KP_Home
+        0xFF9C -> 35 to LINUX_LOC_NUMPAD // XK_KP_End
+        0xFF9A -> 33 to LINUX_LOC_NUMPAD // XK_KP_Page_Up
+        0xFF9B -> 34 to LINUX_LOC_NUMPAD // XK_KP_Page_Down
+        0xFF96 -> 37 to LINUX_LOC_NUMPAD // XK_KP_Left
+        0xFF97 -> 38 to LINUX_LOC_NUMPAD // XK_KP_Up
+        0xFF98 -> 39 to LINUX_LOC_NUMPAD // XK_KP_Right
+        0xFF99 -> 40 to LINUX_LOC_NUMPAD // XK_KP_Down
+        0xFF9E -> 155 to LINUX_LOC_NUMPAD // XK_KP_Insert
+        0xFF9F -> 127 to LINUX_LOC_NUMPAD // XK_KP_Delete
+        0xFF9D -> 12 to LINUX_LOC_NUMPAD // XK_KP_Begin → VK_CLEAR
+
+        // ── US punctuation (Latin-1 keysym == ASCII; AWT diverges on two) ──
+        0x0027 -> 222 to LINUX_LOC_STANDARD // XK_apostrophe → VK_QUOTE
+        0x0060 -> 192 to LINUX_LOC_STANDARD // XK_grave → VK_BACK_QUOTE
+        0x002D -> 45 to LINUX_LOC_STANDARD // XK_minus
+        0x003D -> 61 to LINUX_LOC_STANDARD // XK_equal
+        0x005B -> 91 to LINUX_LOC_STANDARD // XK_bracketleft
+        0x005D -> 93 to LINUX_LOC_STANDARD // XK_bracketright
+        0x003B -> 59 to LINUX_LOC_STANDARD // XK_semicolon
+        0x005C -> 92 to LINUX_LOC_STANDARD // XK_backslash
+        0x002C -> 44 to LINUX_LOC_STANDARD // XK_comma
+        0x002E -> 46 to LINUX_LOC_STANDARD // XK_period
+        0x002F -> 47 to LINUX_LOC_STANDARD // XK_slash
+
+        else -> 0 to LINUX_LOC_STANDARD // Key.Unknown
+    }
+}
+
+private fun isLinuxKeypadKeysym(vkCode: Int): Boolean = vkCode in 0xFF80..0xFFBD
+
+private const val LINUX_LOC_STANDARD = java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
+private const val LINUX_LOC_LEFT = java.awt.event.KeyEvent.KEY_LOCATION_LEFT
+private const val LINUX_LOC_RIGHT = java.awt.event.KeyEvent.KEY_LOCATION_RIGHT
+private const val LINUX_LOC_NUMPAD = java.awt.event.KeyEvent.KEY_LOCATION_NUMPAD
+
+private const val LINUX_LOWER_A = 'a'.code
+private const val LINUX_LOWER_Z = 'z'.code
+private const val LINUX_UPPER_A = 'A'.code
+private const val LINUX_UPPER_Z = 'Z'.code
+private const val LINUX_DIGIT_0 = '0'.code
+private const val LINUX_DIGIT_9 = '9'.code
+private const val LINUX_CASE_OFFSET = 32

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoStandalonePopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoStandalonePopupHostLinux.kt
@@ -1,0 +1,441 @@
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.runtime.BroadcastFrameClock
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.asComposeCanvas
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.WindowInfo
+import androidx.compose.ui.scene.CanvasLayersComposeScene
+import androidx.compose.ui.scene.ComposeScene
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import dev.nucleusframework.window.tao.GlobalLayoutDirection
+import dev.nucleusframework.window.tao.NativeTaoEglBridge
+import dev.nucleusframework.window.tao.PopupNativeBridgeLinux
+import dev.nucleusframework.window.tao.TaoCursorIcon
+import dev.nucleusframework.window.tao.TaoMainDispatcher
+import dev.nucleusframework.window.tao.toTaoCursorIconCode
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.GLAssembledInterface
+import org.jetbrains.skia.makeGLWithInterface
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.math.roundToInt
+
+/**
+ * Standalone transparent popup surface (Linux): a top-level, ownerless,
+ * override-redirect ARGB32 X11 window driving its own Compose scene — the
+ * Linux counterpart of [TaoStandalonePopupHost] (Windows) and
+ * [TaoStandalonePopupHostMac]. Works on X11 sessions and, through XWayland,
+ * on Wayland sessions too (even while the app itself is a native Wayland
+ * client — the panel is an independent X client on its own connection).
+ *
+ * Differences from the Windows host:
+ *  - No headless bootstrap and no shared process context: the Linux EGL
+ *    convention is one private context per attachment
+ *    (`NativeTaoEglBridge.nativeAttachX11`), so there are no sibling
+ *    surfaces to `resetGLAll` against.
+ *  - `eglSwapInterval(0)`: presents must never block the Tao main thread
+ *    on the compositor's vsync; frame pacing is our own 60 fps pacer,
+ *    same as the Windows DComp path.
+ *
+ * Threading: construction and every public method must run on the Tao main
+ * thread (the composable wrapper guarantees this) — it owns both the X
+ * command connection and the panel's EGL context. Input callbacks arrive
+ * on the panel's X event thread and hop to the main thread before touching
+ * the scene.
+ */
+@OptIn(InternalComposeUiApi::class)
+internal class TaoStandalonePopupHostLinux : StandalonePopupHost {
+    override val isValid: Boolean
+
+    private var panel: Long = 0
+    private var attachment: Long = 0
+    private var directContext: DirectContext? = null
+    private var scene: ComposeScene? = null
+    private var disposed = false
+
+    /**
+     * `Xft.dpi`-derived: the panel lives in the X11 coordinate space, which
+     * under XWayland is logical — GDK's Wayland monitor scale would mis-size
+     * it. Captured once; live DPI changes are NOT tracked.
+     */
+    override val scale: Float
+
+    private var widthPx: Int = 1
+    private var heightPx: Int = 1
+
+    override var onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null
+    override var onKeyEvent: ((KeyEvent) -> Boolean)? = null
+
+    private val frameClock = BroadcastFrameClock { scheduleRender() }
+    private val flushingDispatcher = FlushingDispatcher()
+    private val windowInfo = StandalonePopupWindowInfo()
+
+    private val renderPending = AtomicBoolean(false)
+    private var nextFrameNs = 0L
+    private var visible = false
+
+    init {
+        var valid = false
+        var panelScale = 1f
+        if (!PopupNativeBridgeLinux.isLoaded || !NativeTaoEglBridge.isLoaded) {
+            logger.warning("Standalone popup unavailable: native bridges not loaded")
+        } else if (!PopupNativeBridgeLinux.nativeIsAvailable()) {
+            logger.warning("Standalone popup unavailable: no X server (DISPLAY unset, no XWayland?)")
+        } else {
+            panelScale = PopupNativeBridgeLinux.nativeScale()
+            panel =
+                PopupNativeBridgeLinux.nativeCreatePanel(
+                    xPx = HIDDEN_X_PX,
+                    yPx = HIDDEN_Y_PX,
+                    widthPx = 1,
+                    heightPx = 1,
+                )
+            if (panel == 0L) {
+                logger.warning("Standalone popup unavailable: panel creation failed (no ARGB visual?)")
+            } else {
+                attachment =
+                    NativeTaoEglBridge.nativeAttachX11(
+                        displayPtr = PopupNativeBridgeLinux.nativeDisplayPtr(),
+                        xid = PopupNativeBridgeLinux.nativeWindowXid(panel),
+                        widthPx = 1,
+                        heightPx = 1,
+                    )
+                if (attachment == 0L) {
+                    logger.warning("Standalone popup unavailable: EGL attach failed")
+                    PopupNativeBridgeLinux.nativeRelease(panel)
+                    panel = 0
+                } else {
+                    // attachX11 left the context current with swap interval 1;
+                    // never block the Tao main thread on the compositor's vsync.
+                    NativeTaoEglBridge.nativeSetSwapInterval(attachment, 0)
+                    directContext =
+                        runCatching {
+                            val intf =
+                                GLAssembledInterface.createFromNativePointers(
+                                    0L,
+                                    NativeTaoEglBridge.nativeGetProcAddrFunctionPointer(),
+                                )
+                            DirectContext.makeGLWithInterface(intf)
+                        }.getOrNull()
+                    if (directContext != null) {
+                        scene =
+                            CanvasLayersComposeScene(
+                                density = Density(panelScale),
+                                layoutDirection = GlobalLayoutDirection,
+                                size = IntSize(1, 1),
+                                coroutineContext = flushingDispatcher + frameClock,
+                                platformContext = StandalonePopupPlatformContext(),
+                                invalidate = { scheduleRender() },
+                            )
+                        PopupNativeBridgeLinux.nativeSetEventCallback(panel, PanelEventCallback())
+                        valid = true
+                        logger.fine { "Standalone popup panel ready (panel=$panel, scale=$panelScale)" }
+                    } else {
+                        logger.warning("Standalone popup unavailable: Skia DirectContext creation failed")
+                        NativeTaoEglBridge.nativeDetach(attachment)
+                        attachment = 0
+                        PopupNativeBridgeLinux.nativeRelease(panel)
+                        panel = 0
+                    }
+                }
+            }
+        }
+        scale = panelScale
+        isValid = valid
+    }
+
+    override fun setContent(content: @Composable () -> Unit) {
+        scene?.setContent(content)
+        scheduleRender()
+    }
+
+    /** Logical (dp) screen position and size of the panel. */
+    override fun setFrame(
+        xDp: Float,
+        yDp: Float,
+        widthDp: Float,
+        heightDp: Float,
+    ) {
+        if (!isValid) return
+        val x = (xDp * scale).roundToInt()
+        val y = (yDp * scale).roundToInt()
+        val w = (widthDp * scale).roundToInt().coerceAtLeast(1)
+        val h = (heightDp * scale).roundToInt().coerceAtLeast(1)
+        PopupNativeBridgeLinux.nativeSetFrameOnScreen(
+            panel = panel,
+            xPx = x,
+            yPx = y,
+            widthPx = w,
+            heightPx = h,
+        )
+        if (w != widthPx || h != heightPx) {
+            widthPx = w
+            heightPx = h
+            // X11 EGL surfaces follow the window; this refreshes the cached size.
+            NativeTaoEglBridge.nativeResize(attachment, w, h, scale)
+            scene?.size = IntSize(w, h)
+            windowInfo.containerSizeState = IntSize(w, h)
+        }
+        scheduleRender()
+    }
+
+    override fun setVisible(visible: Boolean) {
+        if (!isValid || visible == this.visible) return
+        this.visible = visible
+        if (visible) {
+            PopupNativeBridgeLinux.nativeSetPanelVisible(panel, true)
+            scheduleRender()
+        } else {
+            // Restore the arrow before unmapping so a text-field I-beam
+            // doesn't linger over whatever ends up under the pointer.
+            PopupNativeBridgeLinux.nativeSetPanelCursor(panel, TaoCursorIcon.DEFAULT)
+            PopupNativeBridgeLinux.nativeSetPanelVisible(panel, false)
+        }
+    }
+
+    override fun setFocusable(focusable: Boolean) {
+        if (!isValid) return
+        PopupNativeBridgeLinux.nativeSetFocusable(panel, focusable)
+    }
+
+    override fun setOutsideClickListener(listener: (() -> Unit)?) {
+        if (!isValid) return
+        if (listener != null) {
+            PopupNativeBridgeLinux.nativeInstallOutsideClickMonitor(panel, PanelOutsideClickListener(listener))
+        } else {
+            PopupNativeBridgeLinux.nativeUninstallOutsideClickMonitor(panel)
+        }
+    }
+
+    /**
+     * Named inner class so GraalVM JNI reachability metadata can register
+     * the implementor (same pattern as the Windows/macOS hosts).
+     */
+    private class PanelOutsideClickListener(
+        private val listener: () -> Unit,
+    ) : PopupNativeBridgeLinux.OutsideClickListener {
+        override fun onOutsideClick(
+            type: Int,
+            button: Int,
+        ) {
+            // Arrives on the panel's X event thread.
+            TaoMainDispatcher.dispatch(EmptyCoroutineContext) { listener() }
+        }
+    }
+
+    override fun dispose() {
+        if (!isValid || disposed) return
+        disposed = true
+        PopupNativeBridgeLinux.nativeUninstallOutsideClickMonitor(panel)
+        PopupNativeBridgeLinux.nativeSetEventCallback(panel, null)
+        scene?.close()
+        scene = null
+        NativeTaoEglBridge.nativeMakeCurrent(attachment)
+        directContext?.close()
+        directContext = null
+        NativeTaoEglBridge.nativeDetach(attachment)
+        attachment = 0
+        PopupNativeBridgeLinux.nativeRelease(panel)
+        panel = 0
+    }
+
+    // ── Rendering ─────────────────────────────────────────────────────────
+
+    private fun scheduleRender() {
+        if (disposed) return
+        if (!renderPending.compareAndSet(false, true)) return
+        TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() }
+    }
+
+    private fun renderNow() {
+        renderPending.set(false)
+        if (disposed) return
+        val ctx = directContext ?: return
+        val sc = scene ?: return
+        if (widthPx <= 0 || heightPx <= 0) return
+
+        // Keep the scene's coroutine work (recomposer steps, effects) moving
+        // even while hidden — only the GPU part is skipped below.
+        flushingDispatcher.drain()
+        if (!visible) return
+
+        // Pace self-invalidating content (animations): swap interval is 0,
+        // so an unthrottled invalidate->render loop would spin the Tao
+        // thread at 100%. Pacing runs on an ABSOLUTE deadline (nextFrameNs)
+        // so scheduling latency doesn't accumulate as drift, and the frame
+        // clock is fed evenly spaced timestamps.
+        val now = System.nanoTime()
+        if (now < nextFrameNs) {
+            if (renderPending.compareAndSet(false, true)) {
+                pacer.schedule(
+                    { TaoMainDispatcher.dispatch(EmptyCoroutineContext) { renderNow() } },
+                    nextFrameNs - now,
+                    TimeUnit.NANOSECONDS,
+                )
+            }
+            return
+        }
+        // Resynchronize after an idle gap; otherwise stay on the fixed grid.
+        val frameNs = if (now - nextFrameNs > FRAME_INTERVAL_NS) now else nextFrameNs
+        nextFrameNs = frameNs + FRAME_INTERVAL_NS
+
+        // Tick the frame clock before rendering (same ordering as the window
+        // hosts) so withFrameNanos-driven animation state is current.
+        frameClock.sendFrame(frameNs)
+        flushingDispatcher.drain()
+
+        NativeTaoEglBridge.nativeMakeCurrent(attachment)
+        // The attachment owns a private EGL context that only this host's
+        // Skia DirectContext ever touches — no resetGLAll needed (unlike the
+        // Windows shared-process-context path).
+        renderGlFrame(
+            widthPx = widthPx,
+            heightPx = heightPx,
+            directContext = ctx,
+            clearColorArgb = 0x00000000,
+            present = { NativeTaoEglBridge.nativePresent(attachment) },
+        ) { canvas, nanoTime ->
+            sc.render(canvas.asComposeCanvas(), nanoTime)
+        }
+    }
+
+    // ── Input ─────────────────────────────────────────────────────────────
+
+    /**
+     * Arrives on the panel's X event thread; every scene interaction hops
+     * to the Tao main thread (the scene is not thread-safe).
+     */
+    private inner class PanelEventCallback : PopupNativeBridgeLinux.EventCallback {
+        override fun onPointerEvent(
+            type: Int,
+            x: Float,
+            y: Float,
+            button: Int,
+            modifiers: Int,
+        ) {
+            TaoMainDispatcher.dispatch(EmptyCoroutineContext) {
+                val sc = scene ?: return@dispatch
+                if (disposed) return@dispatch
+                val pointerButton =
+                    when (button) {
+                        TaoNativeWireFormat.BUTTON_PRIMARY -> PointerButton.Primary
+                        TaoNativeWireFormat.BUTTON_SECONDARY -> PointerButton.Secondary
+                        else -> null
+                    }
+                val eventType =
+                    when (type) {
+                        TaoNativeWireFormat.PTR_DOWN -> PointerEventType.Press
+                        TaoNativeWireFormat.PTR_UP -> PointerEventType.Release
+                        else -> PointerEventType.Move
+                    }
+                sc.sendPointerEvent(
+                    eventType = eventType,
+                    position = Offset(x, y),
+                    type = PointerType.Mouse,
+                    button = pointerButton,
+                )
+            }
+        }
+
+        override fun onScroll(
+            x: Float,
+            y: Float,
+            dx: Float,
+            dy: Float,
+        ) {
+            TaoMainDispatcher.dispatch(EmptyCoroutineContext) {
+                if (disposed) return@dispatch
+                scene?.sendPointerEvent(
+                    eventType = PointerEventType.Scroll,
+                    position = Offset(x, y),
+                    scrollDelta = Offset(dx, dy),
+                    type = PointerType.Mouse,
+                )
+            }
+        }
+
+        override fun onKeyEvent(
+            type: Int,
+            vkCode: Int,
+            codePoint: Int,
+            modifiers: Int,
+        ) {
+            TaoMainDispatcher.dispatch(EmptyCoroutineContext) {
+                if (disposed) return@dispatch
+                scene?.dispatchNativeKeyEvent(
+                    type = type,
+                    vkCode = vkCode,
+                    codePoint = codePoint,
+                    modifiers = modifiers,
+                    onPreviewKeyEvent = onPreviewKeyEvent,
+                    onKeyEvent = onKeyEvent,
+                )
+            }
+        }
+    }
+
+    // ── Platform plumbing ─────────────────────────────────────────────────
+
+    private inner class StandalonePopupPlatformContext : PlatformContext.Empty() {
+        override val windowInfo: WindowInfo get() = this@TaoStandalonePopupHostLinux.windowInfo
+
+        override fun setPointerIcon(pointerIcon: PointerIcon) {
+            if (!isValid || disposed) return
+            PopupNativeBridgeLinux.nativeSetPanelCursor(panel, pointerIcon.toTaoCursorIconCode())
+        }
+    }
+
+    private inner class FlushingDispatcher : kotlinx.coroutines.CoroutineDispatcher() {
+        private val queue = ConcurrentLinkedQueue<Runnable>()
+
+        override fun dispatch(
+            context: CoroutineContext,
+            block: Runnable,
+        ) {
+            queue.add(block)
+            scheduleRender()
+        }
+
+        fun drain() {
+            var remaining = queue.size
+            while (remaining-- > 0) {
+                val runnable = queue.poll() ?: break
+                runnable.run()
+            }
+        }
+    }
+
+    private class StandalonePopupWindowInfo : WindowInfo {
+        var containerSizeState: IntSize = IntSize(1, 1)
+        override val isWindowFocused: Boolean get() = true
+        override val containerSize: IntSize get() = containerSizeState
+    }
+
+    private companion object {
+        val logger: java.util.logging.Logger =
+            java.util.logging.Logger
+                .getLogger(TaoStandalonePopupHostLinux::class.java.simpleName)
+
+        const val HIDDEN_X_PX: Int = -32_000
+        const val HIDDEN_Y_PX: Int = -32_000
+        const val FRAME_INTERVAL_NS: Long = 1_000_000_000L / 60
+
+        val pacer =
+            Executors.newSingleThreadScheduledExecutor { r ->
+                Thread(r, "TaoStandalonePopupPacer").apply { isDaemon = true }
+            }
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoSyntheticKey.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoSyntheticKey.kt
@@ -137,7 +137,8 @@ private fun awtModifierMask(
  *
  * [vkCode] is the platform's native virtual-key code: Windows `VK_*` values
  * match the AWT codes Compose's `Key` constants use, but macOS `NSEvent.keyCode`
- * (`kVK_*`) values do not and are translated via [macNativeKeyToAwt].
+ * (`kVK_*`) values and Linux X11 keysyms do not and are translated via
+ * [macNativeKeyToAwt] / [linuxNativeKeyToAwt].
  */
 @OptIn(InternalComposeUiApi::class)
 internal fun ComposeScene.dispatchNativeKeyEvent(
@@ -153,10 +154,10 @@ internal fun ComposeScene.dispatchNativeKeyEvent(
     val isAlt = modifiers and TaoNativeWireFormat.MOD_ALT != 0
     val isMeta = modifiers and TaoNativeWireFormat.MOD_META != 0
     val (awtVkCode, keyLocation) =
-        if (Platform.Current == Platform.MacOS) {
-            macNativeKeyToAwt(vkCode, codePoint)
-        } else {
-            vkCode to java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
+        when (Platform.Current) {
+            Platform.MacOS -> macNativeKeyToAwt(vkCode, codePoint)
+            Platform.Linux -> linuxNativeKeyToAwt(vkCode, codePoint)
+            else -> vkCode to java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
         }
     val ev =
         taoKeyEvent(

--- a/decorated-window-tao/src/main/native/linux/build.sh
+++ b/decorated-window-tao/src/main/native/linux/build.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
-# Compiles three Linux shared libraries into per-architecture resource folders:
+# Compiles four Linux shared libraries into per-architecture resource folders:
 #   - libnucleus_tao.so              (Rust crate, Tao + JNI)
 #   - libnucleus_tao_egl.so          (C, EGL helper for Skia GL backend on
 #                                     X11 / Wayland)
 #   - libnucleus_tao_linux_widget.so (C, GTK widget reparenting helpers used
 #                                     by the GtkWidget variant of NativeView)
+#   - libnucleus_tao_linux_popup.so  (C, standalone transparent popup panel —
+#                                     raw X11/XWayland window for TrayApp)
 #
 # Outputs are placed in src/main/resources/nucleus/native/{linux-x64,linux-aarch64}/.
 #
@@ -115,7 +117,27 @@ case "$HOST_ARCH" in
     aarch64|arm64) build_widget "$OUT_DIR_ARM64" ;;
 esac
 
-# ── 5) Clear NativeLibraryLoader cache so fresh .so's are picked up ────────
+# ── 5) Standalone popup panel helper (libnucleus_tao_linux_popup.so) ───────
+# Compiled against the system X11/XI2 headers (present wherever libgtk-3-dev
+# is) but linked with -ldl only: libX11/libXi/libxkbcommon/libEGL are
+# dlopen-ed at runtime, so the .so ships standalone like its siblings.
+
+build_popup() {
+    local OUT_DIR="$1"
+    local OUT="$OUT_DIR/libnucleus_tao_linux_popup.so"
+    "$CC" -shared -fPIC -O2 -fvisibility=hidden \
+        -I"$JNI_INCLUDE" -I"$JNI_INCLUDE_LINUX" \
+        "$SCRIPT_DIR/nucleus_tao_linux_popup.c" -ldl -lpthread \
+        -o "$OUT"
+    strip --strip-unneeded "$OUT" || true
+}
+
+case "$HOST_ARCH" in
+    x86_64)        build_popup "$OUT_DIR_X64"   ;;
+    aarch64|arm64) build_popup "$OUT_DIR_ARM64" ;;
+esac
+
+# ── 6) Clear NativeLibraryLoader cache so fresh .so's are picked up ────────
 # Per the Linux module checklist in CLAUDE.md: skipping this serves the stale
 # cached copy out of ~/.cache/nucleus/native/<arch>/.
 
@@ -128,6 +150,6 @@ done
 
 echo "Built Linux native libraries:"
 case "$HOST_ARCH" in
-    x86_64) ls -lh "$OUT_DIR_X64"/{libnucleus_tao.so,libnucleus_tao_egl.so,libnucleus_tao_linux_widget.so} ;;
-    aarch64|arm64) ls -lh "$OUT_DIR_ARM64"/{libnucleus_tao.so,libnucleus_tao_egl.so,libnucleus_tao_linux_widget.so} ;;
+    x86_64) ls -lh "$OUT_DIR_X64"/{libnucleus_tao.so,libnucleus_tao_egl.so,libnucleus_tao_linux_widget.so,libnucleus_tao_linux_popup.so} ;;
+    aarch64|arm64) ls -lh "$OUT_DIR_ARM64"/{libnucleus_tao.so,libnucleus_tao_egl.so,libnucleus_tao_linux_widget.so,libnucleus_tao_linux_popup.so} ;;
 esac

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup.c
@@ -75,9 +75,11 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
+#include <X11/Xatom.h>
 #include <X11/XKBlib.h>
 #include <X11/cursorfont.h>
 #include <X11/extensions/XInput2.h>
+#include <X11/extensions/Xrandr.h>
 
 #define NUCLEUS_TAO_POPUP_DEBUG 0
 #if NUCLEUS_TAO_POPUP_DEBUG
@@ -160,9 +162,18 @@ static struct {
     Bool (*XQueryPointer)(Display *, Window, Window *, Window *, int *, int *,
                           int *, int *, unsigned *);
 
+    Atom (*XInternAtom)(Display *, const char *, Bool);
+    int (*XGetWindowProperty)(Display *, Window, Atom, long, long, Bool, Atom,
+                              Atom *, int *, unsigned long *, unsigned long *,
+                              unsigned char **);
+
     /* libXi */
     int (*XISelectEvents)(Display *, Window, XIEventMask *, int);
     int (*XIQueryVersion)(Display *, int *, int *);
+
+    /* libXrandr (optional — full-screen fallback without it) */
+    XRRMonitorInfo *(*XRRGetMonitors)(Display *, Window, Bool, int *);
+    void (*XRRFreeMonitors)(XRRMonitorInfo *);
 
     /* libxkbcommon (optional — Latin-1 fallback without it) */
     uint32_t (*xkb_keysym_to_utf32)(uint32_t keysym);
@@ -187,16 +198,18 @@ static void *load_first(const char *const *names) {
 static int ensure_libs_loaded(void) {
     if (fn.initialized) return 1;
 
-    const char *x11_libs[] = { "libX11.so.6", "libX11.so", NULL };
-    const char *xi_libs[]  = { "libXi.so.6", "libXi.so", NULL };
-    const char *xkb_libs[] = { "libxkbcommon.so.0", "libxkbcommon.so", NULL };
-    const char *egl_libs[] = { "libEGL.so.1", "libEGL.so", NULL };
+    const char *x11_libs[]    = { "libX11.so.6", "libX11.so", NULL };
+    const char *xi_libs[]     = { "libXi.so.6", "libXi.so", NULL };
+    const char *xkb_libs[]    = { "libxkbcommon.so.0", "libxkbcommon.so", NULL };
+    const char *egl_libs[]    = { "libEGL.so.1", "libEGL.so", NULL };
+    const char *xrandr_libs[] = { "libXrandr.so.2", "libXrandr.so", NULL };
 
     void *libx11 = load_first(x11_libs);
     if (libx11 == NULL) { DBG("libX11 not found\n"); return 0; }
     void *libxi  = load_first(xi_libs);   /* optional: outside-click only */
     void *libxkb = load_first(xkb_libs);  /* optional: non-Latin-1 layouts */
     void *libegl = load_first(egl_libs);  /* optional: falls back to XGetVisualInfo */
+    void *libxrandr = load_first(xrandr_libs); /* optional: full-screen fallback */
 
 #define X11_SYM(name) fn.name = (__typeof__(fn.name)) dlsym(libx11, #name)
     X11_SYM(XOpenDisplay);       X11_SYM(XCloseDisplay);
@@ -214,6 +227,7 @@ static int ensure_libs_loaded(void) {
     X11_SYM(XLookupString);      X11_SYM(XkbKeycodeToKeysym);
     X11_SYM(XQueryExtension);    X11_SYM(XGetEventData);
     X11_SYM(XFreeEventData);     X11_SYM(XQueryPointer);
+    X11_SYM(XInternAtom);        X11_SYM(XGetWindowProperty);
 #undef X11_SYM
 
     if (libxi != NULL) {
@@ -223,6 +237,10 @@ static int ensure_libs_loaded(void) {
     if (libxkb != NULL) {
         fn.xkb_keysym_to_utf32 =
             (__typeof__(fn.xkb_keysym_to_utf32)) dlsym(libxkb, "xkb_keysym_to_utf32");
+    }
+    if (libxrandr != NULL) {
+        fn.XRRGetMonitors  = (__typeof__(fn.XRRGetMonitors))  dlsym(libxrandr, "XRRGetMonitors");
+        fn.XRRFreeMonitors = (__typeof__(fn.XRRFreeMonitors)) dlsym(libxrandr, "XRRFreeMonitors");
     }
     if (libegl != NULL) {
         fn.eglGetPlatformDisplay =
@@ -242,7 +260,8 @@ static int ensure_libs_loaded(void) {
         !fn.XCreateColormap || !fn.XFreeColormap || !fn.XGetVisualInfo ||
         !fn.XFree || !fn.XSetInputFocus || !fn.XCreateFontCursor ||
         !fn.XDefineCursor || !fn.XFreeCursor || !fn.XLookupString ||
-        !fn.XkbKeycodeToKeysym || !fn.XQueryPointer) {
+        !fn.XkbKeycodeToKeysym || !fn.XQueryPointer ||
+        !fn.XInternAtom || !fn.XGetWindowProperty) {
         DBG("missing libX11 symbols\n");
         return 0;
     }
@@ -616,21 +635,132 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeDisplayPtr(
 
 /* Xft.dpi from the root resource database. X clients live in the X
  * coordinate space (logical under XWayland), so GDK's Wayland scale must
- * NOT be used for this panel — see TaoStandalonePopupHostLinux. */
+ * NOT be used for this panel — see TaoStandalonePopupHostLinux.
+ *
+ * Opens its own short-lived connection: TaoScreenGeometry routes here from
+ * arbitrary threads (tray callbacks, Tao main) and the command connection
+ * is single-thread-owned. */
 EXPORT jfloat JNICALL
 Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeScale(
     JNIEnv *env, jclass clazz)
 {
     (void) env; (void) clazz;
-    Display *dpy = ensure_cmd_display();
-    if (dpy == NULL || fn.XResourceManagerString == NULL) return 1.0f;
+    if (!ensure_libs_loaded() || fn.XResourceManagerString == NULL) return 1.0f;
+    Display *dpy = fn.XOpenDisplay(NULL);
+    if (dpy == NULL) return 1.0f;
+    float scale = 1.0f;
     const char *rm = fn.XResourceManagerString(dpy);
-    if (rm == NULL) return 1.0f;
-    const char *entry = strstr(rm, "Xft.dpi:");
-    if (entry == NULL) return 1.0f;
-    double dpi = atof(entry + strlen("Xft.dpi:"));
-    if (dpi < 48.0 || dpi > 480.0) return 1.0f;
-    return (float) (dpi / 96.0);
+    if (rm != NULL) {
+        const char *entry = strstr(rm, "Xft.dpi:");
+        if (entry != NULL) {
+            double dpi = atof(entry + strlen("Xft.dpi:"));
+            if (dpi >= 48.0 && dpi <= 480.0) scale = (float) (dpi / 96.0);
+        }
+    }
+    fn.XCloseDisplay(dpy);
+    return scale;
+}
+
+/* Reads one CARDINAL[] root property; returns the item count (0 on failure).
+ * The returned pointer must be XFree'd by the caller. */
+static unsigned long read_root_cardinals(Display *dpy, Window root,
+                                         const char *name, long max_items,
+                                         unsigned long **out_items) {
+    *out_items = NULL;
+    Atom atom = fn.XInternAtom(dpy, name, True);
+    if (atom == None) return 0;
+    Atom actual_type = None;
+    int actual_format = 0;
+    unsigned long nitems = 0, bytes_after = 0;
+    unsigned char *prop = NULL;
+    if (fn.XGetWindowProperty(dpy, root, atom, 0, max_items, False, XA_CARDINAL,
+                              &actual_type, &actual_format, &nitems, &bytes_after,
+                              &prop) != Success ||
+        prop == NULL || actual_format != 32 || nitems == 0) {
+        if (prop != NULL) fn.XFree(prop);
+        return 0;
+    }
+    *out_items = (unsigned long *) prop;
+    return nitems;
+}
+
+/*
+ * Primary-monitor work area in X11 pixels, `[x, y, width, height]`:
+ * the XRandR primary monitor (full screen without XRandR) intersected with
+ * EWMH's `_NET_WORKAREA` for the current desktop (screen minus panels/docks
+ * — Mutter maintains it on XWayland too). Backs
+ * `TaoScreenGeometry.primaryMonitorWorkAreaPx` when no realized Tao window
+ * exists (panel-only tray apps); the GDK path needs a window, this one
+ * doesn't. Own short-lived connection — callable from any thread.
+ */
+EXPORT jlongArray JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativePrimaryWorkArea(
+    JNIEnv *env, jclass clazz)
+{
+    (void) clazz;
+    if (!ensure_libs_loaded()) return NULL;
+    Display *dpy = fn.XOpenDisplay(NULL);
+    if (dpy == NULL) return NULL;
+    Window root = DefaultRootWindow(dpy);
+
+    long mon_x = 0, mon_y = 0;
+    long mon_w = DisplayWidth(dpy, DefaultScreen(dpy));
+    long mon_h = DisplayHeight(dpy, DefaultScreen(dpy));
+    if (fn.XRRGetMonitors != NULL && fn.XRRFreeMonitors != NULL) {
+        int nmon = 0;
+        XRRMonitorInfo *mons = fn.XRRGetMonitors(dpy, root, True, &nmon);
+        if (mons != NULL) {
+            for (int i = 0; i < nmon; i++) {
+                if (mons[i].primary || i == 0) {
+                    mon_x = mons[i].x;
+                    mon_y = mons[i].y;
+                    mon_w = mons[i].width;
+                    mon_h = mons[i].height;
+                }
+                if (mons[i].primary) break;
+            }
+            fn.XRRFreeMonitors(mons);
+        }
+    }
+
+    /* _NET_WORKAREA holds 4 CARDINALs per desktop; pick the current one. */
+    unsigned long desktop = 0;
+    unsigned long *items = NULL;
+    if (read_root_cardinals(dpy, root, "_NET_CURRENT_DESKTOP", 1, &items) >= 1) {
+        desktop = items[0];
+    }
+    if (items != NULL) { fn.XFree(items); items = NULL; }
+
+    long out_x = mon_x, out_y = mon_y, out_w = mon_w, out_h = mon_h;
+    unsigned long nitems =
+        read_root_cardinals(dpy, root, "_NET_WORKAREA", 4L * 64, &items);
+    if (items != NULL) {
+        if (nitems < (desktop + 1) * 4) desktop = 0;
+        if (nitems >= (desktop + 1) * 4) {
+            long wa_x = (long) items[desktop * 4];
+            long wa_y = (long) items[desktop * 4 + 1];
+            long wa_w = (long) items[desktop * 4 + 2];
+            long wa_h = (long) items[desktop * 4 + 3];
+            long left   = mon_x > wa_x ? mon_x : wa_x;
+            long top    = mon_y > wa_y ? mon_y : wa_y;
+            long right  = (mon_x + mon_w) < (wa_x + wa_w) ? (mon_x + mon_w) : (wa_x + wa_w);
+            long bottom = (mon_y + mon_h) < (wa_y + wa_h) ? (mon_y + mon_h) : (wa_y + wa_h);
+            if (right > left && bottom > top) {
+                out_x = left;
+                out_y = top;
+                out_w = right - left;
+                out_h = bottom - top;
+            }
+        }
+        fn.XFree(items);
+    }
+    fn.XCloseDisplay(dpy);
+
+    jlongArray result = (*env)->NewLongArray(env, 4);
+    if (result == NULL) return NULL;
+    jlong values[4] = { out_x, out_y, out_w, out_h };
+    (*env)->SetLongArrayRegion(env, result, 0, 4, values);
+    return result;
 }
 
 /* Picks the X visual for the panel from EGL's alpha-capable desktop-GL

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_popup.c
@@ -1,0 +1,947 @@
+/**
+ * JNI bridge: standalone transparent popup panel for Linux (X11 / XWayland).
+ *
+ * The Linux counterpart of `windows/nucleus_tao_windows_popup.c` and
+ * `macos/popup_panel.m`: a top-level, ownerless, override-redirect ARGB32
+ * X11 window with per-pixel transparency, positioned in global screen
+ * coordinates, that never appears in the taskbar / Alt-Tab and never
+ * activates the application. Rendering is done by the Kotlin host through
+ * `NativeTaoEglBridge.nativeAttachX11` on the window this module creates.
+ *
+ * Why raw X11 and not GTK: GDK's backend is process-wide (native Wayland
+ * on Wayland sessions), and Wayland has no ownerless globally-positioned
+ * topmost surface (no layer-shell in vendored Tao, `gtk_window_move` is a
+ * no-op on xdg-toplevels). A raw X11 window on its own `XOpenDisplay`
+ * connection is an independent X client that works even while the app
+ * itself is a native Wayland client — through XWayland, which is present
+ * on effectively all desktops. When `XOpenDisplay` fails (rare
+ * Wayland-only kiosks), `nativeIsAvailable` returns false and the caller
+ * falls back to a regular window.
+ *
+ * Visual selection: the window's visual is derived from EGL itself (first
+ * alpha=8 desktop-GL `EGLConfig` whose `EGL_NATIVE_VISUAL_ID` is a 32-bit
+ * X visual). `nativeAttachX11` later resolves the same `EGLDisplay` for
+ * the same `Display*` and matches that exact config — no child-window
+ * fallback, alpha preserved end to end.
+ *
+ * Threading model — two X connections, each single-threaded (no
+ * XInitThreads dependency):
+ *   - The COMMAND connection (`g_cmd_dpy`) is owned by the Tao main
+ *     thread. Every JNI entry point below runs on it (the composable
+ *     wrapper guarantees this): create/move/map/unmap/cursor/destroy.
+ *     The Kotlin host also hands this `Display*` to
+ *     `NativeTaoEglBridge.nativeAttachX11`, so EGL work stays on the
+ *     same thread/connection.
+ *   - Each panel owns an EVENT connection + thread: it opens its own
+ *     `Display`, calls `XSelectInput` on the panel XID (event masks are
+ *     per-client, so this works across connections) and blocks in a
+ *     `poll()` loop on the X fd + a quit pipe. Input events are forwarded
+ *     to Java through cached JNI method IDs (same pattern as
+ *     `nucleus_tao_linux_widget.c`).
+ *
+ * Outside-click: XI2 raw ButtonPress on the root window — the X11 analog
+ * of the Windows `WH_MOUSE_LL` hook (raw events are observe-only, don't
+ * consume, and multiple clients may listen). Fully global on X11
+ * sessions; under XWayland raw events only fire while X11 surfaces have
+ * input focus — the tray-icon toggle covers the remaining cases.
+ *
+ * Keyboard: clicking the panel while focusable calls
+ * `XSetInputFocus(RevertToParent)` (the `takeKeyboardFocus()` equivalent).
+ * Key events forward the ACTIVE-layout keysym resolved to a Unicode code
+ * point via libxkbcommon (`xkb_keysym_to_utf32` — needed for non-Latin-1
+ * layouts, e.g. Hebrew), plus a LATIN keysym scanned across XKB groups as
+ * the vkCode so shortcuts (Ctrl+C on a Hebrew layout) land on the right
+ * `Key`. `linuxNativeKeyToAwt` (TaoKeyLinux.kt) does the keysym → AWT VK
+ * translation Kotlin-side.
+ *
+ * Build: compiled against the system X11/XI2 headers (guaranteed present
+ * wherever Tao's GTK 3 dev headers are, i.e. every build environment) but
+ * linked with `-ldl` only — libX11.so.6, libXi.so.6, libxkbcommon.so.0
+ * and libEGL.so.1 are dlopen-ed at runtime so the .so ships standalone,
+ * matching `nucleus_tao_egl.c`. XEvent/XVisualInfo layouts are stable
+ * Xlib ABI; using the real headers avoids hand-redeclaring the XEvent
+ * union.
+ */
+
+#include <jni.h>
+#include <dlfcn.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/XKBlib.h>
+#include <X11/cursorfont.h>
+#include <X11/extensions/XInput2.h>
+
+#define NUCLEUS_TAO_POPUP_DEBUG 0
+#if NUCLEUS_TAO_POPUP_DEBUG
+#define DBG(...) fprintf(stderr, "[nucleus_tao_linux_popup] " __VA_ARGS__)
+#else
+#define DBG(...) ((void)0)
+#endif
+
+/* ── Wire format (must stay in sync with TaoNativeWireFormat.kt) ────────── */
+
+#define WIRE_PTR_DOWN 1
+#define WIRE_PTR_UP   2
+#define WIRE_PTR_MOVE 3
+
+#define WIRE_BUTTON_NONE      0
+#define WIRE_BUTTON_PRIMARY   1
+#define WIRE_BUTTON_SECONDARY 2
+
+#define WIRE_KEY_DOWN 1
+#define WIRE_KEY_UP   2
+
+#define WIRE_MOD_SHIFT 0x1
+#define WIRE_MOD_CTRL  0x2
+#define WIRE_MOD_ALT   0x4
+#define WIRE_MOD_META  0x8
+
+/* TaoCursorIcon codes (NativeTaoBridge.kt). */
+#define ICON_DEFAULT     0
+#define ICON_TEXT        1
+#define ICON_HAND        2
+#define ICON_CROSSHAIR   3
+#define ICON_WAIT        4
+#define ICON_MOVE        5
+#define ICON_NOT_ALLOWED 6
+#define ICON_HELP        7
+#define ICON_PROGRESS    8
+#define ICON_EW_RESIZE   9
+#define ICON_NS_RESIZE   10
+#define ICON_NESW_RESIZE 11
+#define ICON_NWSE_RESIZE 12
+
+/* ── dlopen-ed symbol tables ────────────────────────────────────────────── */
+
+typedef struct xkb_keysym_dummy xkb_keysym_dummy; /* unused, keeps clang-tidy calm */
+
+static struct {
+    int initialized;
+
+    /* libX11 */
+    Display *(*XOpenDisplay)(const char *);
+    int (*XCloseDisplay)(Display *);
+    Window (*XCreateWindow)(Display *, Window, int, int, unsigned, unsigned,
+                            unsigned, int, unsigned, Visual *, unsigned long,
+                            XSetWindowAttributes *);
+    int (*XDestroyWindow)(Display *, Window);
+    int (*XMapRaised)(Display *, Window);
+    int (*XUnmapWindow)(Display *, Window);
+    int (*XRaiseWindow)(Display *, Window);
+    int (*XMoveResizeWindow)(Display *, Window, int, int, unsigned, unsigned);
+    int (*XFlush)(Display *);
+    int (*XSync)(Display *, Bool);
+    int (*XSelectInput)(Display *, Window, long);
+    int (*XNextEvent)(Display *, XEvent *);
+    int (*XPending)(Display *);
+    Colormap (*XCreateColormap)(Display *, Window, Visual *, int);
+    int (*XFreeColormap)(Display *, Colormap);
+    XVisualInfo *(*XGetVisualInfo)(Display *, long, XVisualInfo *, int *);
+    int (*XFree)(void *);
+    int (*XSetInputFocus)(Display *, Window, int, Time);
+    Cursor (*XCreateFontCursor)(Display *, unsigned int);
+    int (*XDefineCursor)(Display *, Window, Cursor);
+    int (*XFreeCursor)(Display *, Cursor);
+    int (*XStoreName)(Display *, Window, const char *);
+    char *(*XResourceManagerString)(Display *);
+    int (*XLookupString)(XKeyEvent *, char *, int, KeySym *, XComposeStatus *);
+    KeySym (*XkbKeycodeToKeysym)(Display *, KeyCode, unsigned, unsigned);
+    Bool (*XQueryExtension)(Display *, const char *, int *, int *, int *);
+    Bool (*XGetEventData)(Display *, XGenericEventCookie *);
+    void (*XFreeEventData)(Display *, XGenericEventCookie *);
+    Bool (*XQueryPointer)(Display *, Window, Window *, Window *, int *, int *,
+                          int *, int *, unsigned *);
+
+    /* libXi */
+    int (*XISelectEvents)(Display *, Window, XIEventMask *, int);
+    int (*XIQueryVersion)(Display *, int *, int *);
+
+    /* libxkbcommon (optional — Latin-1 fallback without it) */
+    uint32_t (*xkb_keysym_to_utf32)(uint32_t keysym);
+
+    /* libEGL (visual selection only) */
+    void *(*eglGetPlatformDisplay)(unsigned, void *, const intptr_t *);
+    void *(*eglGetDisplay)(void *);
+    int (*eglInitialize)(void *, int *, int *);
+    int (*eglBindAPI)(unsigned);
+    int (*eglChooseConfig)(void *, const int *, void **, int, int *);
+    int (*eglGetConfigAttrib)(void *, void *, int, int *);
+} fn;
+
+static void *load_first(const char *const *names) {
+    for (int i = 0; names[i] != NULL; i++) {
+        void *h = dlopen(names[i], RTLD_NOW | RTLD_GLOBAL);
+        if (h != NULL) return h;
+    }
+    return NULL;
+}
+
+static int ensure_libs_loaded(void) {
+    if (fn.initialized) return 1;
+
+    const char *x11_libs[] = { "libX11.so.6", "libX11.so", NULL };
+    const char *xi_libs[]  = { "libXi.so.6", "libXi.so", NULL };
+    const char *xkb_libs[] = { "libxkbcommon.so.0", "libxkbcommon.so", NULL };
+    const char *egl_libs[] = { "libEGL.so.1", "libEGL.so", NULL };
+
+    void *libx11 = load_first(x11_libs);
+    if (libx11 == NULL) { DBG("libX11 not found\n"); return 0; }
+    void *libxi  = load_first(xi_libs);   /* optional: outside-click only */
+    void *libxkb = load_first(xkb_libs);  /* optional: non-Latin-1 layouts */
+    void *libegl = load_first(egl_libs);  /* optional: falls back to XGetVisualInfo */
+
+#define X11_SYM(name) fn.name = (__typeof__(fn.name)) dlsym(libx11, #name)
+    X11_SYM(XOpenDisplay);       X11_SYM(XCloseDisplay);
+    X11_SYM(XCreateWindow);      X11_SYM(XDestroyWindow);
+    X11_SYM(XMapRaised);         X11_SYM(XUnmapWindow);
+    X11_SYM(XRaiseWindow);       X11_SYM(XMoveResizeWindow);
+    X11_SYM(XFlush);             X11_SYM(XSync);
+    X11_SYM(XSelectInput);       X11_SYM(XNextEvent);
+    X11_SYM(XPending);           X11_SYM(XCreateColormap);
+    X11_SYM(XFreeColormap);      X11_SYM(XGetVisualInfo);
+    X11_SYM(XFree);              X11_SYM(XSetInputFocus);
+    X11_SYM(XCreateFontCursor);  X11_SYM(XDefineCursor);
+    X11_SYM(XFreeCursor);        X11_SYM(XStoreName);
+    X11_SYM(XResourceManagerString);
+    X11_SYM(XLookupString);      X11_SYM(XkbKeycodeToKeysym);
+    X11_SYM(XQueryExtension);    X11_SYM(XGetEventData);
+    X11_SYM(XFreeEventData);     X11_SYM(XQueryPointer);
+#undef X11_SYM
+
+    if (libxi != NULL) {
+        fn.XISelectEvents = (__typeof__(fn.XISelectEvents)) dlsym(libxi, "XISelectEvents");
+        fn.XIQueryVersion = (__typeof__(fn.XIQueryVersion)) dlsym(libxi, "XIQueryVersion");
+    }
+    if (libxkb != NULL) {
+        fn.xkb_keysym_to_utf32 =
+            (__typeof__(fn.xkb_keysym_to_utf32)) dlsym(libxkb, "xkb_keysym_to_utf32");
+    }
+    if (libegl != NULL) {
+        fn.eglGetPlatformDisplay =
+            (__typeof__(fn.eglGetPlatformDisplay)) dlsym(libegl, "eglGetPlatformDisplay");
+        fn.eglGetDisplay    = (__typeof__(fn.eglGetDisplay))    dlsym(libegl, "eglGetDisplay");
+        fn.eglInitialize    = (__typeof__(fn.eglInitialize))    dlsym(libegl, "eglInitialize");
+        fn.eglBindAPI       = (__typeof__(fn.eglBindAPI))       dlsym(libegl, "eglBindAPI");
+        fn.eglChooseConfig  = (__typeof__(fn.eglChooseConfig))  dlsym(libegl, "eglChooseConfig");
+        fn.eglGetConfigAttrib =
+            (__typeof__(fn.eglGetConfigAttrib)) dlsym(libegl, "eglGetConfigAttrib");
+    }
+
+    if (!fn.XOpenDisplay || !fn.XCloseDisplay || !fn.XCreateWindow ||
+        !fn.XDestroyWindow || !fn.XMapRaised || !fn.XUnmapWindow ||
+        !fn.XRaiseWindow || !fn.XMoveResizeWindow || !fn.XFlush ||
+        !fn.XSync || !fn.XSelectInput || !fn.XNextEvent || !fn.XPending ||
+        !fn.XCreateColormap || !fn.XFreeColormap || !fn.XGetVisualInfo ||
+        !fn.XFree || !fn.XSetInputFocus || !fn.XCreateFontCursor ||
+        !fn.XDefineCursor || !fn.XFreeCursor || !fn.XLookupString ||
+        !fn.XkbKeycodeToKeysym || !fn.XQueryPointer) {
+        DBG("missing libX11 symbols\n");
+        return 0;
+    }
+    fn.initialized = 1;
+    return 1;
+}
+
+/* ── Command connection (Tao main thread) ───────────────────────────────── */
+
+static Display *g_cmd_dpy = NULL;
+static int g_cmd_dpy_failed = 0;
+
+static Display *ensure_cmd_display(void) {
+    if (g_cmd_dpy != NULL) return g_cmd_dpy;
+    if (g_cmd_dpy_failed) return NULL;
+    if (!ensure_libs_loaded()) { g_cmd_dpy_failed = 1; return NULL; }
+    g_cmd_dpy = fn.XOpenDisplay(NULL);
+    if (g_cmd_dpy == NULL) {
+        DBG("XOpenDisplay failed (no X server / XWayland?)\n");
+        g_cmd_dpy_failed = 1;
+    }
+    return g_cmd_dpy;
+}
+
+/* ── JNI callback plumbing ──────────────────────────────────────────────── */
+
+static JavaVM *g_jvm = NULL;
+
+/* Cached once per interface, from the first registered instance (all
+ * implementors are the same named classes — GraalVM metadata requirement). */
+static jmethodID g_on_pointer_event = NULL; /* (IFFII)V  */
+static jmethodID g_on_scroll        = NULL; /* (FFFF)V   */
+static jmethodID g_on_key_event     = NULL; /* (IIII)V   */
+static jmethodID g_on_outside_click = NULL; /* (II)V     */
+
+static JNIEnv *attach_jvm_thread(void) {
+    if (g_jvm == NULL) return NULL;
+    JNIEnv *env = NULL;
+    jint status = (*g_jvm)->GetEnv(g_jvm, (void **) &env, JNI_VERSION_1_8);
+    if (status == JNI_EDETACHED) {
+        if ((*g_jvm)->AttachCurrentThreadAsDaemon(g_jvm, (void **) &env, NULL) != JNI_OK) {
+            return NULL;
+        }
+    } else if (status != JNI_OK) {
+        return NULL;
+    }
+    return env;
+}
+
+static void cache_event_callback_ids(JNIEnv *env, jobject callback) {
+    if (g_on_pointer_event != NULL) return;
+    jclass cls = (*env)->GetObjectClass(env, callback);
+    if (cls == NULL) return;
+    g_on_pointer_event = (*env)->GetMethodID(env, cls, "onPointerEvent", "(IFFII)V");
+    g_on_scroll        = (*env)->GetMethodID(env, cls, "onScroll", "(FFFF)V");
+    g_on_key_event     = (*env)->GetMethodID(env, cls, "onKeyEvent", "(IIII)V");
+    (*env)->DeleteLocalRef(env, cls);
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+}
+
+static void cache_outside_listener_id(JNIEnv *env, jobject listener) {
+    if (g_on_outside_click != NULL) return;
+    jclass cls = (*env)->GetObjectClass(env, listener);
+    if (cls == NULL) return;
+    g_on_outside_click = (*env)->GetMethodID(env, cls, "onOutsideClick", "(II)V");
+    (*env)->DeleteLocalRef(env, cls);
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+}
+
+/* ── Panel state ────────────────────────────────────────────────────────── */
+
+typedef struct {
+    Window   win;
+    Colormap cmap;
+    Cursor   cursor;         /* current XCreateFontCursor, or None        */
+
+    /* Geometry mirror for the outside-click hit test (event thread reads,
+     * command thread writes). */
+    pthread_mutex_t lock;
+    int x, y, w, h;
+    int visible;
+    int focusable;
+
+    /* Event thread. */
+    pthread_t evt_thread;
+    int       evt_thread_started;
+    int       quit_pipe[2];
+
+    /* Java refs (guarded by [lock]; invoked from the event thread). */
+    jobject event_cb;    /* EventCallback global ref, or NULL   */
+    jobject outside_cb;  /* OutsideClickListener global ref     */
+} Panel;
+
+/* ── Keysym helpers ─────────────────────────────────────────────────────── */
+
+/* Active-layout keysym → Unicode code point. libxkbcommon handles every
+ * legacy keysym block (Hebrew, Cyrillic, Greek…); the fallback covers
+ * Latin-1 and the direct-Unicode keysym range only. */
+static int keysym_to_codepoint(KeySym ks) {
+    if (fn.xkb_keysym_to_utf32 != NULL) {
+        return (int) fn.xkb_keysym_to_utf32((uint32_t) ks);
+    }
+    if (ks >= 0x20 && ks <= 0xFF) return (int) ks;              /* Latin-1  */
+    if ((ks & 0xFF000000UL) == 0x01000000UL) return (int) (ks & 0x00FFFFFF);
+    return 0;
+}
+
+/* Scans XKB groups for a Latin keysym at shift level 0 so shortcuts land
+ * on the right key under non-Latin layouts (Ctrl+C while typing Hebrew).
+ * Falls back to the group-0 keysym. */
+static KeySym vk_keysym_for(Display *dpy, KeyCode keycode) {
+    for (unsigned group = 0; group < 4; group++) {
+        KeySym ks = fn.XkbKeycodeToKeysym(dpy, keycode, group, 0);
+        if (ks == NoSymbol) continue;
+        if ((ks >= 'a' && ks <= 'z') || (ks >= 'A' && ks <= 'Z') ||
+            (ks >= '0' && ks <= '9')) {
+            return ks;
+        }
+    }
+    KeySym base = fn.XkbKeycodeToKeysym(dpy, keycode, 0, 0);
+    return base != NoSymbol ? base : 0;
+}
+
+static int wire_modifiers(unsigned state) {
+    int mods = 0;
+    if (state & ShiftMask)   mods |= WIRE_MOD_SHIFT;
+    if (state & ControlMask) mods |= WIRE_MOD_CTRL;
+    if (state & Mod1Mask)    mods |= WIRE_MOD_ALT;   /* Alt   */
+    if (state & Mod4Mask)    mods |= WIRE_MOD_META;  /* Super */
+    return mods;
+}
+
+static int wire_button(unsigned xbutton) {
+    switch (xbutton) {
+        case Button1: return WIRE_BUTTON_PRIMARY;
+        case Button3: return WIRE_BUTTON_SECONDARY;
+        default:      return WIRE_BUTTON_NONE;
+    }
+}
+
+/* ── Event thread ───────────────────────────────────────────────────────── */
+
+static void forward_pointer(JNIEnv *env, Panel *p, int type, float x, float y,
+                            int button, int mods) {
+    pthread_mutex_lock(&p->lock);
+    jobject cb = p->event_cb;
+    pthread_mutex_unlock(&p->lock);
+    if (cb == NULL || g_on_pointer_event == NULL) return;
+    (*env)->CallVoidMethod(env, cb, g_on_pointer_event, (jint) type,
+                           (jfloat) x, (jfloat) y, (jint) button, (jint) mods);
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+}
+
+static void forward_scroll(JNIEnv *env, Panel *p, float x, float y,
+                           float dx, float dy) {
+    pthread_mutex_lock(&p->lock);
+    jobject cb = p->event_cb;
+    pthread_mutex_unlock(&p->lock);
+    if (cb == NULL || g_on_scroll == NULL) return;
+    (*env)->CallVoidMethod(env, cb, g_on_scroll, (jfloat) x, (jfloat) y,
+                           (jfloat) dx, (jfloat) dy);
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+}
+
+static void forward_key(JNIEnv *env, Panel *p, int type, int vk, int codepoint,
+                        int mods) {
+    pthread_mutex_lock(&p->lock);
+    jobject cb = p->event_cb;
+    pthread_mutex_unlock(&p->lock);
+    if (cb == NULL || g_on_key_event == NULL) return;
+    (*env)->CallVoidMethod(env, cb, g_on_key_event, (jint) type, (jint) vk,
+                           (jint) codepoint, (jint) mods);
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+}
+
+static void forward_outside_click(JNIEnv *env, Panel *p, int button) {
+    pthread_mutex_lock(&p->lock);
+    jobject cb = p->outside_cb;
+    pthread_mutex_unlock(&p->lock);
+    if (cb == NULL || g_on_outside_click == NULL) return;
+    (*env)->CallVoidMethod(env, cb, g_on_outside_click, (jint) 1, (jint) button);
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+}
+
+/* Raw XI2 ButtonPress: hit-test the pointer against the panel rect and
+ * notify when the press landed outside while the panel is visible. */
+static void handle_raw_press(JNIEnv *env, Display *dpy, Panel *p, int button) {
+    pthread_mutex_lock(&p->lock);
+    int visible = p->visible;
+    int px = p->x, py = p->y, pw = p->w, ph = p->h;
+    jobject cb = p->outside_cb;
+    pthread_mutex_unlock(&p->lock);
+    if (!visible || cb == NULL) return;
+
+    Window root_ret, child_ret;
+    int root_x = 0, root_y = 0, wx = 0, wy = 0;
+    unsigned mask = 0;
+    Window root = DefaultRootWindow(dpy);
+    if (!fn.XQueryPointer(dpy, root, &root_ret, &child_ret, &root_x, &root_y,
+                          &wx, &wy, &mask)) {
+        return;
+    }
+    int inside = root_x >= px && root_x < px + pw &&
+                 root_y >= py && root_y < py + ph;
+    if (!inside) {
+        int wire = button == 1 ? WIRE_BUTTON_PRIMARY
+                 : button == 3 ? WIRE_BUTTON_SECONDARY
+                 : 3; /* "other", matches the macOS monitor's encoding */
+        forward_outside_click(env, p, wire);
+    }
+}
+
+static void handle_key_event(JNIEnv *env, Display *dpy, Panel *p, XKeyEvent *ke,
+                             int wire_type) {
+    char buf[8];
+    KeySym active_ks = NoSymbol;
+    fn.XLookupString(ke, buf, sizeof(buf), &active_ks, NULL);
+    int codepoint = active_ks != NoSymbol ? keysym_to_codepoint(active_ks) : 0;
+    KeySym vk = vk_keysym_for(dpy, (KeyCode) ke->keycode);
+    /* Non-printable actives (arrows, F-keys…) map to codepoint 0 upstream;
+     * dispatchSyntheticKeyTyped filters control chars anyway. */
+    forward_key(env, p, wire_type, (int) vk, codepoint, wire_modifiers(ke->state));
+}
+
+static void *event_thread_main(void *arg) {
+    Panel *p = (Panel *) arg;
+
+    Display *dpy = fn.XOpenDisplay(NULL);
+    if (dpy == NULL) return NULL;
+
+    /* Per-client event mask on the shared XID — the command connection
+     * never selects anything, so ButtonPress ownership is uncontended. */
+    fn.XSelectInput(dpy, p->win,
+                    ButtonPressMask | ButtonReleaseMask | PointerMotionMask |
+                    KeyPressMask | KeyReleaseMask | StructureNotifyMask);
+
+    /* XI2 raw buttons on the root for the outside-click monitor. Selected
+     * unconditionally (cheap); forwarding is gated on the Java listener. */
+    int xi_opcode = -1;
+    if (fn.XISelectEvents != NULL && fn.XIQueryVersion != NULL &&
+        fn.XQueryExtension != NULL && fn.XGetEventData != NULL) {
+        int ev_base = 0, err_base = 0;
+        if (fn.XQueryExtension(dpy, "XInputExtension", &xi_opcode, &ev_base, &err_base)) {
+            int maj = 2, min = 0;
+            if (fn.XIQueryVersion(dpy, &maj, &min) == Success) {
+                unsigned char mask_bits[XIMaskLen(XI_LASTEVENT)];
+                memset(mask_bits, 0, sizeof(mask_bits));
+                XISetMask(mask_bits, XI_RawButtonPress);
+                XIEventMask evmask = {
+                    .deviceid = XIAllMasterDevices,
+                    .mask_len = sizeof(mask_bits),
+                    .mask = mask_bits,
+                };
+                fn.XISelectEvents(dpy, DefaultRootWindow(dpy), &evmask, 1);
+            } else {
+                xi_opcode = -1;
+            }
+        } else {
+            xi_opcode = -1;
+        }
+    }
+    fn.XFlush(dpy);
+
+    JNIEnv *env = attach_jvm_thread();
+
+    struct pollfd fds[2] = {
+        { .fd = ConnectionNumber(dpy), .events = POLLIN },
+        { .fd = p->quit_pipe[0],       .events = POLLIN },
+    };
+
+    int running = 1;
+    while (running) {
+        /* Drain everything already buffered before blocking in poll —
+         * Xlib reads whole batches off the socket, so poll() alone would
+         * sleep on events sitting in the client-side queue. */
+        while (fn.XPending(dpy) > 0) {
+            XEvent ev;
+            fn.XNextEvent(dpy, &ev);
+            if (env == NULL) continue;
+
+            switch (ev.type) {
+                case ButtonPress: {
+                    XButtonEvent *be = &ev.xbutton;
+                    if (be->button >= Button4 && be->button <= 7) {
+                        /* 4/5 = vertical wheel, 6/7 = horizontal. One line
+                         * per click; sign matches the Compose convention
+                         * (positive Y scrolls the content down). */
+                        float dx = be->button == 6 ? -1.0f : be->button == 7 ? 1.0f : 0.0f;
+                        float dy = be->button == Button4 ? -1.0f : be->button == Button5 ? 1.0f : 0.0f;
+                        forward_scroll(env, p, (float) be->x, (float) be->y, dx, dy);
+                        break;
+                    }
+                    pthread_mutex_lock(&p->lock);
+                    int focusable = p->focusable;
+                    pthread_mutex_unlock(&p->lock);
+                    if (focusable) {
+                        /* takeKeyboardFocus() equivalent: OR windows never
+                         * receive focus from the WM, grab it explicitly. */
+                        fn.XSetInputFocus(dpy, p->win, RevertToParent, be->time);
+                    }
+                    forward_pointer(env, p, WIRE_PTR_DOWN, (float) be->x, (float) be->y,
+                                    wire_button(be->button), wire_modifiers(be->state));
+                    break;
+                }
+                case ButtonRelease: {
+                    XButtonEvent *be = &ev.xbutton;
+                    if (be->button >= Button4 && be->button <= 7) break;
+                    forward_pointer(env, p, WIRE_PTR_UP, (float) be->x, (float) be->y,
+                                    wire_button(be->button), wire_modifiers(be->state));
+                    break;
+                }
+                case MotionNotify: {
+                    XMotionEvent *me = &ev.xmotion;
+                    forward_pointer(env, p, WIRE_PTR_MOVE, (float) me->x, (float) me->y,
+                                    WIRE_BUTTON_NONE, wire_modifiers(me->state));
+                    break;
+                }
+                case KeyPress:
+                    handle_key_event(env, dpy, p, &ev.xkey, WIRE_KEY_DOWN);
+                    break;
+                case KeyRelease:
+                    handle_key_event(env, dpy, p, &ev.xkey, WIRE_KEY_UP);
+                    break;
+                case DestroyNotify:
+                    if (ev.xdestroywindow.window == p->win) running = 0;
+                    break;
+                case GenericEvent: {
+                    XGenericEventCookie *cookie = &ev.xcookie;
+                    if (xi_opcode >= 0 && cookie->extension == xi_opcode &&
+                        cookie->evtype == XI_RawButtonPress &&
+                        fn.XGetEventData(dpy, cookie)) {
+                        XIRawEvent *raw = (XIRawEvent *) cookie->data;
+                        handle_raw_press(env, dpy, p, raw->detail);
+                        fn.XFreeEventData(dpy, cookie);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+        if (!running) break;
+
+        if (poll(fds, 2, -1) < 0) continue;
+        if (fds[1].revents & POLLIN) break; /* quit pipe */
+    }
+
+    fn.XCloseDisplay(dpy);
+    return NULL;
+}
+
+/* ── JNI exports ────────────────────────────────────────────────────────── */
+
+#define EXPORT JNIEXPORT __attribute__((visibility("default")))
+
+EXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeIsAvailable(
+    JNIEnv *env, jclass clazz)
+{
+    (void) env; (void) clazz;
+    return ensure_cmd_display() != NULL ? JNI_TRUE : JNI_FALSE;
+}
+
+EXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeDisplayPtr(
+    JNIEnv *env, jclass clazz)
+{
+    (void) env; (void) clazz;
+    return (jlong) (uintptr_t) ensure_cmd_display();
+}
+
+/* Xft.dpi from the root resource database. X clients live in the X
+ * coordinate space (logical under XWayland), so GDK's Wayland scale must
+ * NOT be used for this panel — see TaoStandalonePopupHostLinux. */
+EXPORT jfloat JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeScale(
+    JNIEnv *env, jclass clazz)
+{
+    (void) env; (void) clazz;
+    Display *dpy = ensure_cmd_display();
+    if (dpy == NULL || fn.XResourceManagerString == NULL) return 1.0f;
+    const char *rm = fn.XResourceManagerString(dpy);
+    if (rm == NULL) return 1.0f;
+    const char *entry = strstr(rm, "Xft.dpi:");
+    if (entry == NULL) return 1.0f;
+    double dpi = atof(entry + strlen("Xft.dpi:"));
+    if (dpi < 48.0 || dpi > 480.0) return 1.0f;
+    return (float) (dpi / 96.0);
+}
+
+/* Picks the X visual for the panel from EGL's alpha-capable desktop-GL
+ * configs so the later `nativeAttachX11` matches the exact same config.
+ * Falls back to any 32-bit TrueColor visual, then to CopyFromParent. */
+static Visual *choose_argb_visual(Display *dpy, int *out_depth) {
+    *out_depth = 0;
+
+    if (fn.eglInitialize != NULL && fn.eglChooseConfig != NULL &&
+        fn.eglGetConfigAttrib != NULL && fn.eglBindAPI != NULL) {
+        void *edpy = NULL;
+        if (fn.eglGetPlatformDisplay != NULL) {
+            edpy = fn.eglGetPlatformDisplay(0x31D5 /* EGL_PLATFORM_X11_KHR */, dpy, NULL);
+        }
+        if (edpy == NULL && fn.eglGetDisplay != NULL) {
+            edpy = fn.eglGetDisplay(dpy);
+        }
+        int maj = 0, min = 0;
+        if (edpy != NULL && fn.eglInitialize(edpy, &maj, &min) &&
+            fn.eglBindAPI(0x30A2 /* EGL_OPENGL_API */)) {
+            const int attrs[] = {
+                0x3033, 0x0004,   /* EGL_SURFACE_TYPE,    EGL_WINDOW_BIT */
+                0x3040, 0x0008,   /* EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT */
+                0x3024, 8, 0x3023, 8, 0x3022, 8, 0x3021, 8, /* RGBA 8888 */
+                0x3038            /* EGL_NONE */
+            };
+            void *cfgs[64];
+            int ncfg = 0;
+            if (fn.eglChooseConfig(edpy, attrs, cfgs, 64, &ncfg) && ncfg > 0) {
+                for (int i = 0; i < ncfg; i++) {
+                    int vid = 0;
+                    fn.eglGetConfigAttrib(edpy, cfgs[i], 0x302E /* NATIVE_VISUAL_ID */, &vid);
+                    if (vid == 0) continue;
+                    XVisualInfo tmpl;
+                    memset(&tmpl, 0, sizeof(tmpl));
+                    tmpl.visualid = (VisualID) vid;
+                    int n = 0;
+                    XVisualInfo *vi = fn.XGetVisualInfo(dpy, VisualIDMask, &tmpl, &n);
+                    if (vi != NULL && n > 0 && vi[0].depth == 32) {
+                        Visual *v = vi[0].visual;
+                        *out_depth = vi[0].depth;
+                        fn.XFree(vi);
+                        DBG("visual from EGL config: 0x%lx depth 32\n", (unsigned long) vid);
+                        return v;
+                    }
+                    if (vi != NULL) fn.XFree(vi);
+                }
+            }
+        }
+    }
+
+    XVisualInfo tmpl;
+    memset(&tmpl, 0, sizeof(tmpl));
+    tmpl.depth = 32;
+    tmpl.class = TrueColor;
+    int n = 0;
+    XVisualInfo *vi = fn.XGetVisualInfo(dpy, VisualDepthMask | VisualClassMask, &tmpl, &n);
+    if (vi != NULL && n > 0) {
+        Visual *v = vi[0].visual;
+        *out_depth = vi[0].depth;
+        fn.XFree(vi);
+        DBG("visual fallback: first ARGB32\n");
+        return v;
+    }
+    if (vi != NULL) fn.XFree(vi);
+    return NULL;
+}
+
+EXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeCreatePanel(
+    JNIEnv *env, jclass clazz, jint xPx, jint yPx, jint widthPx, jint heightPx)
+{
+    (void) clazz;
+    Display *dpy = ensure_cmd_display();
+    if (dpy == NULL) return 0;
+    if (g_jvm == NULL) (*env)->GetJavaVM(env, &g_jvm);
+
+    int depth = 0;
+    Visual *visual = choose_argb_visual(dpy, &depth);
+    if (visual == NULL) {
+        DBG("no ARGB visual — compositor missing?\n");
+        return 0;
+    }
+
+    Window root = DefaultRootWindow(dpy);
+    Colormap cmap = fn.XCreateColormap(dpy, root, visual, AllocNone);
+
+    XSetWindowAttributes swa;
+    memset(&swa, 0, sizeof(swa));
+    swa.colormap = cmap;
+    swa.border_pixel = 0;
+    swa.background_pixel = 0;
+    swa.override_redirect = True;
+    /* No event_mask here: input is selected per-client by the event
+     * thread's own connection. */
+    unsigned w = widthPx > 0 ? (unsigned) widthPx : 1;
+    unsigned h = heightPx > 0 ? (unsigned) heightPx : 1;
+    Window win = fn.XCreateWindow(
+        dpy, root, xPx, yPx, w, h, 0, depth, InputOutput, visual,
+        CWColormap | CWBorderPixel | CWBackPixel | CWOverrideRedirect, &swa);
+    if (win == 0) {
+        fn.XFreeColormap(dpy, cmap);
+        return 0;
+    }
+    if (fn.XStoreName != NULL) fn.XStoreName(dpy, win, "NucleusStandalonePopup");
+    fn.XSync(dpy, False);
+
+    Panel *p = (Panel *) calloc(1, sizeof(Panel));
+    if (p == NULL) {
+        fn.XDestroyWindow(dpy, win);
+        fn.XFreeColormap(dpy, cmap);
+        return 0;
+    }
+    p->win = win;
+    p->cmap = cmap;
+    p->x = xPx;
+    p->y = yPx;
+    p->w = (int) w;
+    p->h = (int) h;
+    pthread_mutex_init(&p->lock, NULL);
+    if (pipe(p->quit_pipe) != 0) {
+        p->quit_pipe[0] = p->quit_pipe[1] = -1;
+    }
+
+    if (pthread_create(&p->evt_thread, NULL, event_thread_main, p) == 0) {
+        p->evt_thread_started = 1;
+    } else {
+        DBG("event thread creation failed\n");
+    }
+
+    DBG("panel created: win=0x%lx depth=%d\n", win, depth);
+    return (jlong) (uintptr_t) p;
+}
+
+EXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeWindowXid(
+    JNIEnv *env, jclass clazz, jlong panel)
+{
+    (void) env; (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    return p != NULL ? (jlong) p->win : 0;
+}
+
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeSetFrameOnScreen(
+    JNIEnv *env, jclass clazz, jlong panel, jint xPx, jint yPx, jint widthPx, jint heightPx)
+{
+    (void) env; (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    Display *dpy = g_cmd_dpy;
+    if (p == NULL || dpy == NULL) return;
+    unsigned w = widthPx > 0 ? (unsigned) widthPx : 1;
+    unsigned h = heightPx > 0 ? (unsigned) heightPx : 1;
+    fn.XMoveResizeWindow(dpy, p->win, xPx, yPx, w, h);
+    fn.XFlush(dpy);
+    pthread_mutex_lock(&p->lock);
+    p->x = xPx;
+    p->y = yPx;
+    p->w = (int) w;
+    p->h = (int) h;
+    pthread_mutex_unlock(&p->lock);
+}
+
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeSetPanelVisible(
+    JNIEnv *env, jclass clazz, jlong panel, jboolean visible)
+{
+    (void) env; (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    Display *dpy = g_cmd_dpy;
+    if (p == NULL || dpy == NULL) return;
+    if (visible) {
+        fn.XMapRaised(dpy, p->win);
+    } else {
+        fn.XUnmapWindow(dpy, p->win);
+    }
+    fn.XFlush(dpy);
+    pthread_mutex_lock(&p->lock);
+    p->visible = visible ? 1 : 0;
+    pthread_mutex_unlock(&p->lock);
+}
+
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeSetFocusable(
+    JNIEnv *env, jclass clazz, jlong panel, jboolean focusable)
+{
+    (void) env; (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    if (p == NULL) return;
+    pthread_mutex_lock(&p->lock);
+    p->focusable = focusable ? 1 : 0;
+    pthread_mutex_unlock(&p->lock);
+}
+
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeSetPanelCursor(
+    JNIEnv *env, jclass clazz, jlong panel, jint iconCode)
+{
+    (void) env; (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    Display *dpy = g_cmd_dpy;
+    if (p == NULL || dpy == NULL) return;
+    unsigned shape;
+    switch (iconCode) {
+        case ICON_TEXT:        shape = XC_xterm;              break;
+        case ICON_HAND:        shape = XC_hand2;              break;
+        case ICON_CROSSHAIR:   shape = XC_crosshair;          break;
+        case ICON_WAIT:        shape = XC_watch;              break;
+        case ICON_MOVE:        shape = XC_fleur;              break;
+        case ICON_NOT_ALLOWED: shape = XC_X_cursor;           break;
+        case ICON_HELP:        shape = XC_question_arrow;     break;
+        case ICON_PROGRESS:    shape = XC_watch;              break;
+        case ICON_EW_RESIZE:   shape = XC_sb_h_double_arrow;  break;
+        case ICON_NS_RESIZE:   shape = XC_sb_v_double_arrow;  break;
+        case ICON_NESW_RESIZE: shape = XC_bottom_left_corner; break;
+        case ICON_NWSE_RESIZE: shape = XC_bottom_right_corner; break;
+        default:               shape = XC_left_ptr;           break;
+    }
+    Cursor cursor = fn.XCreateFontCursor(dpy, shape);
+    fn.XDefineCursor(dpy, p->win, cursor);
+    fn.XFlush(dpy);
+    if (p->cursor != None) fn.XFreeCursor(dpy, p->cursor);
+    p->cursor = cursor;
+}
+
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeSetEventCallback(
+    JNIEnv *env, jclass clazz, jlong panel, jobject callback)
+{
+    (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    if (p == NULL) return;
+    if (g_jvm == NULL) (*env)->GetJavaVM(env, &g_jvm);
+    jobject global = NULL;
+    if (callback != NULL) {
+        cache_event_callback_ids(env, callback);
+        global = (*env)->NewGlobalRef(env, callback);
+    }
+    pthread_mutex_lock(&p->lock);
+    jobject prev = p->event_cb;
+    p->event_cb = global;
+    pthread_mutex_unlock(&p->lock);
+    if (prev != NULL) (*env)->DeleteGlobalRef(env, prev);
+}
+
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeInstallOutsideClickMonitor(
+    JNIEnv *env, jclass clazz, jlong panel, jobject listener)
+{
+    (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    if (p == NULL || listener == NULL) return;
+    if (g_jvm == NULL) (*env)->GetJavaVM(env, &g_jvm);
+    cache_outside_listener_id(env, listener);
+    jobject global = (*env)->NewGlobalRef(env, listener);
+    pthread_mutex_lock(&p->lock);
+    jobject prev = p->outside_cb;
+    p->outside_cb = global;
+    pthread_mutex_unlock(&p->lock);
+    if (prev != NULL) (*env)->DeleteGlobalRef(env, prev);
+}
+
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeUninstallOutsideClickMonitor(
+    JNIEnv *env, jclass clazz, jlong panel)
+{
+    (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    if (p == NULL) return;
+    pthread_mutex_lock(&p->lock);
+    jobject prev = p->outside_cb;
+    p->outside_cb = NULL;
+    pthread_mutex_unlock(&p->lock);
+    if (prev != NULL) (*env)->DeleteGlobalRef(env, prev);
+}
+
+EXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_PopupNativeBridgeLinux_nativeRelease(
+    JNIEnv *env, jclass clazz, jlong panel)
+{
+    (void) clazz;
+    Panel *p = (Panel *) (uintptr_t) panel;
+    Display *dpy = g_cmd_dpy;
+    if (p == NULL) return;
+
+    if (p->evt_thread_started) {
+        if (p->quit_pipe[1] >= 0) {
+            char one = 1;
+            ssize_t ignored = write(p->quit_pipe[1], &one, 1);
+            (void) ignored;
+        }
+        pthread_join(p->evt_thread, NULL);
+    }
+    if (p->quit_pipe[0] >= 0) close(p->quit_pipe[0]);
+    if (p->quit_pipe[1] >= 0) close(p->quit_pipe[1]);
+
+    pthread_mutex_lock(&p->lock);
+    jobject event_cb = p->event_cb;
+    jobject outside_cb = p->outside_cb;
+    p->event_cb = NULL;
+    p->outside_cb = NULL;
+    pthread_mutex_unlock(&p->lock);
+    if (event_cb != NULL) (*env)->DeleteGlobalRef(env, event_cb);
+    if (outside_cb != NULL) (*env)->DeleteGlobalRef(env, outside_cb);
+
+    if (dpy != NULL) {
+        if (p->cursor != None) fn.XFreeCursor(dpy, p->cursor);
+        fn.XDestroyWindow(dpy, p->win);
+        fn.XFreeColormap(dpy, p->cmap);
+        fn.XFlush(dpy);
+    }
+    pthread_mutex_destroy(&p->lock);
+    free(p);
+}

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -271,6 +271,26 @@
             ]
         },
         {
+            "type": "dev.nucleusframework.window.tao.PopupNativeBridgeLinux",
+            "jniAccessible": true
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.render.TaoStandalonePopupHostLinux$PanelEventCallback",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onPointerEvent", "parameterTypes": ["int","float","float","int","int"] },
+                { "name": "onScroll",       "parameterTypes": ["float","float","float","float"] },
+                { "name": "onKeyEvent",     "parameterTypes": ["int","int","int","int"] }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.render.TaoStandalonePopupHostLinux$PanelOutsideClickListener",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "onOutsideClick", "parameterTypes": ["int","int"] }
+            ]
+        },
+        {
             "type": "dev.nucleusframework.window.tao.render.TaoPopupSceneLayer$PopupEventCallback",
             "jniAccessible": true,
             "methods": [

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelLinuxNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelLinuxNativeSmokeTest.kt
@@ -1,0 +1,67 @@
+package dev.nucleusframework.window.tao
+
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.GLAssembledInterface
+import org.jetbrains.skia.makeGLWithInterface
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the native chain behind the Linux standalone popup panel without
+ * any Tao event loop: X connection, override-redirect ARGB panel creation,
+ * EGL attach and Skia DirectContext creation. The Linux twin of
+ * [StandalonePanelNativeSmokeTest] (Windows). Unlike AppKit, X11 has no
+ * main-thread requirement — the command connection is owned by whichever
+ * single thread uses it, here the test worker.
+ *
+ * Skipped when no X server is reachable (headless CI without Xvfb, rare
+ * Wayland-only setups) — the same signal `isTaoStandalonePopupAvailable()`
+ * reports to production callers.
+ */
+class StandalonePanelLinuxNativeSmokeTest {
+    @Test
+    fun standalonePanelPipelineInitializes() {
+        if (!System.getProperty("os.name", "").lowercase().contains("linux")) return
+
+        assertTrue(PopupNativeBridgeLinux.isLoaded, "nucleus_tao_linux_popup failed to load")
+        assertTrue(NativeTaoEglBridge.isLoaded, "nucleus_tao_egl failed to load")
+        if (!PopupNativeBridgeLinux.nativeIsAvailable()) {
+            println("SKIP: no X server reachable (DISPLAY unset?)")
+            return
+        }
+
+        val panel =
+            PopupNativeBridgeLinux.nativeCreatePanel(
+                xPx = -32_000,
+                yPx = -32_000,
+                widthPx = 300,
+                heightPx = 200,
+            )
+        assertNotEquals(0L, panel, "standalone panel creation failed (no ARGB visual?)")
+
+        var attachment = 0L
+        try {
+            attachment =
+                NativeTaoEglBridge.nativeAttachX11(
+                    displayPtr = PopupNativeBridgeLinux.nativeDisplayPtr(),
+                    xid = PopupNativeBridgeLinux.nativeWindowXid(panel),
+                    widthPx = 300,
+                    heightPx = 200,
+                )
+            assertNotEquals(0L, attachment, "EGL attach failed on standalone panel")
+            NativeTaoEglBridge.nativeSetSwapInterval(attachment, 0)
+            val intf =
+                GLAssembledInterface.createFromNativePointers(
+                    0L,
+                    NativeTaoEglBridge.nativeGetProcAddrFunctionPointer(),
+                )
+            val ctx = DirectContext.makeGLWithInterface(intf)
+            ctx.close()
+            assertTrue(PopupNativeBridgeLinux.nativeScale() > 0f, "panel scale must be positive")
+        } finally {
+            if (attachment != 0L) NativeTaoEglBridge.nativeDetach(attachment)
+            PopupNativeBridgeLinux.nativeRelease(panel)
+        }
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelLinuxNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/StandalonePanelLinuxNativeSmokeTest.kt
@@ -5,6 +5,7 @@ import org.jetbrains.skia.GLAssembledInterface
 import org.jetbrains.skia.makeGLWithInterface
 import kotlin.test.Test
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -59,6 +60,13 @@ class StandalonePanelLinuxNativeSmokeTest {
             val ctx = DirectContext.makeGLWithInterface(intf)
             ctx.close()
             assertTrue(PopupNativeBridgeLinux.nativeScale() > 0f, "panel scale must be positive")
+            val workArea = PopupNativeBridgeLinux.nativePrimaryWorkArea()
+            assertNotNull(workArea, "primary work area query failed")
+            assertTrue(
+                workArea.size == 4 && workArea[2] > 0 && workArea[3] > 0,
+                "invalid work area: ${workArea.toList()}",
+            )
+            println("work area: ${workArea.toList()}, scale: ${PopupNativeBridgeLinux.nativeScale()}")
         } finally {
             if (attachment != 0L) NativeTaoEglBridge.nativeDetach(attachment)
             PopupNativeBridgeLinux.nativeRelease(panel)


### PR DESCRIPTION
## Summary

- Adds the Linux implementation of `TaoStandalonePopup`: a top-level, ownerless, override-redirect ARGB32 X11 window with per-pixel transparency, global-screen positioning and no taskbar/Alt-Tab presence — the Linux counterpart of the Windows `WS_POPUP`/DComp and macOS `NSPanel`/CAMetalLayer panels.
- Raw X11 on its own `XOpenDisplay` connection rather than GTK: GDK's backend is process-wide (native Wayland on Wayland sessions), while an independent X client works through XWayland even when the app itself is a native Wayland client. Native Wayland-only setups (no `DISPLAY`) report unavailable via the new public `isTaoStandalonePopupAvailable()` so callers can fall back to a regular window.
- New native module `nucleus_tao_linux_popup.c` (dlopen-only deps, ships standalone like its siblings): window creation with the visual derived from EGL's alpha config (guarantees a direct `nativeAttachX11` config match), per-panel X event thread, XI2 raw-button outside-click monitor, `XSetInputFocus` keyboard takeover, Xft.dpi scale.
- Rendering reuses the per-attachment EGL bridge with `eglSwapInterval(0)` and the 60 fps absolute-deadline pacer from the Windows host (`TaoStandalonePopupHostLinux`).
- Keyboard: keys forward the active-layout X keysym resolved to Unicode via libxkbcommon (non-Latin-1 layouts work) plus a Latin keysym scanned across XKB groups for shortcuts; new `linuxNativeKeyToAwt` translator wired into `dispatchNativeKeyEvent`.
- `TaoScreenGeometry` Linux queries now fall back to an X11-side implementation (XRandR primary ∩ `_NET_WORKAREA`, Xft.dpi) when no realized Tao window exists — panel-only tray apps previously got a hardcoded 1920×1080 work area and mispositioned popups on wider screens.
- GraalVM reachability metadata for the new JNI callbacks, CI build/verify entries, and a Linux native smoke test (panel → EGL attach → Skia DirectContext → work-area query), skipped when no X server is reachable.

## Test plan

- [x] `StandalonePanelLinuxNativeSmokeTest` passes on GNOME Wayland (Ubuntu, Mutter) through XWayland
- [x] `:decorated-window-tao:check` (ktlint/detekt) passes
- [x] Validated end-to-end with ComposeNativeTray's TrayApp on GNOME Wayland: transparent panel composites over the desktop, positioned from the SNI click coordinates
- [ ] CI natives build (linux x64/aarch64)