### PR TITLE
fix(tao-windows): tame fling release velocity (windowed estimate + cap)

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFling.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFling.kt
@@ -1,7 +1,6 @@
 package dev.nucleusframework.window.tao.render
 
 import androidx.compose.runtime.withFrameNanos
-import androidx.compose.ui.input.pointer.util.VelocityTracker1D
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -39,8 +38,23 @@ internal class TaoWheelFling(
     private val pixelsPerTick: Float,
     private val emitTicks: (dxTicks: Float, dyTicks: Float) -> Unit,
 ) {
-    private val xVelocity = VelocityTracker1D(isDataDifferential = true)
-    private val yVelocity = VelocityTracker1D(isDataDifferential = true)
+    /**
+     * Gesture samples (timeMillis, dxPx, dyPx) for the release-velocity
+     * estimate. A windowed distance-over-time mean is used instead of an
+     * impulse/LSQ velocity tracker: Windows synthesizes coalesced wheel
+     * quanta (a single 2-tick event = 200px at one instant ≈ a 25 000 px/s
+     * point-wise spike), which tracker strategies built for touch positions
+     * wildly overestimate — measured glides hit the curve's 20 946 px/s cap
+     * on ordinary flicks. Total distance ÷ elapsed time over the last
+     * [VELOCITY_WINDOW_MS] is immune to the burst shape.
+     */
+    private class Sample(
+        val timeMillis: Long,
+        val dxPx: Float,
+        val dyPx: Float,
+    )
+
+    private val samples = ArrayDeque<Sample>()
     private var armJob: Job? = null
 
     // Volatile only for cross-thread visibility in tests; production access
@@ -64,8 +78,8 @@ internal class TaoWheelFling(
     ) {
         cancelFling()
         if (isFractional(dxTicks) || isFractional(dyTicks)) sawFractionalTick = true
-        xVelocity.addDataPoint(timeMillis, dxTicks * pixelsPerTick)
-        yVelocity.addDataPoint(timeMillis, dyTicks * pixelsPerTick)
+        samples.addLast(Sample(timeMillis, dxTicks * pixelsPerTick, dyTicks * pixelsPerTick))
+        while (samples.size > MAX_SAMPLES) samples.removeFirst()
         armJob?.cancel()
         armJob =
             scope.launch {
@@ -88,17 +102,49 @@ internal class TaoWheelFling(
     }
 
     private fun resetGesture() {
-        xVelocity.resetTracking()
-        yVelocity.resetTracking()
+        samples.clear()
         sawFractionalTick = false
     }
 
+    /**
+     * Windowed release velocity: distance ÷ time over the samples inside the
+     * last [VELOCITY_WINDOW_MS] before the final event. Requires
+     * [MIN_SAMPLES] events (a lone coalesced quantum has no measurable
+     * duration) and caps the result at [MAX_FLING_VELOCITY_PX_PER_S] — the
+     * curve tops out at 20 946 px/s, far beyond any deliberate gesture.
+     */
+    private fun releaseVelocityPxPerS(): Pair<Float, Float>? {
+        val last = samples.lastOrNull() ?: return null
+        val windowed = samples.filter { last.timeMillis - it.timeMillis <= VELOCITY_WINDOW_MS }
+        if (windowed.size < MIN_SAMPLES) return null
+        // The first sample's delta accumulated BEFORE the window starts;
+        // count only the time span and distance between first and last.
+        val spanMs = (last.timeMillis - windowed.first().timeMillis).coerceAtLeast(1L)
+        var dx = 0f
+        var dy = 0f
+        for (i in 1 until windowed.size) {
+            dx += windowed[i].dxPx
+            dy += windowed[i].dyPx
+        }
+        val vx = dx * MS_PER_SECOND / spanMs
+        val vy = dy * MS_PER_SECOND / spanMs
+        val magnitude = max(abs(vx), abs(vy))
+        if (magnitude <= 0f) return null
+        val scale =
+            if (magnitude > MAX_FLING_VELOCITY_PX_PER_S) {
+                MAX_FLING_VELOCITY_PX_PER_S / magnitude
+            } else {
+                1f
+            }
+        return (vx * scale) to (vy * scale)
+    }
+
     private fun maybeStartFling() {
-        val vx = xVelocity.calculateVelocity()
-        val vy = yVelocity.calculateVelocity()
+        val velocity = releaseVelocityPxPerS()
         val touchpadGesture = sawFractionalTick
         resetGesture()
-        if (!touchpadGesture) return
+        if (!touchpadGesture || velocity == null) return
+        val (vx, vy) = velocity
         if (max(abs(vx), abs(vy)) < MIN_FLING_VELOCITY_PX_PER_S) return
         val curve = ChromiumFlingCurve(vx, vy)
         if (!curve.isValid) return
@@ -130,6 +176,25 @@ internal class TaoWheelFling(
 
         /** Below this release velocity a glide wouldn't be perceptible. */
         const val MIN_FLING_VELOCITY_PX_PER_S = 100f
+
+        /**
+         * Release-velocity ceiling. Chrome's DirectManipulation inertia never
+         * launches anywhere near the curve's 20 946 px/s top; 6 000 px/s
+         * (≈ Avalonia's 8 000 cap, Chromium gesture configs are lower still)
+         * bounds the glide at ~1 450 px for the hardest flick.
+         */
+        const val MAX_FLING_VELOCITY_PX_PER_S = 6_000f
+
+        /** Sliding window for the distance-over-time velocity estimate. */
+        const val VELOCITY_WINDOW_MS = 120L
+
+        /** A single coalesced quantum has no measurable duration — no glide. */
+        const val MIN_SAMPLES = 3
+
+        /** Ring-buffer bound; ~2× any realistic 120 ms event burst. */
+        const val MAX_SAMPLES = 32
+
+        const val MS_PER_SECOND = 1_000f
 
         /** Skip emissions Compose would discard as sub-visible anyway. */
         const val MIN_EMIT_PX = 0.01f

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFlingTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFlingTest.kt
@@ -82,10 +82,10 @@ class TaoWheelFlingTest {
             val deltas = h.emitted.toList()
             assertTrue(deltas.size > 10, "glide should span many frames, got ${deltas.size}")
             assertTrue(deltas.all { it.second > 0f }, "glide must keep the flick direction")
-            // ~19125 px/s on the Chromium curve ≈ 4950 px ≈ 49.5 ticks; leave
-            // headroom for the velocity-tracker estimate.
+            // Windowed estimate: 7×153px over 56ms ≈ 19 125 px/s, capped at
+            // 6 000 px/s → Chromium-curve glide ≈ 1 455 px ≈ 14.6 ticks.
             val totalTicks = deltas.map { it.second }.sum()
-            assertTrue(totalTicks in 30f..70f, "expected ~49 ticks of glide, got $totalTicks")
+            assertTrue(totalTicks in 12f..18f, "expected ~14.6 ticks of glide, got $totalTicks")
         }
     }
 
@@ -112,6 +112,18 @@ class TaoWheelFlingTest {
             }
             assertFalse(h.awaitGlideStart(timeoutMs = 300))
             assertTrue(h.emitted.isEmpty(), "sub-threshold release velocity must not glide")
+        }
+    }
+
+    @Test
+    fun tooFewEventsDoNotGlide() {
+        Harness().use { h ->
+            // A lone coalesced quantum (or two) has no measurable duration —
+            // the windowed estimate needs MIN_SAMPLES events.
+            h.fling.onUserScroll(0f, 1.53f, 0L)
+            h.fling.onUserScroll(0f, 1.53f, 8L)
+            assertFalse(h.awaitGlideStart(timeoutMs = 300))
+            assertTrue(h.emitted.isEmpty(), "sub-MIN_SAMPLES gestures must not glide")
         }
     }
 


### PR DESCRIPTION
## Problem

On-device testing of #309: glides launch way too fast ("ça va hyper hyper vite"). `VelocityTracker1D`'s impulse strategy — designed for touch position streams — wildly overestimates on Windows' coalesced wheel quanta: one 2-tick event is a 200px step at a single instant (~25,000 px/s point-wise spike), so ordinary flicks hit the Chromium curve's 20,946 px/s maximum and glided ~5,400px at full speed.

## Fix

- **Windowed distance-over-time velocity**: sum of deltas over the last 120ms of samples ÷ elapsed span (first sample counts for time only). Immune to burst shape — measures actual content speed.
- **6,000 px/s release cap** (~Avalonia's 8,000; Chromium gesture configs lower still): hardest flick glides ~1,450px, gentle swipes a few hundred px.
- **≥3 events required**: a lone coalesced quantum has no measurable duration → no surprise glide on tiny nudges.

Reference points on the Chromium curve after cap: 8,440 px/s real flick (from the earlier scroll-test logs) → capped 6,000 → ~1,450px glide; 2,000 px/s gentle swipe → ~370px.

## Verification

`TaoWheelFlingTest` updated (6 tests, incl. new sub-MIN_SAMPLES gate); curve tests unchanged; detekt + ktlint green. On-device Windows validation pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)