### PR TITLE
feat(tao-windows): Chrome-like touchpad scroll inertia (synthetic fling)

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ChromiumFlingCurve.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ChromiumFlingCurve.kt
@@ -1,0 +1,74 @@
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.math.abs
+import kotlin.math.exp
+import kotlin.math.ln
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Faithful port of Chromium's touchpad fling curve
+ * (`ui/events/gestures/fling_curve.cc`) — the deceleration physics behind
+ * Chrome's post-flick glide.
+ *
+ * The curve is one universal deceleration profile in pixels,
+ * `position(t) = α·e^(−γt) − β·t − α`, with `velocity(t)` its derivative
+ * (α = −5707.62, β = 172, γ = 3.7). A fling with release velocity `v₀`
+ * enters the curve at the time offset where the curve's velocity equals
+ * `v₀` and rides it until the velocity reaches zero (~1.3 s from the very
+ * top). A faster flick enters earlier and therefore travels further; the
+ * tail — the "slower and slower" feel — is identical for every fling.
+ *
+ * The 2-D direction is preserved through the displacement ratio exactly as
+ * in Chromium: the dominant axis rides the curve at full scale, the other
+ * axis is scaled proportionally.
+ */
+internal class ChromiumFlingCurve(
+    velocityX: Float,
+    velocityY: Float,
+) {
+    private val maxAxisVelocity: Float = max(abs(velocityX), abs(velocityY))
+    private val startVelocity: Float = min(maxAxisVelocity, velocityAtTime(0f))
+
+    /** False when the release velocity can't produce any motion. */
+    val isValid: Boolean = startVelocity > 0f
+
+    private val curveDuration: Float = timeAtVelocity(0f)
+    private val timeOffset: Float = if (isValid) timeAtVelocity(startVelocity) else 0f
+    private val positionOffset: Float = positionAtTime(timeOffset)
+
+    // Chromium divides by the CLAMPED max (its callers pre-clamp velocity via
+    // kMaxFlingVelocity, so the ratio stays ≤1 there). Our velocities come
+    // straight from a tracker estimate, so divide by the unclamped max — an
+    // implausibly fast estimate rides the full curve instead of multiplying it.
+    private val displacementRatioX: Float = if (isValid) velocityX / maxAxisVelocity else 0f
+    private val displacementRatioY: Float = if (isValid) velocityY / maxAxisVelocity else 0f
+
+    /** Seconds of glide remaining from the fling start. */
+    val remainingSeconds: Float
+        get() = if (isValid) curveDuration - timeOffset else 0f
+
+    /** Cumulative glide offset in px, [elapsedSeconds] after the fling start. */
+    fun offsetAt(elapsedSeconds: Float): Offset {
+        if (!isValid) return Offset.Zero
+        val t = (elapsedSeconds + timeOffset).coerceIn(timeOffset, curveDuration)
+        val displacement = positionAtTime(t) - positionOffset
+        return Offset(displacement * displacementRatioX, displacement * displacementRatioY)
+    }
+
+    fun isFinishedAt(elapsedSeconds: Float): Boolean = !isValid || elapsedSeconds + timeOffset >= curveDuration
+
+    private companion object {
+        // Chromium ui/events/gestures/fling_curve.cc (kDefaultAlpha/Beta/Gamma).
+        const val ALPHA = -5707.62f
+        const val BETA = 172f
+        const val GAMMA = 3.7f
+
+        fun positionAtTime(t: Float): Float = ALPHA * exp(-GAMMA * t) - BETA * t - ALPHA
+
+        fun velocityAtTime(t: Float): Float = -ALPHA * GAMMA * exp(-GAMMA * t) - BETA
+
+        fun timeAtVelocity(v: Float): Float = -ln((v + BETA) / (-ALPHA * GAMMA)) / GAMMA
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -112,12 +112,30 @@ internal class TaoComposeSceneHostWindows(
     private val flushingDispatcher = FlushingMainDispatcher()
 
     /**
-     * Scope for host-owned timers (currently only the trackpad-pinch idle-end
-     * debounce). Runs on [flushingDispatcher] so resumed continuations land on
-     * the event-loop thread; `delay` itself ticks on the shared coroutines
-     * scheduler. Cancelled in [detach].
+     * Scope for host-owned gesture work (trackpad-pinch idle-end debounce,
+     * synthetic wheel fling). Runs on [flushingDispatcher] so resumed
+     * continuations land on the event-loop thread; `delay` itself ticks on
+     * the shared coroutines scheduler, and [frameClock] paces the fling's
+     * `withFrameNanos` loop at the render cadence. Cancelled in [detach].
      */
-    private val gestureScope = CoroutineScope(coroutineContext + flushingDispatcher + SupervisorJob())
+    private val gestureScope =
+        CoroutineScope(coroutineContext + flushingDispatcher + frameClock + SupervisorJob())
+
+    /**
+     * Chrome-like scroll inertia for touchpad flicks — Windows delivers no
+     * momentum events on the wheel path, so the glide is synthesized here
+     * and re-enters the scene as regular (precise) wheel ticks.
+     */
+    private val wheelFling =
+        TaoWheelFling(
+            scope = gestureScope,
+            pixelsPerTick = ChromeScrollConfig.WINDOWS_PIXELS_PER_TICK,
+            emitTicks = { dxTicks, dyTicks ->
+                sendScrollToScene(
+                    TaoPointerScrollEvent(dxAwt = dxTicks, dyAwt = dyTicks, scrollAmount = 1),
+                )
+            },
+        )
 
     /** Floating text-selection bar shown on touch selection. */
     private val textToolbar = TaoTextToolbar()
@@ -880,6 +898,7 @@ internal class TaoComposeSceneHostWindows(
     }
 
     fun onFocusChanged(focused: Boolean) {
+        if (!focused) wheelFling.cancel()
         windowInfo.isWindowFocused = focused
     }
 
@@ -1032,6 +1051,8 @@ internal class TaoComposeSceneHostWindows(
         buttonCode: Int,
         pressed: Boolean,
     ) {
+        // A click anywhere stops an in-flight glide, as in Chrome.
+        if (pressed) wheelFling.cancel()
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
         scene?.sendPointerEvent(
@@ -1044,6 +1065,13 @@ internal class TaoComposeSceneHostWindows(
     }
 
     fun onPointerScroll(event: TaoPointerScrollEvent) {
+        // Real input always preempts a synthetic glide (as in Chrome) and
+        // feeds the release-velocity tracker.
+        wheelFling.onUserScroll(event.dxAwt, event.dyAwt, System.nanoTime() / 1_000_000)
+        sendScrollToScene(event)
+    }
+
+    private fun sendScrollToScene(event: TaoPointerScrollEvent) {
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
         scene?.sendPointerEvent(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFling.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFling.kt
@@ -1,0 +1,142 @@
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.input.pointer.util.VelocityTracker1D
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.round
+
+/**
+ * Synthesizes Chrome-like scroll inertia for the Windows wheel path.
+ *
+ * macOS pushes decaying momentum events after a trackpad flick; Windows
+ * precision touchpads stop the `WM_MOUSEWHEEL` stream dead at finger lift,
+ * so a flick halts abruptly. Compose's own wheel fling can't help: it is
+ * gated off for default fling behaviors (`shouldBeTriggeredByMouseWheel`)
+ * and the default is resolved per scrollable with no global hook. So the
+ * glide is synthesized here at the input layer instead — velocity-track the
+ * real events, and once the stream goes quiet, emit synthetic wheel ticks
+ * riding [ChromiumFlingCurve] until it decays to rest: the same event
+ * stream a momentum-scrolling OS/driver would deliver, consumed by the
+ * existing precise-wheel direct path.
+ *
+ * Only gestures containing fractional ticks (precision touchpads) glide;
+ * notched mouse wheels keep the plain animated scroll, mirroring Chrome
+ * (DirectManipulation inertia vs. wheel tick animation). Drivers that
+ * already synthesize inertia events self-correct: their decaying tail keeps
+ * the gesture alive and leaves only a tiny release velocity here.
+ *
+ * Threading: single-threaded on the Tao event-loop thread — [onUserScroll]
+ * and [cancel] run from native event dispatch, and the arm/fling coroutines
+ * resume through the host's flushing dispatcher, drained on that thread.
+ */
+internal class TaoWheelFling(
+    private val scope: CoroutineScope,
+    private val pixelsPerTick: Float,
+    private val emitTicks: (dxTicks: Float, dyTicks: Float) -> Unit,
+) {
+    private val xVelocity = VelocityTracker1D(isDataDifferential = true)
+    private val yVelocity = VelocityTracker1D(isDataDifferential = true)
+    private var armJob: Job? = null
+
+    // Volatile only for cross-thread visibility in tests; production access
+    // is single-threaded (event-loop thread).
+    @Volatile
+    private var flingJob: Job? = null
+    private var sawFractionalTick = false
+
+    /** True while a synthetic glide is emitting ticks. */
+    val isFlinging: Boolean
+        get() = flingJob?.isActive == true
+
+    /**
+     * Feeds a real user wheel event (tick units, AWT sign convention). Any
+     * active glide is cancelled — new input always takes over, as in Chrome.
+     */
+    fun onUserScroll(
+        dxTicks: Float,
+        dyTicks: Float,
+        timeMillis: Long,
+    ) {
+        cancelFling()
+        if (isFractional(dxTicks) || isFractional(dyTicks)) sawFractionalTick = true
+        xVelocity.addDataPoint(timeMillis, dxTicks * pixelsPerTick)
+        yVelocity.addDataPoint(timeMillis, dyTicks * pixelsPerTick)
+        armJob?.cancel()
+        armJob =
+            scope.launch {
+                delay(GESTURE_END_MS)
+                maybeStartFling()
+            }
+    }
+
+    /** Stops tracking and any active glide (button press, focus loss, detach). */
+    fun cancel() {
+        armJob?.cancel()
+        armJob = null
+        cancelFling()
+        resetGesture()
+    }
+
+    private fun cancelFling() {
+        flingJob?.cancel()
+        flingJob = null
+    }
+
+    private fun resetGesture() {
+        xVelocity.resetTracking()
+        yVelocity.resetTracking()
+        sawFractionalTick = false
+    }
+
+    private fun maybeStartFling() {
+        val vx = xVelocity.calculateVelocity()
+        val vy = yVelocity.calculateVelocity()
+        val touchpadGesture = sawFractionalTick
+        resetGesture()
+        if (!touchpadGesture) return
+        if (max(abs(vx), abs(vy)) < MIN_FLING_VELOCITY_PX_PER_S) return
+        val curve = ChromiumFlingCurve(vx, vy)
+        if (!curve.isValid) return
+        flingJob =
+            scope.launch {
+                var emittedX = 0f
+                var emittedY = 0f
+                val startNanos = withFrameNanos { it }
+                while (true) {
+                    val elapsed = (withFrameNanos { it } - startNanos) / NANOS_PER_SECOND
+                    val target = curve.offsetAt(elapsed)
+                    val dx = target.x - emittedX
+                    val dy = target.y - emittedY
+                    if (abs(dx) > MIN_EMIT_PX || abs(dy) > MIN_EMIT_PX) {
+                        emittedX += dx
+                        emittedY += dy
+                        emitTicks(dx / pixelsPerTick, dy / pixelsPerTick)
+                    }
+                    if (curve.isFinishedAt(elapsed)) break
+                }
+            }
+    }
+
+    private fun isFractional(ticks: Float): Boolean = abs(ticks - round(ticks)) > FRACTIONAL_TICK_EPSILON
+
+    internal companion object {
+        /** Quiet gap that ends a gesture — matches Compose's `ScrollProgressTimeout`. */
+        const val GESTURE_END_MS = 50L
+
+        /** Below this release velocity a glide wouldn't be perceptible. */
+        const val MIN_FLING_VELOCITY_PX_PER_S = 100f
+
+        /** Skip emissions Compose would discard as sub-visible anyway. */
+        const val MIN_EMIT_PX = 0.01f
+
+        /** Mirrors [ChromeScrollConfig.FRACTIONAL_TICK_EPSILON]. */
+        const val FRACTIONAL_TICK_EPSILON = 0.001f
+
+        const val NANOS_PER_SECOND = 1e9f
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/ChromiumFlingCurveTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/ChromiumFlingCurveTest.kt
@@ -1,0 +1,88 @@
+package dev.nucleusframework.window.tao.render
+
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Expected values precomputed from Chromium's closed-form curve
+ * (`ui/events/gestures/fling_curve.cc`, α=−5707.62 β=172 γ=3.7):
+ * duration-from-top = 1.30011 s, max curve velocity = 20946 px/s,
+ * distance(300) = 34.15 px, distance(5000) = 1193.13 px,
+ * distance(8000) = 1982.68 px, full-curve distance = 5437.52 px.
+ */
+class ChromiumFlingCurveTest {
+    @Test
+    fun zeroVelocityIsInvalid() {
+        val curve = ChromiumFlingCurve(0f, 0f)
+        assertFalse(curve.isValid)
+        assertTrue(curve.isFinishedAt(0f))
+        assertEquals(0f, curve.offsetAt(1f).y)
+    }
+
+    @Test
+    fun glideDistanceMatchesChromiumClosedForm() {
+        assertTotalDistance(velocityY = 300f, expectedPx = 34.15f)
+        assertTotalDistance(velocityY = 5_000f, expectedPx = 1_193.13f)
+        assertTotalDistance(velocityY = 8_000f, expectedPx = 1_982.68f)
+    }
+
+    @Test
+    fun velocityAboveCurveMaxIsClamped() {
+        assertTotalDistance(velocityY = 50_000f, expectedPx = 5_437.52f)
+    }
+
+    @Test
+    fun negativeVelocityMirrors() {
+        assertTotalDistance(velocityY = -5_000f, expectedPx = -1_193.13f)
+    }
+
+    @Test
+    fun startsAtZeroAndFinishesAtRemainingSeconds() {
+        val curve = ChromiumFlingCurve(0f, 5_000f)
+        assertEquals(0f, curve.offsetAt(0f).y, absoluteTolerance = 0.01f)
+        assertEquals(0.91987f, curve.remainingSeconds, absoluteTolerance = 0.001f)
+        assertFalse(curve.isFinishedAt(curve.remainingSeconds - 0.01f))
+        assertTrue(curve.isFinishedAt(curve.remainingSeconds + 0.001f))
+    }
+
+    @Test
+    fun offsetsGrowMonotonicallyWithDecayingDeltas() {
+        val curve = ChromiumFlingCurve(0f, 8_000f)
+        var previousOffset = 0f
+        var previousDelta = Float.MAX_VALUE
+        var t = 0.016f
+        while (t < curve.remainingSeconds) {
+            val offset = curve.offsetAt(t).y
+            val delta = offset - previousOffset
+            assertTrue(delta > 0f, "offset must keep growing at t=$t")
+            assertTrue(delta <= previousDelta + 0.001f, "glide must decelerate at t=$t")
+            previousOffset = offset
+            previousDelta = delta
+            t += 0.016f
+        }
+    }
+
+    @Test
+    fun directionRatioIsPreserved() {
+        val curve = ChromiumFlingCurve(-2_500f, 5_000f)
+        val end = curve.offsetAt(curve.remainingSeconds)
+        assertEquals(-0.5f, end.x / end.y, absoluteTolerance = 0.001f)
+        assertEquals(1_193.13f, end.y, absoluteTolerance = 2f)
+    }
+
+    private fun assertTotalDistance(
+        velocityY: Float,
+        expectedPx: Float,
+    ) {
+        val curve = ChromiumFlingCurve(0f, velocityY)
+        assertTrue(curve.isValid)
+        val total = curve.offsetAt(curve.remainingSeconds + 1f).y
+        assertTrue(
+            abs(total - expectedPx) < 2f,
+            "expected ~${expectedPx}px for v0=$velocityY, got $total",
+        )
+    }
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFlingTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFlingTest.kt
@@ -1,0 +1,143 @@
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.runtime.BroadcastFrameClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Drives [TaoWheelFling] against a real [BroadcastFrameClock] pumped from a
+ * background thread (standing in for the host render loop). Event
+ * timestamps are synthetic, so tracked velocities are deterministic; frame
+ * timing only affects emission granularity, never the glide's total
+ * distance (deltas are derived from absolute curve positions).
+ */
+class TaoWheelFlingTest {
+    private class Harness : AutoCloseable {
+        private val frameClock = BroadcastFrameClock()
+        private val scope = CoroutineScope(Dispatchers.Default + frameClock + SupervisorJob())
+        val emitted = ConcurrentLinkedQueue<Pair<Float, Float>>()
+        val fling =
+            TaoWheelFling(scope = scope, pixelsPerTick = 100f) { dx, dy ->
+                emitted.add(dx to dy)
+            }
+
+        @Volatile
+        private var pumping = true
+
+        init {
+            Thread {
+                while (pumping) {
+                    frameClock.sendFrame(System.nanoTime())
+                    Thread.sleep(4)
+                }
+            }.apply {
+                isDaemon = true
+                start()
+            }
+        }
+
+        /** ~19125 px/s touchpad flick: 8 fractional-tick events, 8 ms apart. */
+        fun flickTouchpad(dyTicks: Float = 1.53f) {
+            var t = 0L
+            repeat(8) {
+                fling.onUserScroll(0f, dyTicks, t)
+                t += 8
+            }
+        }
+
+        fun awaitGlideStart(timeoutMs: Long = 1_000): Boolean = pollUntil(timeoutMs) { fling.isFlinging }
+
+        fun awaitGlideEnd(timeoutMs: Long = 4_000): Boolean =
+            awaitGlideStart(timeoutMs) && pollUntil(timeoutMs) { !fling.isFlinging }
+
+        private fun pollUntil(
+            timeoutMs: Long,
+            condition: () -> Boolean,
+        ): Boolean {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (!condition()) {
+                if (System.currentTimeMillis() > deadline) return false
+                Thread.sleep(5)
+            }
+            return true
+        }
+
+        override fun close() {
+            pumping = false
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun touchpadFlickGlidesWithChromiumDistance() {
+        Harness().use { h ->
+            h.flickTouchpad()
+            assertTrue(h.awaitGlideEnd(), "glide never started or never finished")
+            val deltas = h.emitted.toList()
+            assertTrue(deltas.size > 10, "glide should span many frames, got ${deltas.size}")
+            assertTrue(deltas.all { it.second > 0f }, "glide must keep the flick direction")
+            // ~19125 px/s on the Chromium curve ≈ 4950 px ≈ 49.5 ticks; leave
+            // headroom for the velocity-tracker estimate.
+            val totalTicks = deltas.map { it.second }.sum()
+            assertTrue(totalTicks in 30f..70f, "expected ~49 ticks of glide, got $totalTicks")
+        }
+    }
+
+    @Test
+    fun notchedWheelDoesNotGlide() {
+        Harness().use { h ->
+            var t = 0L
+            repeat(8) {
+                h.fling.onUserScroll(0f, 2f, t) // exact integer ticks = real wheel
+                t += 8
+            }
+            assertFalse(h.awaitGlideStart(timeoutMs = 300))
+            assertTrue(h.emitted.isEmpty(), "integer-tick gestures must not glide")
+        }
+    }
+
+    @Test
+    fun slowTouchpadScrollDoesNotGlide() {
+        Harness().use { h ->
+            var t = 0L
+            repeat(5) {
+                h.fling.onUserScroll(0f, 0.005f, t) // ~12 px/s, below MIN_FLING
+                t += 40
+            }
+            assertFalse(h.awaitGlideStart(timeoutMs = 300))
+            assertTrue(h.emitted.isEmpty(), "sub-threshold release velocity must not glide")
+        }
+    }
+
+    @Test
+    fun newScrollEventCancelsGlide() {
+        Harness().use { h ->
+            h.flickTouchpad()
+            assertTrue(h.awaitGlideStart(), "glide never started")
+            h.fling.onUserScroll(0f, -0.4f, 1_000L)
+            assertFalse(h.fling.isFlinging, "real input must preempt the glide")
+        }
+    }
+
+    @Test
+    fun cancelStopsGlide() {
+        Harness().use { h ->
+            h.flickTouchpad()
+            assertTrue(h.awaitGlideStart(), "glide never started")
+            h.fling.cancel()
+            assertFalse(h.fling.isFlinging)
+            val sizeAfterCancel = h.emitted.size
+            Thread.sleep(100)
+            assertTrue(
+                h.emitted.size <= sizeAfterCancel + 1,
+                "emissions must stop after cancel()",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The direct-application fix (#306) killed the flick saccade, but the scroll now stops dead at finger lift — "brut". Chrome keeps gliding after a flick, decelerating naturally.

## Why the glide is missing

- macOS pushes decaying momentum events after a flick; Windows delivers **nothing** on the `WM_MOUSEWHEEL` path (PTP inertia rides DirectManipulation, which plain HWNDs never see).
- Compose's own wheel fling can't fill the gap: `shouldBeTriggeredByMouseWheel` is false for default fling behaviors, and the default is resolved per scrollable via `platformScrollableDefaultFlingBehavior()` — an `expect fun`, no global hook.

## Fix — synthesize the inertia at the input layer

Emit the same event stream a momentum-scrolling OS/driver would deliver:

- **`ChromiumFlingCurve`** — faithful port of Chromium's `ui/events/gestures/fling_curve.cc` deceleration physics (α=−5707.62, β=172, γ=3.7): one universal curve, entered at the release velocity, ridden to rest (~1.3s max). Faster flick → earlier entry → longer/further glide, identical natural tail for every fling. One deliberate divergence: the displacement ratio divides by the *unclamped* max-axis velocity, so an implausibly fast velocity-tracker estimate rides the full curve instead of multiplying it (Chromium pre-clamps upstream via `kMaxFlingVelocity`).
- **`TaoWheelFling`** — velocity-tracks real wheel events (`VelocityTracker1D`, differential — the same tracker CMP uses internally). 50ms of silence ends the gesture; if it contained fractional ticks (precision touchpad) and released above 100px/s, synthetic wheel ticks are emitted per frame along the curve and re-enter the scene as regular precise ticks (consumed by the #306 direct path).
- **Chrome-matching semantics**: notched wheels never glide (DirectManipulation inertia vs. wheel animation split); new scroll input, any click, and focus loss preempt the glide instantly. Drivers that already fake inertia (legacy Synaptics) self-correct — their decaying tail keeps the gesture alive and leaves only a negligible release velocity.

## Verification

- `ChromiumFlingCurveTest` (7 tests): glide distances match the closed form (300px/s → 34px, 5000 → 1193px, 8000 → 1983px, clamped max → 5438px), monotonic decelerating offsets, 2-D direction ratio, validity edges.
- `TaoWheelFlingTest` (5 tests): drives a real `BroadcastFrameClock` — touchpad flick glides ~the Chromium distance and terminates; integer-tick (notched wheel) and sub-threshold gestures don't glide; new input and `cancel()` stop emissions.
- detekt + ktlint green.
- On-device Windows validation pending: a hard flick should glide and decelerate like Chrome, a slow release should barely drift, and a click mid-glide should stop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)