### PR TITLE
fix(tao-windows): apply touchpad scroll directly, bypass the wheel tween

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ChromeScrollConfig.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ChromeScrollConfig.kt
@@ -12,10 +12,14 @@ import androidx.compose.foundation.gestures.ScrollConfig
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
+import java.awt.event.MouseWheelEvent
+import kotlin.math.abs
+import kotlin.math.round
 
 /**
  * Mouse-wheel scroll mapping that mirrors Chromium's, replacing Compose's
@@ -46,8 +50,26 @@ import androidx.compose.ui.unit.IntSize
  * Linux 53 (`MouseWheelEvent::kWheelDelta`); macOS/Linux trackpads bypass this
  * with pixel-precise deltas.
  *
- * `isSmoothScrollingEnabled` (true) and `isPreciseWheelScroll` (false) keep
- * Compose's stock desktop defaults, so only the wheel-to-pixel mapping changes.
+ * `isSmoothScrollingEnabled` stays true (stock default): notched mouse-wheel
+ * ticks animate, as in Chromium.
+ *
+ * [isPreciseWheelScroll], however, deliberately diverges from Compose's
+ * Windows default (hardcoded `false` in `DesktopScrollable.desktop.kt`).
+ * Windows delivers precision-touchpad pans as synthesized `WM_MOUSEWHEEL`
+ * bursts (fractional ticks, ~60–125 Hz). Funnelling those into the smooth-
+ * scroll tween reads as a visible saccade on fast flicks: the tween consumes
+ * at `AnimationSpeed = 1dp/ms` with `MaxAnimationDuration = 100ms`
+ * (`MouseWheelScrollingLogic`), while a flick feeds ~8–10 px/ms — the backlog
+ * balloons, then drains in one ~100ms linear lurch and stops dead. Native
+ * Windows apps (and Chromium, via DirectManipulation) apply touchpad pans
+ * directly, finger-tracking. So: fractional ticks → precise (delta applied
+ * on arrival, batched per frame); integer ticks → animated wheel notches.
+ *
+ * A short session latch keeps a touchpad burst on the direct path even when
+ * an individual event happens to quantize to a whole tick —
+ * `MouseWheelScrollingLogic` samples the flag from the first event of a burst
+ * and sticks with it, so one integer-looking first event would otherwise
+ * re-animate the whole gesture.
  */
 internal class ChromeScrollConfig(
     private val pixelsPerTick: Float = WINDOWS_PIXELS_PER_TICK,
@@ -63,9 +85,39 @@ internal class ChromeScrollConfig(
         return totalScrollDelta * -pixelsPerTick
     }
 
+    /** Event-time timestamp until which the source is treated as a touchpad. */
+    private var touchpadActiveUntilMs = 0L
+
+    override fun isPreciseWheelScroll(event: PointerEvent): Boolean {
+        val wheel = event.awtEventOrNull as? MouseWheelEvent ?: return false
+        return isPreciseTick(wheel.preciseWheelRotation, wheel.`when`)
+    }
+
+    /**
+     * Precision touchpads synthesize fractional wheel ticks; physical wheel
+     * notches are exact integers (also when Windows coalesces a fast spin).
+     * A fractional tick opens a [TOUCHPAD_SESSION_MS] window during which
+     * integer-quantized ticks stay on the direct path too.
+     */
+    internal fun isPreciseTick(
+        rotation: Double,
+        nowMs: Long,
+    ): Boolean {
+        val fractional = abs(rotation - round(rotation)) > FRACTIONAL_TICK_EPSILON
+        if (fractional) touchpadActiveUntilMs = nowMs + TOUCHPAD_SESSION_MS
+        return fractional || nowMs < touchpadActiveUntilMs
+    }
+
     companion object {
         /** Chromium Windows: 3 lines per tick × (100/3) px per line = 100 px per tick. */
         const val WINDOWS_PIXELS_PER_TICK = 100f
+
+        /** Same tolerance as Compose's own precise-wheel heuristic on macOS/Linux. */
+        const val FRACTIONAL_TICK_EPSILON = 0.001
+
+        /** Touchpad inertia tails pause briefly; 1s bridges the gaps without
+         *  noticeably delaying the switch back to animated wheel notches. */
+        const val TOUCHPAD_SESSION_MS = 1_000L
     }
 }
 

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/ChromeScrollConfigTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/ChromeScrollConfigTest.kt
@@ -1,0 +1,42 @@
+package dev.nucleusframework.window.tao.render
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ChromeScrollConfigTest {
+    @Test
+    fun integerTicksAnimate() {
+        val config = ChromeScrollConfig()
+        assertFalse(config.isPreciseTick(rotation = 1.0, nowMs = 0L))
+        assertFalse(config.isPreciseTick(rotation = -3.0, nowMs = 10L))
+    }
+
+    @Test
+    fun fractionalTicksApplyImmediately() {
+        val config = ChromeScrollConfig()
+        assertTrue(config.isPreciseTick(rotation = 1.47, nowMs = 0L))
+        assertTrue(config.isPreciseTick(rotation = -0.5, nowMs = 10L))
+    }
+
+    @Test
+    fun integerTickInsideTouchpadSessionStaysImmediate() {
+        val config = ChromeScrollConfig()
+        assertTrue(config.isPreciseTick(rotation = 1.47, nowMs = 0L))
+        // Quantized-to-integer event mid-gesture must not flip the burst
+        // back to the animated path.
+        assertTrue(config.isPreciseTick(rotation = 1.0, nowMs = 300L))
+    }
+
+    @Test
+    fun touchpadSessionExpiresBackToAnimatedWheel() {
+        val config = ChromeScrollConfig()
+        assertTrue(config.isPreciseTick(rotation = 1.47, nowMs = 0L))
+        assertFalse(
+            config.isPreciseTick(
+                rotation = 1.0,
+                nowMs = ChromeScrollConfig.TOUCHPAD_SESSION_MS + 1L,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Big touchpad scroll gestures on Windows visibly saccade: sluggish start, violent lurch at the end, dead stop. Scroll-test logs proved the pipeline healthy — zero delta loss (px = raw ticks × 100 exactly on every gesture) and 60fps throughout — so all previous pacing-level fixes (slew limiter, vsync heartbeat, DwmFlush) never touched the real cause.

## Root cause

CMP hardcodes `isPreciseWheelScroll = false` on Windows (`DesktopScrollable.desktop.kt`), so precision-touchpad pans (fractional `WM_MOUSEWHEEL` ticks at ~60–125 Hz) run the animated wheel path in `MouseWheelScrollingLogic`. That tween consumes at most `max(1dp/ms, leftover/100ms)` while a fast flick feeds ~8–10 px/ms (996px/118ms in the logs). The backlog balloons during the gesture, then drains in one ~100ms linear tween and stops dead — the saccade. Small scrolls stay under the cap, which is why only big gestures judder.

## Fix

Override `isPreciseWheelScroll` in `ChromeScrollConfig` (the Windows-only scroll config we already own):

- **Fractional ticks (precision touchpad)** → `shouldApplyImmediately`: deltas applied on arrival, batched per frame — finger-tracking, matching native Windows apps and Chromium (which routes touchpad pans through DirectManipulation, never the wheel animation).
- **Integer ticks (notched mouse wheel)** → unchanged Chromium-style 100px/tick animation.
- A **1s session latch** keeps a burst on the direct path when its first event happens to quantize to a whole tick, since `MouseWheelScrollingLogic` samples the flag from the burst's first event and sticks with it.

## Verification

- `ChromeScrollConfigTest` (4 tests) covers the fractional heuristic and the session latch expiry.
- Existing `TaoWindowScrollTest` / `TaoSyntheticMouseWheelEventTest` still green; detekt + ktlint pass.
- On-device Windows validation pending: ScrollTestScreen should track the finger with no end-of-gesture lurch; a notched wheel must still animate its 100px steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)