### PR TITLE
fix(tao-windows): remove resize frame cap that stuttered the title bar

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoWindowsDecoBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoWindowsDecoBridge.kt
@@ -140,14 +140,6 @@ internal object NativeTaoWindowsDecoBridge {
     external fun nativeIsMaximized(hwnd: Long): Boolean
 
     /**
-     * Refresh rate (Hz) of the monitor the window is on, or `0` if it can't be
-     * resolved. Used to cap the render rate during the modal resize loop (VSync
-     * is off then) so a border drag doesn't render far above the display refresh.
-     */
-    @JvmStatic
-    external fun nativeMonitorRefreshHz(hwnd: Long): Int
-
-    /**
      * Atomic unmaximize + reposition under the finger when a touch drag
      * starts on a maximized window. Returns the restored outer rect as
      * `[x, y, w, h]` in physical pixels, or `null` on failure.

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -144,16 +144,6 @@ internal class TaoComposeSceneHostWindows(
     private var heightPx: Int = 0
     private var scale: Float = 1f
 
-    /**
-     * While the OS modal resize loop is active (VSync off, see
-     * [onResizeLoopChanged]) this is the minimum spacing between resize
-     * repaints — a frame cap that coalesces the WM_SIZE flood down to roughly
-     * the display refresh so we don't render far above what the monitor shows.
-     * 0 = uncapped (outside the loop, or when the refresh rate is unknown).
-     */
-    private var resizeFrameIntervalNanos: Long = 0L
-    private var lastResizePaintNanos: Long = 0L
-
     private var lastPointerX: Float = 0f
     private var lastPointerY: Float = 0f
 
@@ -818,22 +808,6 @@ internal class TaoComposeSceneHostWindows(
         scene?.size = IntSize(widthPx, heightPx)
         updateWindowInfoSize()
 
-        // Frame cap during the modal resize loop. VSync is off then (see
-        // onResizeLoopChanged), so nothing paces the render loop: Win32 can
-        // deliver WM_SIZE far above the display refresh and we'd render frames
-        // the monitor never shows — the CPU/GPU spike observed during resize.
-        // Coalesce the burst to ~refresh by skipping repaints that fall inside
-        // one frame interval. The swap-chain resize (nativeResize) is deferred
-        // to the frame we actually paint, so a coalesced-out WM_SIZE never
-        // leaves an enlarged-but-unpainted (black) surface: the child simply
-        // lags the window by at most one refresh interval, which the monitor
-        // can't display anyway. The final size is reconciled on loop exit.
-        if (resizeFrameIntervalNanos > 0L) {
-            val now = System.nanoTime()
-            if (now - lastResizePaintNanos < resizeFrameIntervalNanos) return
-            lastResizePaintNanos = now
-        }
-
         NativeTaoGlBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
         // Paint synchronously instead of deferring via requestRedraw().
         //
@@ -858,24 +832,16 @@ internal class TaoComposeSceneHostWindows(
      * WM_EXITSIZEMOVE). VSync is dropped while the loop is active so the
      * synchronous per-WM_SIZE present in [onResized] doesn't block on the
      * display refresh — the window edge tracks the cursor with no added
-     * latency. To stop that from turning into an uncapped render loop (VSync
-     * being the usual frame limiter), [onResized] paces itself to the monitor
-     * refresh via [resizeFrameIntervalNanos] for the duration. On exit VSync is
-     * restored and the swap chain is reconciled to the exact final size (a
-     * coalesced-out last WM_SIZE may have left it one step behind).
+     * latency. Every WM_SIZE is resized and painted atomically; allowing the
+     * scene size to advance while the ANGLE child surface remains at an older
+     * size makes DWM stretch the old frame and visibly shifts the title bar.
+     * On exit VSync is restored and the final size is presented once more.
      */
     fun onResizeLoopChanged(active: Boolean) {
         if (attachmentHandle == 0L) return
         if (active) {
             NativeTaoGlBridge.nativeSetVSyncEnabled(attachmentHandle, false)
-            val hz = if (hwnd != 0L) NativeTaoWindowsDecoBridge.nativeMonitorRefreshHz(hwnd) else 0
-            // Allow ~10% headroom over the refresh period so timing jitter
-            // doesn't drop every other frame into the next interval (beating
-            // down to half-rate). Unknown refresh (0) leaves the loop uncapped.
-            resizeFrameIntervalNanos = if (hz > 1) 1_000_000_000L / hz * 9 / 10 else 0L
-            lastResizePaintNanos = 0L
         } else {
-            resizeFrameIntervalNanos = 0L
             NativeTaoGlBridge.nativeSetVSyncEnabled(attachmentHandle, true)
             NativeTaoGlBridge.nativeResize(attachmentHandle, widthPx, heightPx, scale)
             onRedrawRequested()

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_deco.c
@@ -703,41 +703,6 @@ static int clampInt(int value, int minValue, int maxValue) {
     return value;
 }
 
-/* Refresh rate (Hz) of the monitor the window is currently on, used to cap the
- * resize render rate while VSync is disabled during the modal resize loop.
- * Resolves the monitor's current display mode via EnumDisplaySettingsW; falls
- * back to GetDeviceCaps(VREFRESH), then 0 when nothing usable is available (the
- * caller then leaves the resize loop uncapped). */
-JNIEXPORT jint JNICALL
-Java_dev_nucleusframework_window_tao_NativeTaoWindowsDecoBridge_nativeMonitorRefreshHz(
-    JNIEnv *env, jclass clazz, jlong hwndLong)
-{
-    (void)env; (void)clazz;
-    HWND hwnd = (HWND)(uintptr_t)hwndLong;
-    if (!hwnd || !IsWindow(hwnd)) return 0;
-
-    HMONITOR hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-    MONITORINFOEXW mi;
-    mi.cbSize = sizeof(mi);
-    if (GetMonitorInfoW(hMon, (MONITORINFO *)&mi)) {
-        DEVMODEW dm;
-        memset(&dm, 0, sizeof(dm));
-        dm.dmSize = sizeof(dm);
-        if (EnumDisplaySettingsW(mi.szDevice, ENUM_CURRENT_SETTINGS, &dm)
-            && dm.dmDisplayFrequency > 1) {
-            return (jint)dm.dmDisplayFrequency;
-        }
-    }
-
-    HDC hdc = GetDC(hwnd);
-    if (hdc) {
-        int vr = GetDeviceCaps(hdc, VREFRESH);
-        ReleaseDC(hwnd, hdc);
-        if (vr > 1) return (jint)vr;
-    }
-    return 0;
-}
-
 /* Win32 IsZoomed. */
 JNIEXPORT jboolean JNICALL
 Java_dev_nucleusframework_window_tao_NativeTaoWindowsDecoBridge_nativeIsMaximized(


### PR DESCRIPTION
## What & why

Fixes #300 — Windows title bar stuttering during resize.

During the Win32 modal resize loop (`WM_ENTERSIZEMOVE`→`WM_EXITSIZEMOVE`), `onResized` advanced the Compose scene size (`scene?.size = ...`) but then **early-returned inside the `resizeFrameIntervalNanos` frame cap *before* calling `nativeResize`**. The ANGLE swap chain was therefore left at the older size while the scene believed it was the new one, so DWM stretched the old frame to fill the enlarged window — a visible shift of the title bar on every coalesced `WM_SIZE`.

The frame cap was introduced in `905a66f0` (\"smooth, tear-free Windows resize\") to bound CPU/GPU while VSync is off during the loop. Its ordering bug (scene advances, swap chain doesn't) is exactly what it was supposed to prevent visually.

## Change

Drop the cap entirely. Every `WM_SIZE` now resizes the swap chain and paints atomically, keeping scene and child surface in lockstep. VSync stays off for the duration of the loop (edge tracks the cursor with no added latency); the loop is effectively uncapped, trading a transient CPU/GPU spike during the drag for visual correctness.

Cleanup the now-dead refresh-rate plumbing:
- remove `resizeFrameIntervalNanos` / `lastResizePaintNanos` fields + the early-return block in `onResized`
- remove the `nativeMonitorRefreshHz` JNI bridge (Kotlin `external` + C impl) and its sole call site in `onResizeLoopChanged`
- no reachability-metadata entry existed for the removed method (verified)

3 files, +4 / −81.

## Verification

- `:decorated-window-tao:compileKotlin` — OK
- `:decorated-window-tao:test` — BUILD SUCCESSFUL, 26 tests / 0 failure / 0 error / 0 skipped (no test referenced the cap)
- ⚠️ **Native rebuild required** (C change): `decorated-window-tao/src/main/native/windows/build.bat` on x64 **and** aarch64 — regenerates the `.dll` in `resources/nucleus/native/{win32-x64,win32-aarch64}/` and clears the `~/.cache/nucleus/native/<arch>/` loader cache. Run locally on Windows or via the `build-natives.yaml` CI workflow (no workflow change needed — symbol removal only, naming/paths unchanged).
- ⚠️ **Visual end-to-end (Windows)** still to run: fast border drag → title bar must no longer stutter, no black edge on the dragged border, clean settle on release.

## Notes

If the transient CPU/GPU during resize becomes a concern again, the right fix is **not** to reintroduce a software cap (it recreates the scene↔surface desync). Re-enable VSync *during* the resize loop instead — VSync paces frames while keeping scene and surface synchronized. Leave that for a separate ticket if measured necessary.

