### PR TITLE
fix(tao-windows): no drift on slow release; catch-up glide start; DManip contact diag

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoDManipBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoDManipBridge.kt
@@ -47,10 +47,12 @@ internal object NativeTaoDManipBridge {
     external fun nativeDetach(hwnd: Long)
 
     /**
-     * Drains accumulated manipulation deltas into [out] (size >= 3):
+     * Drains accumulated manipulation deltas into [out] (size >= 4):
      * `out[0]`/`out[1]` = pan delta X/Y in physical px since the last fetch,
-     * `out[2]` = multiplicative scale delta (1.0 = no zoom). Returns the
-     * current `STATUS_*`.
+     * `out[2]` = multiplicative scale delta (1.0 = no zoom),
+     * `out[3]` = cumulative touchpad hit-test count (0 forever = legacy
+     * driver, DManip can't engage on that machine). Returns the current
+     * `STATUS_*`.
      */
     @JvmStatic
     external fun nativeFetch(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoScrollDiagnostics.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoScrollDiagnostics.kt
@@ -29,4 +29,14 @@ public object TaoScrollDiagnostics {
     @Volatile
     public var softwareFlingActive: Boolean = false
         internal set
+
+    /**
+     * Cumulative touchpad hit-tests handed to the DirectManipulation
+     * viewport. Stuck at 0 while scrolling = the touchpad driver is legacy
+     * (mouse emulation, no pointer stack) and DManip can never engage on
+     * that machine.
+     */
+    @Volatile
+    public var directManipulationContacts: Int = 0
+        internal set
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -1049,7 +1049,7 @@ internal class TaoComposeSceneHostWindows(
     // ── DirectManipulation drain ────────────────────────────────────────
     private var dmanipAttached = false
     private var dmanipSessionActive = false
-    private val dmanipDeltas = FloatArray(3)
+    private val dmanipDeltas = FloatArray(4)
 
     @OptIn(ExperimentalComposeUiApi::class)
     private fun drainDirectManipulation() {
@@ -1067,6 +1067,8 @@ internal class TaoComposeSceneHostWindows(
         }
         dmanipSessionActive = active
         dev.nucleusframework.window.tao.TaoScrollDiagnostics.directManipulationSession = active
+        dev.nucleusframework.window.tao.TaoScrollDiagnostics.directManipulationContacts =
+            dmanipDeltas[3].toInt()
         // While the OS runs a manipulation, keep frames coming at vsync so
         // the fetch pumps DManip at render cadence — Chromium pumps from its
         // BeginFrame the same way. The native 8ms timer (~15.6ms real

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFling.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFling.kt
@@ -55,6 +55,9 @@ internal class TaoWheelFling(
     )
 
     private val samples = ArrayDeque<Sample>()
+
+    /** Wall-clock (frame-clock timebase) instant of the last real event. */
+    private var lastEventWallNanos = 0L
     private var armJob: Job? = null
 
     // Volatile only for cross-thread visibility in tests; production access
@@ -80,6 +83,7 @@ internal class TaoWheelFling(
         if (isFractional(dxTicks) || isFractional(dyTicks)) sawFractionalTick = true
         samples.addLast(Sample(timeMillis, dxTicks * pixelsPerTick, dyTicks * pixelsPerTick))
         while (samples.size > MAX_SAMPLES) samples.removeFirst()
+        lastEventWallNanos = System.nanoTime()
         armJob?.cancel()
         armJob =
             scope.launch {
@@ -155,11 +159,13 @@ internal class TaoWheelFling(
                 try {
                     var emittedX = 0f
                     var emittedY = 0f
-                    // Baseline on the launch instant, not the first frame tick —
-                    // the host frame clock runs on the same System.nanoTime base,
-                    // and burning a frame just to read the clock would add ~16ms
-                    // to the lift-to-glide gap (visible on a hard flick).
-                    val startNanos = System.nanoTime()
+                    // Baseline on the LAST REAL EVENT (same System.nanoTime base
+                    // as the host frame clock), not on fling launch: the first
+                    // emitted frame then covers the whole gesture-end detection
+                    // window in one catch-up step, so the content lands where it
+                    // would have been had the glide started at finger lift —
+                    // the eye reads continuous motion instead of a ~35ms freeze.
+                    val startNanos = lastEventWallNanos
                     while (true) {
                         val elapsed = (withFrameNanos { it } - startNanos) / NANOS_PER_SECOND
                         val target = curve.offsetAt(elapsed)
@@ -191,8 +197,14 @@ internal class TaoWheelFling(
          */
         const val GESTURE_END_MS = 35L
 
-        /** Below this release velocity a glide wouldn't be perceptible. */
-        const val MIN_FLING_VELOCITY_PX_PER_S = 100f
+        /**
+         * Below this release velocity, no glide: a slow deliberate scroll
+         * must stop EXACTLY where the fingers stop (drift after a precise
+         * positioning is jarring). Real flicks release well above 1500px/s;
+         * OS inertia (macOS, DManip) has the same behavior — momentum only
+         * for genuine flicks.
+         */
+        const val MIN_FLING_VELOCITY_PX_PER_S = 500f
 
         /**
          * Release-velocity ceiling. Chrome's DirectManipulation inertia never
@@ -202,8 +214,14 @@ internal class TaoWheelFling(
          */
         const val MAX_FLING_VELOCITY_PX_PER_S = 6_000f
 
-        /** Sliding window for the distance-over-time velocity estimate. */
-        const val VELOCITY_WINDOW_MS = 120L
+        /**
+         * Sliding window for the distance-over-time velocity estimate.
+         * Short on purpose: it must capture the RELEASE velocity, including
+         * the deceleration before a lift. A 120ms window averaged over the
+         * slowdown and made precise slow scrolls drift past their stop
+         * point; 64ms still holds 4-5 samples of a dense flick burst.
+         */
+        const val VELOCITY_WINDOW_MS = 64L
 
         /** A single coalesced quantum has no measurable duration — no glide. */
         const val MIN_SAMPLES = 3

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_dmanip.cpp
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_dmanip.cpp
@@ -146,6 +146,7 @@ struct DManipState {
   float pendingScale; /* multiplicative, 1.0 = no zoom */
   int status;         /* DMANIP_STATUS_* as of the last callback */
   BOOL timerActive;
+  LONG contactCount; /* PT_TOUCHPAD hit-tests handed to the viewport (diagnostic) */
 };
 
 static DManipState* GetState(HWND hwnd) {
@@ -278,6 +279,7 @@ static LRESULT CALLBACK DManipSubclassProc(HWND hwnd,
       if (s->getPointerType && s->getPointerType(pointerId, &type) &&
           type == PT_TOUCHPAD) {
         s->viewport->SetContact(pointerId);
+        s->contactCount++;
         if (!s->timerActive) {
           SetTimer(hwnd, DMANIP_TIMER_ID, DMANIP_TIMER_MS, nullptr);
           s->timerActive = TRUE;
@@ -448,10 +450,13 @@ Java_dev_nucleusframework_window_tao_NativeTaoDManipBridge_nativeDetach(
 }
 
 /*
- * Drains accumulated manipulation deltas into out[0..2]:
+ * Drains accumulated manipulation deltas into out[0..3]:
  *   out[0] = pan delta X (physical px since last fetch)
  *   out[1] = pan delta Y (physical px since last fetch)
  *   out[2] = multiplicative scale delta since last fetch (1.0 = none)
+ *   out[3] = cumulative PT_TOUCHPAD hit-test count (diagnostic; 0 forever
+ *            means the pad never routes through the pointer stack — legacy
+ *            driver — and DManip can't engage on that machine)
  * Returns the viewport status (DMANIP_STATUS_*), or -1 when not attached.
  * Also pumps the update manager so callbacks fire even between timer ticks.
  */
@@ -461,18 +466,19 @@ Java_dev_nucleusframework_window_tao_NativeTaoDManipBridge_nativeFetch(
   (void)clazz;
   HWND hwnd = (HWND)(UINT_PTR)hwndHandle;
   DManipState* s = GetState(hwnd);
-  if (!s || !out || env->GetArrayLength(out) < 3) return -1;
+  if (!s || !out || env->GetArrayLength(out) < 4) return -1;
 
   if (s->updateManager) s->updateManager->Update(nullptr);
 
-  jfloat values[3];
+  jfloat values[4];
   values[0] = s->pendingPanX;
   values[1] = s->pendingPanY;
   values[2] = s->pendingScale;
+  values[3] = (jfloat)s->contactCount;
   s->pendingPanX = 0.0f;
   s->pendingPanY = 0.0f;
   s->pendingScale = 1.0f;
-  env->SetFloatArrayRegion(out, 0, 3, values);
+  env->SetFloatArrayRegion(out, 0, 4, values);
   return (jint)s->status;
 }
 

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/DManipNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/DManipNativeSmokeTest.kt
@@ -37,12 +37,13 @@ class DManipNativeSmokeTest {
                 "DirectManipulation viewport attach failed (COM/manager/viewport)",
             )
 
-            val out = FloatArray(3)
+            val out = FloatArray(4)
             val status = NativeTaoDManipBridge.nativeFetch(hwnd, out)
             assertEquals(NativeTaoDManipBridge.STATUS_IDLE, status, "fresh viewport must be idle")
             assertEquals(0f, out[0], "no pan X expected while idle")
             assertEquals(0f, out[1], "no pan Y expected while idle")
             assertEquals(1f, out[2], "no scale delta expected while idle")
+            assertEquals(0f, out[3], "no touchpad contacts expected on a fresh viewport")
 
             NativeTaoDManipBridge.nativeDetach(hwnd)
             assertEquals(

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFlingTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/render/TaoWheelFlingTest.kt
@@ -116,6 +116,25 @@ class TaoWheelFlingTest {
     }
 
     @Test
+    fun deceleratingReleaseDoesNotGlide() {
+        Harness().use { h ->
+            // Fast start, then the fingers slow to a near-stop before lifting
+            // (precise positioning). The release velocity must come from the
+            // deceleration tail, not the earlier speed — no drift allowed.
+            var t = 0L
+            repeat(4) {
+                h.fling.onUserScroll(0f, 1.5f, t)
+                t += 8
+            }
+            h.fling.onUserScroll(0f, 0.05f, 60L)
+            h.fling.onUserScroll(0f, 0.03f, 85L)
+            h.fling.onUserScroll(0f, 0.02f, 110L)
+            assertFalse(h.awaitGlideStart(timeoutMs = 300))
+            assertTrue(h.emitted.isEmpty(), "a decelerated release must stop in place")
+        }
+    }
+
+    @Test
     fun tooFewEventsDoNotGlide() {
         Harness().use { h ->
             // A lone coalesced quantum (or two) has no measurable duration —

--- a/example/src/main/kotlin/com/example/demo/ScrollTestScreen.kt
+++ b/example/src/main/kotlin/com/example/demo/ScrollTestScreen.kt
@@ -133,7 +133,11 @@ fun ScrollTestScreen() {
                     else -> "inactive"
                 }
             backendLabel =
-                if (TaoScrollDiagnostics.directManipulationAttached) "DManip" else "molette"
+                if (TaoScrollDiagnostics.directManipulationAttached) {
+                    "DManip (contacts=${TaoScrollDiagnostics.directManipulationContacts})"
+                } else {
+                    "molette"
+                }
             val now = System.nanoTime() / 1_000_000
             if (meter.inGesture && now - meter.lastTimeMs >= IDLE_MS) {
                 val px = scrollState.value - meter.startValuePx


### PR DESCRIPTION
## On-device findings (legacy ELAN I2C pad — wheel-path fling is the permanent pipeline there)

1. **Slow-release drift**: precise slow scrolls kept moving after lift. The velocity window (120ms) averaged straight through the user's deceleration and the 100px/s fling floor was far too low. → window 64ms (captures the decel tail, still 4-5 samples for a flick burst) + floor 500px/s. Precise positioning now stops in place; genuine flicks (>1500px/s) glide as before. New `deceleratingReleaseDoesNotGlide` test.
2. **Residual lift-to-glide micro-lag**: the glide curve now baselines on the last real event instead of fling launch — the first frame catches up the 35ms detection window in one step, reading as continuous motion instead of a freeze.
3. **DManip contact counter** (`out[3]` → `TaoScrollDiagnostics.directManipulationContacts` → ScrollTestScreen `DManip (contacts=N)`): distinguishes "viewport attached but the driver never routes gestures" (legacy pad, contacts stuck at 0 — the ELAN machine's case) from a hit-test routing bug on true PTP hardware.

## Verification

12 fling/curve tests green (incl. the new decel-release case), detekt/ktlint/example compile green; Windows CI runs the DManip smoke (updated to the 4-slot fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)