### PR TITLE
fix(tao-windows): close the lift-to-glide gap; scroll pipeline diagnostics

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoScrollDiagnostics.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoScrollDiagnostics.kt
@@ -1,0 +1,32 @@
+package dev.nucleusframework.window.tao
+
+/**
+ * Live scroll-pipeline diagnostics for the Tao Windows backend, meant for
+ * test/diagnostic screens (e.g. the example app's ScrollTestScreen).
+ *
+ * Answers two questions a tester can't see from the outside:
+ *  - which input pipeline is running — a DirectManipulation viewport
+ *    (OS-computed pan/pinch/inertia) or the synthesized-wheel fallback;
+ *  - whether an inertia phase is active right now, and whose it is
+ *    (OS-computed vs. the software [render.TaoWheelFling] glide).
+ *
+ * Values are written by the window host on its event-loop thread and read
+ * from anywhere (@Volatile); with several windows open the last writer
+ * wins — fine for a diagnostic. Always false on non-Windows platforms.
+ */
+public object TaoScrollDiagnostics {
+    /** A DirectManipulation viewport is attached to the active window. */
+    @Volatile
+    public var directManipulationAttached: Boolean = false
+        internal set
+
+    /** The OS is running a manipulation right now (gesture or inertia). */
+    @Volatile
+    public var directManipulationSession: Boolean = false
+        internal set
+
+    /** The software wheel fling is emitting glide ticks right now. */
+    @Volatile
+    public var softwareFlingActive: Boolean = false
+        internal set
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -230,6 +230,8 @@ internal class TaoComposeSceneHostWindows(
             dev.nucleusframework.window.tao.NativeTaoDManipBridge.isLoaded &&
             dev.nucleusframework.window.tao.NativeTaoDManipBridge
                 .nativeAttach(hwnd)
+        dev.nucleusframework.window.tao.TaoScrollDiagnostics
+            .directManipulationAttached = dmanipAttached
 
         // ANGLE/D3D11 (WARP-capable on RDP/VMs) is the only Windows backend.
         // Skia needs an EGL-assembled GL interface — the default makeGL()
@@ -1064,6 +1066,12 @@ internal class TaoComposeSceneHostWindows(
             wheelFling.cancel()
         }
         dmanipSessionActive = active
+        dev.nucleusframework.window.tao.TaoScrollDiagnostics.directManipulationSession = active
+        // While the OS runs a manipulation, keep frames coming at vsync so
+        // the fetch pumps DManip at render cadence — Chromium pumps from its
+        // BeginFrame the same way. The native 8ms timer (~15.6ms real
+        // granularity) remains as a backstop when nothing else invalidates.
+        if (active) window.requestRedraw()
 
         val scaleDelta = dmanipDeltas[2]
         if (kotlin.math.abs(scaleDelta - 1f) > DMANIP_SCALE_EPSILON) {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFling.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFling.kt
@@ -99,6 +99,7 @@ internal class TaoWheelFling(
     private fun cancelFling() {
         flingJob?.cancel()
         flingJob = null
+        dev.nucleusframework.window.tao.TaoScrollDiagnostics.softwareFlingActive = false
     }
 
     private fun resetGesture() {
@@ -148,22 +149,31 @@ internal class TaoWheelFling(
         if (max(abs(vx), abs(vy)) < MIN_FLING_VELOCITY_PX_PER_S) return
         val curve = ChromiumFlingCurve(vx, vy)
         if (!curve.isValid) return
+        dev.nucleusframework.window.tao.TaoScrollDiagnostics.softwareFlingActive = true
         flingJob =
             scope.launch {
-                var emittedX = 0f
-                var emittedY = 0f
-                val startNanos = withFrameNanos { it }
-                while (true) {
-                    val elapsed = (withFrameNanos { it } - startNanos) / NANOS_PER_SECOND
-                    val target = curve.offsetAt(elapsed)
-                    val dx = target.x - emittedX
-                    val dy = target.y - emittedY
-                    if (abs(dx) > MIN_EMIT_PX || abs(dy) > MIN_EMIT_PX) {
-                        emittedX += dx
-                        emittedY += dy
-                        emitTicks(dx / pixelsPerTick, dy / pixelsPerTick)
+                try {
+                    var emittedX = 0f
+                    var emittedY = 0f
+                    // Baseline on the launch instant, not the first frame tick —
+                    // the host frame clock runs on the same System.nanoTime base,
+                    // and burning a frame just to read the clock would add ~16ms
+                    // to the lift-to-glide gap (visible on a hard flick).
+                    val startNanos = System.nanoTime()
+                    while (true) {
+                        val elapsed = (withFrameNanos { it } - startNanos) / NANOS_PER_SECOND
+                        val target = curve.offsetAt(elapsed)
+                        val dx = target.x - emittedX
+                        val dy = target.y - emittedY
+                        if (abs(dx) > MIN_EMIT_PX || abs(dy) > MIN_EMIT_PX) {
+                            emittedX += dx
+                            emittedY += dy
+                            emitTicks(dx / pixelsPerTick, dy / pixelsPerTick)
+                        }
+                        if (curve.isFinishedAt(elapsed)) break
                     }
-                    if (curve.isFinishedAt(elapsed)) break
+                } finally {
+                    dev.nucleusframework.window.tao.TaoScrollDiagnostics.softwareFlingActive = false
                 }
             }
     }
@@ -171,8 +181,15 @@ internal class TaoWheelFling(
     private fun isFractional(ticks: Float): Boolean = abs(ticks - round(ticks)) > FRACTIONAL_TICK_EPSILON
 
     internal companion object {
-        /** Quiet gap that ends a gesture — matches Compose's `ScrollProgressTimeout`. */
-        const val GESTURE_END_MS = 50L
+        /**
+         * Quiet gap that ends a gesture. Precision-touchpad wheel synthesis
+         * arrives at 60–125 Hz (gaps ≤ ~16 ms), so 35 ms is still safely
+         * above one inter-event gap while shaving the lift-to-glide freeze —
+         * at 6 000 px/s a 50 ms gap read as a visible hitch on hard flicks.
+         * A premature fire mid-gesture self-heals: the next real event
+         * cancels the glide and the windowed velocity barely differs.
+         */
+        const val GESTURE_END_MS = 35L
 
         /** Below this release velocity a glide wouldn't be perceptible. */
         const val MIN_FLING_VELOCITY_PX_PER_S = 100f

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_dmanip.cpp
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_dmanip.cpp
@@ -282,6 +282,10 @@ static LRESULT CALLBACK DManipSubclassProc(HWND hwnd,
           SetTimer(hwnd, DMANIP_TIMER_ID, DMANIP_TIMER_MS, nullptr);
           s->timerActive = TRUE;
         }
+        /* Pump immediately: waiting for the first WM_TIMER tick (8 ms
+         * nominal, ~15.6 ms real granularity) plus a paint adds a visible
+         * dead window at gesture start on hard flicks. */
+        PumpAndInvalidate(s);
       }
       break;
     }

--- a/example/src/main/kotlin/com/example/demo/ScrollTestScreen.kt
+++ b/example/src/main/kotlin/com/example/demo/ScrollTestScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import dev.nucleusframework.window.tao.TaoScrollDiagnostics
 import kotlinx.coroutines.delay
 import kotlin.math.abs
 import kotlin.math.max
@@ -93,6 +94,8 @@ fun ScrollTestScreen() {
     var liveRawY by remember { mutableStateOf(0f) }
     var liveValue by remember { mutableStateOf(0) }
     var fps by remember { mutableStateOf(0) }
+    var inertiaLabel by remember { mutableStateOf("inactive") }
+    var backendLabel by remember { mutableStateOf("?") }
 
     // Live render FPS = frame-clock ticks per second. This is the metric the
     // scroll-cadence fix changes (the smooth-scroll tween ticks once per frame):
@@ -123,6 +126,14 @@ fun ScrollTestScreen() {
         while (true) {
             delay(40)
             liveValue = scrollState.value
+            inertiaLabel =
+                when {
+                    TaoScrollDiagnostics.directManipulationSession -> "OS (DManip)"
+                    TaoScrollDiagnostics.softwareFlingActive -> "logicielle (fling)"
+                    else -> "inactive"
+                }
+            backendLabel =
+                if (TaoScrollDiagnostics.directManipulationAttached) "DManip" else "molette"
             val now = System.nanoTime() / 1_000_000
             if (meter.inGesture && now - meter.lastTimeMs >= IDLE_MS) {
                 val px = scrollState.value - meter.startValuePx
@@ -158,6 +169,8 @@ fun ScrollTestScreen() {
                 value = liveValue,
                 maxValue = scrollState.maxValue,
                 fps = fps,
+                inertiaLabel = inertiaLabel,
+                backendLabel = backendLabel,
                 onReset = {
                     gestures.clear()
                     counter = 0
@@ -231,6 +244,8 @@ private fun StatsPanel(
     value: Int,
     maxValue: Int,
     fps: Int,
+    inertiaLabel: String,
+    backendLabel: String,
     onReset: () -> Unit,
     onCopy: () -> Unit,
 ) {
@@ -247,6 +262,11 @@ private fun StatsPanel(
         Text(
             "live rawΔy = %+.3f   |   offset = %d / %d   |   avg px/gesture = %.0f   |   render = %d fps"
                 .format(liveRawY, value, maxValue, avgPx, fps),
+            fontFamily = FontFamily.Monospace,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Text(
+            "backend = $backendLabel   |   inertie = $inertiaLabel",
             fontFamily = FontFamily.Monospace,
             style = MaterialTheme.typography.bodyMedium,
         )


### PR DESCRIPTION
## Problem (on-device report)

Hard flicks show a mini-hitch right before the now-smooth inertia. The software fling freezes for `GESTURE_END_MS` (50ms) + one burned frame between the last wheel event and the first glide tick — ~65ms dead at 6,000 px/s.

## Fixes

- **Fling**: `GESTURE_END_MS` 50→35ms (PTP synthesis gaps ≤ ~16ms; premature fire self-heals — next real event cancels the glide) + glide baseline on the launch instant instead of the first frame tick (same `System.nanoTime` base as the host frame clock) → gap shrinks from ~65ms to ~35ms + paint.
- **DManip** (same symptom family where it attaches): immediate pump+invalidate on `DM_POINTERHITTEST` (first WM_TIMER tick has ~15.6ms real granularity), and the host re-requests a frame each drain while a session is active — render-cadence pumping, Chromium-BeginFrame style.
- **Diagnostics** (user request): `TaoScrollDiagnostics` + ScrollTestScreen now displays `backend = DManip|molette` and `inertie = OS (DManip)|logicielle (fling)|inactive` — on-device reports can finally tell which pipeline is live.

## Verification

Module tests, detekt, ktlint, example compile green. Windows CI runs the DManip smoke on a real HWND. Feel validation on-device with the next alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)