### PR TITLE
fix(tao-macos): live Compose recompose during double-click maximize animation

### DIFF
--- a/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/macos/util/async.rs
+++ b/decorated-window-tao/src/main/native/vendor/tao/src/platform_impl/macos/util/async.rs
@@ -184,8 +184,40 @@ pub unsafe fn set_maximized_async(
       } else if curr_mask.contains(NSWindowStyleMask::Resizable)
         && curr_mask.contains(NSWindowStyleMask::Titled)
       {
-        // Just use the native zoom if resizable
-        ns_window.zoom(None);
+        // PATCH(nucleus): upstream calls `ns_window.zoom(None)` here. AppKit's
+        // `zoom:` runs its resize animation SYNCHRONOUSLY on the main thread
+        // (~350 ms) in a private run-loop mode that services neither the main
+        // dispatch queue nor observers registered on `kCFRunLoopCommonModes`.
+        // Tao's run-loop observer therefore never drains the queued
+        // `WindowEvent::Resized` (windowDidResize: fires per animation step)
+        // until the animation completes — the embedder sees a single Resized
+        // at the end, so the content is stretched for the whole animation and
+        // snaps into place at the end.
+        //
+        // Instead, compute the zoom target frame ourselves (the same frames
+        // `zoom:` uses: screen visibleFrame ⇄ saved standard frame) and
+        // animate via the NSWindow animator proxy, which is non-blocking: the
+        // run loop keeps turning in common modes, windowDidResize: fires per
+        // step, and the embedder receives live Resized events throughout.
+        // `is_zoomed()` is frame-based (see window.rs) so bypassing `zoom:`
+        // keeps the maximized-state tracking consistent.
+        let mtm = MainThreadMarker::new_unchecked();
+        let screen = ns_window.screen().or_else(|| NSScreen::mainScreen(mtm));
+        let target = if maximized {
+          match screen {
+            Some(screen) => NSScreen::visibleFrame(&screen),
+            None => return,
+          }
+        } else {
+          shared_state_lock.saved_standard_frame()
+        };
+        let duration: f64 = msg_send![&*ns_window, animationResizeTime: target];
+        let _: () = msg_send![class!(NSAnimationContext), beginGrouping];
+        let ctx: id = msg_send![class!(NSAnimationContext), currentContext];
+        let _: () = msg_send![ctx, setDuration: duration];
+        let animator: id = msg_send![&*ns_window, animator];
+        let _: () = msg_send![animator, setFrame: target, display: YES];
+        let _: () = msg_send![class!(NSAnimationContext), endGrouping];
       } else {
         // if it's not resizable, we set the frame directly
         let new_rect = if maximized {


### PR DESCRIPTION
## Problem

Double-clicking the title bar to maximize on macOS resized the window without recomposing the Compose content during the animation — the CAMetalLayer was stretched by Core Animation for ~350 ms, then snapped to the final layout. Native macOS windows re-layout live during the zoom animation.

## Root cause (measured with a standalone AppKit probe)

`-[NSWindow zoom:]` (called by tao's `set_maximized_async` for resizable windows) runs its resize animation **synchronously on the main thread** in a private run-loop mode:

- `windowDidResize:` fires per animation step (~16 ms) → tao queues `WindowEvent::Resized` in `AppState`
- but the main dispatch queue and `kCFRunLoopCommonModes` observers are **not serviced** until `zoom:` returns — a `dispatch_async(main)` block posted right before `zoom:` only ran 353 ms later

Tao's run-loop observer therefore drained the whole Resized queue at animation end: the JVM host (`TaoComposeSceneHost.onResized` → `nativeResize` + `scene.size` + `requestRedraw`) recomposed exactly once, after the animation.

## Fix

Replace `zoom:` in `set_maximized_async`'s resizable branch with a non-blocking NSWindow animator-proxy `setFrame:` inside an `NSAnimationContext` group:

- same target frames `zoom:` uses (screen `visibleFrame` on maximize, saved standard frame on restore) and same duration (`animationResizeTime:`)
- probe confirms: the call returns in ~1 ms, `windowDidResize:` fires per step **and** the main queue + common-mode timers keep running throughout — so Resized events drain per step and Compose recomposes live

`is_zoomed()` is already frame-based (earlier `PATCH(nucleus)` for the creation-time maximize path), so bypassing `zoom:` keeps maximized-state tracking consistent, including the Kotlin placement sync layer.

## Testing

- Standalone ObjC probes measuring run-loop behavior of `zoom:` vs animator `setFrame:` (per-step `didResize`, main-queue servicing, blocking time)
- `sample-tao` on macOS (aarch64): double-click maximize/restore now recomposes live during the animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)