### PR TITLE
feat(tao-linux): nativePopupLayers on X11 + Wayland

### DIFF
--- a/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
+++ b/decorated-window-material2/src/main/kotlin/dev/nucleusframework/window/material2/MaterialDecoratedWindow.kt
@@ -78,8 +78,8 @@ fun NucleusApplicationScope.MaterialDecoratedWindow(
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
     // Materialise Compose Popup layers as native transparent windows
-    // (NSPanel / WS_POPUP HWND) so menus can extend past the window bounds.
-    // Honoured by the Tao backend on Windows/macOS; ignored elsewhere.
+    // (NSPanel / WS_POPUP HWND / Tao popup window on Linux) so menus can
+    // extend past the window bounds. Honoured by the Tao backend; ignored by AWT.
     nativePopupLayers: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },

--- a/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
+++ b/decorated-window-material3/src/main/kotlin/dev/nucleusframework/window/material/MaterialDecoratedWindow.kt
@@ -91,8 +91,8 @@ fun NucleusApplicationScope.MaterialDecoratedWindow(
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
     // Materialise Compose Popup layers as native transparent windows
-    // (NSPanel / WS_POPUP HWND) so menus can extend past the window bounds.
-    // Honoured by the Tao backend on Windows/macOS; ignored elsewhere.
+    // (NSPanel / WS_POPUP HWND / Tao popup window on Linux) so menus can
+    // extend past the window bounds. Honoured by the Tao backend; ignored by AWT.
     nativePopupLayers: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -113,8 +113,8 @@ internal fun ApplicationScope.openDecoratedWindow(
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     // Materialise Compose Popup layers as native transparent windows
-    // (NSPanel / WS_POPUP HWND) instead of drawing them inline in this
-    // window's render target. Windows/macOS only; ignored on Linux.
+    // (NSPanel / WS_POPUP HWND / Tao popup window on Linux) instead of
+    // drawing them inline in this window's render target.
     nativePopupLayers: Boolean = false,
     macOSStyle: MacOSStyle = MacOSStyle.Classic,
     // Parent composition locals to bridge into this window's own ComposeScene
@@ -184,6 +184,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             onPreviewKeyEvent,
             onKeyEvent,
             initialCompositionLocalContext,
+            nativePopupLayers,
             content,
         )
     }
@@ -406,9 +407,11 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     onPreviewKeyEvent: (KeyEvent) -> Boolean,
     onKeyEvent: (KeyEvent) -> Boolean,
     initialCompositionLocalContext: CompositionLocalContext?,
+    nativePopupLayers: Boolean,
     content: @Composable TaoDecoratedWindowScope.() -> Unit,
 ): TaoWindow {
     val host = TaoComposeSceneHostLinux(window)
+    host.nativePopupLayers = nativePopupLayers
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
     host.setSceneCompositionLocalContext(initialCompositionLocalContext)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -71,8 +71,9 @@ fun ApplicationScope.DecoratedWindow(
     onKeyEvent: (KeyEvent) -> Boolean = { false },
     /**
      * Materialise Compose Popup layers as native transparent windows
-     * (NSPanel / WS_POPUP HWND) instead of drawing them inline in this
-     * window's render target. Windows/macOS only; ignored on Linux.
+     * (NSPanel / WS_POPUP HWND / Tao popup window on Linux — override-
+     * redirect on X11, `wl_subsurface` on Wayland) instead of drawing them
+     * inline in this window's render target.
      */
     nativePopupLayers: Boolean = false,
     macOSStyle: MacOSStyle = MacOSStyle.Classic,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneContextLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneContextLinux.kt
@@ -1,0 +1,36 @@
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.runtime.CompositionContext
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.scene.ComposeSceneContext
+import androidx.compose.ui.scene.ComposeSceneLayer
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+
+/**
+ * Linux port of [TaoComposeSceneContext] (macOS) /
+ * [TaoComposeSceneContextWindows]. Installed on the main host scene when
+ * `nativePopupLayers = true`: every Compose Popup / DropdownMenu / Tooltip
+ * layer materialises as a [TaoPopupSceneLayerLinux] (a Tao popup window)
+ * instead of drawing inside the host's EGL render target.
+ */
+@OptIn(InternalComposeUiApi::class)
+internal class TaoComposeSceneContextLinux(
+    override val platformContext: PlatformContext,
+    private val popupHost: TaoPopupHostLinux,
+) : ComposeSceneContext {
+    override fun createLayer(
+        density: Density,
+        layoutDirection: LayoutDirection,
+        focusable: Boolean,
+        compositionContext: CompositionContext,
+    ): ComposeSceneLayer =
+        TaoPopupSceneLayerLinux(
+            host = popupHost,
+            initialDensity = density,
+            initialLayoutDirection = layoutDirection,
+            initialFocusable = focusable,
+            parentCompositionContext = compositionContext,
+        )
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
@@ -18,8 +18,10 @@ import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeScenePointer
+import androidx.compose.ui.scene.PlatformLayersComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
@@ -105,6 +107,42 @@ internal class TaoComposeSceneHostLinux(
      * BaseComposeScene picks it up. Set once before [attach].
      */
     var semanticsOwnerListener: androidx.compose.ui.platform.PlatformContext.SemanticsOwnerListener? = null
+
+    /**
+     * When true, Compose Popup / DropdownMenu / Tooltip layers materialise as
+     * real Tao popup windows ([TaoPopupSceneLayerLinux] — override-redirect on
+     * X11, `wl_subsurface` on Wayland) instead of drawing inside this window's
+     * EGL render target. Opt-in — see the Windows/macOS counterparts. Set
+     * before [attach].
+     */
+    var nativePopupLayers: Boolean = false
+
+    /**
+     * Renderers registered by popup layers. Drained AFTER the main scene's
+     * render in [onRedrawRequested] — each popup binds its own private EGL
+     * context (one context per attachment on Linux), paints, presents with
+     * swap interval 0 and releases, so no state leaks into the host context.
+     */
+    private val popupRenderers: MutableMap<Any, () -> Unit> = LinkedHashMap()
+
+    /**
+     * Key handlers consulted before the main scene's key dispatch. Popup
+     * windows never own keyboard focus on Linux (override-redirect /
+     * subsurface), so the parent forwards — mirrors the macOS chain.
+     */
+    private val popupKeyHandlers: MutableMap<Any, (KeyEvent) -> Boolean> = LinkedHashMap()
+
+    /** Callbacks invoked when the owner window's screen position changes (X11). */
+    private val ownerMoveListeners: MutableMap<Any, () -> Unit> = LinkedHashMap()
+
+    /**
+     * Callbacks invoked when a press reaches the parent scene while popup
+     * layers are alive — the popup windows own their input region, so a
+     * parent press is by definition outside every popup. See
+     * [TaoPopupHostLinux.registerOutsidePressListener].
+     */
+    private val outsidePressListeners: MutableMap<Any, (androidx.compose.ui.input.pointer.PointerButton?) -> Unit> =
+        LinkedHashMap()
 
     private val windowInfo = LinuxTaoWindowInfo()
     private var currentKeyboardModifiers: PointerKeyboardModifiers = PointerKeyboardModifiers()
@@ -257,40 +295,71 @@ internal class TaoComposeSceneHostLinux(
                 getRootNode = { scene!!.rootDragAndDropNode },
                 outboundLauncher = ::launchLinuxOutboundDrag,
             )
+        val platformContext =
+            LinuxTaoPlatformContext(
+                windowHandle = window.handle,
+                // The custom CSD title bar is drawn inside the same Compose
+                // scene as the rest of the content, so it shares the (0, 0)
+                // origin with everything else. We must NOT report it as a
+                // `PlatformInsets.top`: Compose's `RootMeasurePolicy` (cf.
+                // `RootMeasurePolicy.skiko.kt::positionWithInsets`) applies
+                // platform insets as an *additive offset* on the popup
+                // position (designed for iOS notches / Android status
+                // bars, where the safe area is outside the Compose surface).
+                // Reporting `top = titleBarHeight` here shifts every Popup,
+                // DropdownMenu, ContextMenu, and Tooltip down by that
+                // amount — visible as a consistent "title-bar-height
+                // downward drift" of every popup the user opens. Popups
+                // are free to overlap the title bar zone; the title bar
+                // composable's own z-order keeps it visually on top of
+                // the page content but popups (rendered in a higher
+                // ComposeSceneLayer) naturally float above both.
+                topInsetPx = { 0 },
+                windowInfo = windowInfo,
+                semanticsOwnerListener = semanticsOwnerListener,
+                dragAndDropManager = dndManager,
+                textToolbar = textToolbar,
+            )
         scene =
-            CanvasLayersComposeScene(
-                density = Density(scale),
-                layoutDirection = GlobalLayoutDirection,
-                coroutineContext = coroutineContext + frameClock + flushingDispatcher,
-                platformContext =
-                    LinuxTaoPlatformContext(
-                        windowHandle = window.handle,
-                        // The custom CSD title bar is drawn inside the same Compose
-                        // scene as the rest of the content, so it shares the (0, 0)
-                        // origin with everything else. We must NOT report it as a
-                        // `PlatformInsets.top`: Compose's `RootMeasurePolicy` (cf.
-                        // `RootMeasurePolicy.skiko.kt::positionWithInsets`) applies
-                        // platform insets as an *additive offset* on the popup
-                        // position (designed for iOS notches / Android status
-                        // bars, where the safe area is outside the Compose surface).
-                        // Reporting `top = titleBarHeight` here shifts every Popup,
-                        // DropdownMenu, ContextMenu, and Tooltip down by that
-                        // amount — visible as a consistent "title-bar-height
-                        // downward drift" of every popup the user opens. Popups
-                        // are free to overlap the title bar zone; the title bar
-                        // composable's own z-order keeps it visually on top of
-                        // the page content but popups (rendered in a higher
-                        // ComposeSceneLayer) naturally float above both.
-                        topInsetPx = { 0 },
-                        windowInfo = windowInfo,
-                        semanticsOwnerListener = semanticsOwnerListener,
-                        dragAndDropManager = dndManager,
-                        textToolbar = textToolbar,
-                    ),
-                invalidate = {
-                    requestRedrawCoalesced()
-                },
-            ).apply { compositionLocalContext = pendingCompositionLocalContext }
+            if (nativePopupLayers) {
+                // Opt-in path: every Popup becomes a Tao popup window owned by
+                // this window (override-redirect on X11, wl_subsurface on
+                // Wayland), so popup content can extend beyond — and float
+                // independently of — the window bounds.
+                PlatformLayersComposeScene(
+                    density = Density(scale),
+                    layoutDirection = GlobalLayoutDirection,
+                    coroutineContext = coroutineContext + frameClock + flushingDispatcher,
+                    composeSceneContext =
+                        TaoComposeSceneContextLinux(
+                            platformContext = platformContext,
+                            popupHost = popupHost(),
+                        ),
+                    invalidate = {
+                        requestRedrawCoalesced()
+                    },
+                ).apply { compositionLocalContext = pendingCompositionLocalContext }
+            } else {
+                // Default: Compose Popup / DropdownMenu / Tooltip content stays
+                // in the same EGL render target as the rest of the UI.
+                CanvasLayersComposeScene(
+                    density = Density(scale),
+                    layoutDirection = GlobalLayoutDirection,
+                    coroutineContext = coroutineContext + frameClock + flushingDispatcher,
+                    platformContext = platformContext,
+                    invalidate = {
+                        requestRedrawCoalesced()
+                    },
+                ).apply { compositionLocalContext = pendingCompositionLocalContext }
+            }
+
+        // Notify popup layers when the host window moves on screen — X11
+        // popups are positioned in root coordinates and don't auto-track.
+        window.onMoved { _, _ ->
+            if (ownerMoveListeners.isNotEmpty()) {
+                for (cb in ownerMoveListeners.values.toList()) cb()
+            }
+        }
 
         registerInboundDnD()
         registerTouch()
@@ -1168,6 +1237,17 @@ internal class TaoComposeSceneHostLinux(
         surface.flushAndSubmit(syncCpu = false)
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
+
+        // Drain popup-layer renderers after the host context was released.
+        // Each layer binds its own private EGL context on this thread (the
+        // swap thread holds the *host* context on its own thread — EGL allows
+        // one current context per thread), paints, presents with swap
+        // interval 0 (non-blocking) and releases. Snapshot: rendering one
+        // layer can recompose and close a sibling.
+        if (popupRenderers.isNotEmpty()) {
+            val snapshot = popupRenderers.values.toList()
+            for (render in snapshot) render()
+        }
     }
 
     /**
@@ -1296,6 +1376,15 @@ internal class TaoComposeSceneHostLinux(
             if (resizeDecoration.onLeftPress(direction)) return
         }
         if (pressed) pressedButtons.add(buttonCode) else pressedButtons.remove(buttonCode)
+
+        // A press reaching the parent scene is outside every popup layer (the
+        // popup windows own their input region) — forward so Compose's
+        // dismiss-on-click-outside fires. The Linux stand-in for macOS's
+        // NSEvent monitor / Windows' WH_MOUSE_LL hook.
+        if (pressed && outsidePressListeners.isNotEmpty()) {
+            val button = mapButton(buttonCode)
+            for (cb in outsidePressListeners.values.toList()) cb(button)
+        }
 
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
         windowInfo.keyboardModifiers = currentKeyboardModifiers
@@ -1432,8 +1521,99 @@ internal class TaoComposeSceneHostLinux(
                 else -> return false
             }
         if (previewKeyHandler?.invoke(composeEvent) == true) return true
+        // Popup layers get a chance to consume the event before the main
+        // scene — popup windows never own keyboard focus on Linux, so the
+        // parent forwards. Mirrors the macOS popupKeyHandlers chain.
+        if (popupKeyHandlers.isNotEmpty()) {
+            for (handler in popupKeyHandlers.values.toList()) {
+                if (handler(composeEvent)) return true
+            }
+        }
         if (sc.sendKeyEvent(composeEvent)) return true
         return keyHandler?.invoke(composeEvent) == true
+    }
+
+    /**
+     * Plumbing handed to [TaoPopupSceneLayerLinux] instances when
+     * [nativePopupLayers] is enabled. Mirrors the Windows
+     * [TaoComposeSceneHostWindows.popupHost] contract, adapted to the Linux
+     * backend: layers are Tao popup windows keyed on [parentWindow], and each
+     * owns a private EGL context so there is no shared DirectContext.
+     */
+    private fun popupHost(): TaoPopupHostLinux {
+        val outer = this
+        return object : TaoPopupHostLinux {
+            override val parentWindow: TaoWindow get() = outer.window
+            override val scale: Float get() = outer.scale
+            override val parentWindowSize: IntSize get() = IntSize(outer.widthPx, outer.heightPx)
+            override val workAreaSize: IntSize get() =
+                NativeTaoBridge
+                    .nativeLinuxPrimaryMonitorWorkArea(outer.window.handle)
+                    ?.takeIf { it.size >= 4 && it[2] > 0 && it[3] > 0 }
+                    ?.let { IntSize(it[2].toInt(), it[3].toInt()) }
+                    ?: parentWindowSize
+
+            // Wayland popups are subsurfaces positioned relative to the
+            // parent surface — no global origin exists (or is needed).
+            override val parentScreenOriginPx: IntOffset get() =
+                if (outer.attachedKind != 1) {
+                    IntOffset.Zero
+                } else {
+                    NativeTaoBridge
+                        .nativeLinuxGetWindowRect(outer.window.handle)
+                        ?.takeIf { it.size >= 2 }
+                        ?.let { IntOffset(it[0].toInt(), it[1].toInt()) }
+                        ?: IntOffset.Zero
+                }
+            override val sceneCoroutineContext: CoroutineContext
+                get() = outer.coroutineContext + outer.frameClock + outer.flushingDispatcher
+
+            override fun requestRedraw() = outer.requestRedrawCoalesced()
+
+            override fun registerRenderer(
+                token: Any,
+                render: () -> Unit,
+            ) {
+                outer.popupRenderers[token] = render
+            }
+
+            override fun unregisterRenderer(token: Any) {
+                outer.popupRenderers.remove(token)
+            }
+
+            override fun registerKeyHandler(
+                token: Any,
+                handler: (KeyEvent) -> Boolean,
+            ) {
+                outer.popupKeyHandlers[token] = handler
+            }
+
+            override fun unregisterKeyHandler(token: Any) {
+                outer.popupKeyHandlers.remove(token)
+            }
+
+            override fun registerOwnerMoveListener(
+                token: Any,
+                onMoved: () -> Unit,
+            ) {
+                outer.ownerMoveListeners[token] = onMoved
+            }
+
+            override fun unregisterOwnerMoveListener(token: Any) {
+                outer.ownerMoveListeners.remove(token)
+            }
+
+            override fun registerOutsidePressListener(
+                token: Any,
+                onPress: (androidx.compose.ui.input.pointer.PointerButton?) -> Unit,
+            ) {
+                outer.outsidePressListeners[token] = onPress
+            }
+
+            override fun unregisterOutsidePressListener(token: Any) {
+                outer.outsidePressListeners.remove(token)
+            }
+        }
     }
 
     /**
@@ -1610,6 +1790,15 @@ internal class TaoComposeSceneHostLinux(
         swapThread?.shutdownAndJoin()
         swapThread = null
 
+        // Close the scene BEFORE re-binding the host EGL context: with
+        // nativePopupLayers, closing a PlatformLayersComposeScene tears down
+        // its live popup layers, and each layer binds *its own* EGL context
+        // to free its Skia resources — leaving that context current. The
+        // host re-bind below must come after so the host's GPU releases land
+        // on the right context.
+        scene?.close()
+        scene = null
+
         // Re-bind THIS window's EGL context before tearing down Skia. The
         // GPU-resource releases that follow (glDeleteFramebuffers /
         // glDeleteTextures inside Surface.close + DirectContext.close) reach
@@ -1627,8 +1816,6 @@ internal class TaoComposeSceneHostLinux(
         cachedSurface = null
         cachedRt?.close()
         cachedRt = null
-        scene?.close()
-        scene = null
         directContext?.close()
         directContext = null
         // Clear any input region we may have set while the window was

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupHostLinux.kt
@@ -1,0 +1,120 @@
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import dev.nucleusframework.window.tao.TaoWindow
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Linux counterpart to [TaoPopupHost] (macOS) / [TaoPopupHostWindows].
+ * Plumbing the popup scene layers need from their host scene on Linux.
+ *
+ * macOS keys on `parentNsView`, Windows on `parentHwnd`; Linux keys on the
+ * parent [TaoWindow] itself — popup layers are real Tao popup windows
+ * (`openWindow(popupOf = parent)`: GTK_WINDOW_POPUP, override-redirect on
+ * X11, `wl_subsurface` on Wayland) so they need the parent handle, not a
+ * raw native pointer.
+ *
+ * Threading: every call must run on the Tao event-loop thread.
+ */
+internal interface TaoPopupHostLinux {
+    /** Tao window hosting the main scene — the popup windows' `popupOf` parent. */
+    val parentWindow: TaoWindow
+
+    /** Backing-scale factor (logical→physical multiplier). */
+    val scale: Float
+
+    /** Host window's content size in physical pixels. */
+    val parentWindowSize: IntSize
+
+    /**
+     * Screen work area in physical pixels. Used as the inner scene's
+     * layout size so a tall popup (DropdownMenu, expanded Tooltip) in a
+     * small parent window lays out at full height instead of being
+     * artificially clipped by the owner window's bounds. Mirrors the
+     * macOS [TaoPopupHost.workAreaSize] contract. Defaults to
+     * [parentWindowSize] when the host can't resolve the monitor.
+     */
+    val workAreaSize: IntSize get() = parentWindowSize
+
+    /**
+     * Parent window's content origin in global screen physical pixels.
+     * X11 popups (override-redirect) are positioned in root coordinates,
+     * so a layer's window-relative `boundsInWindow` must be offset by
+     * this. On Wayland the popup is a `wl_subsurface` positioned
+     * *relative to the parent surface*, so this is [IntOffset.Zero] and
+     * `boundsInWindow` is used as-is.
+     */
+    val parentScreenOriginPx: IntOffset
+
+    /** Coroutine context to feed inner scenes. */
+    val sceneCoroutineContext: CoroutineContext
+
+    /**
+     * Offset added to a popup's `boundsInWindow` before positioning the
+     * popup window. Non-zero when the popup originates from a nested
+     * scene whose origin is not at the host window's top-left.
+     */
+    val coordinateOffset: IntOffset get() = IntOffset.Zero
+
+    fun requestRedraw()
+
+    /**
+     * Registers a per-frame render callback. The host invokes it at the end
+     * of its own [TaoComposeSceneHostLinux.onRedrawRequested], after the main
+     * scene's EGL context was released — each popup binds its *own* private
+     * EGL context (Linux convention: one context per attachment), paints,
+     * presents (swap interval 0, non-blocking) and releases.
+     */
+    fun registerRenderer(
+        token: Any,
+        render: () -> Unit,
+    )
+
+    fun unregisterRenderer(token: Any)
+
+    /**
+     * Registers a key handler consulted by the host's `onKeyEvent` before
+     * the main scene's dispatch. Popup windows never own keyboard focus on
+     * Linux (override-redirect windows on X11, subsurfaces on Wayland), so
+     * key events keep arriving on the parent window and are forwarded here
+     * — same piggy-back path as the macOS popupKeyHandlers chain.
+     */
+    fun registerKeyHandler(
+        token: Any,
+        handler: (KeyEvent) -> Boolean,
+    )
+
+    fun unregisterKeyHandler(token: Any)
+
+    /**
+     * Registers a callback invoked when the host window's screen position
+     * changes. X11 popups are positioned in root coordinates and don't
+     * auto-track their owner — each layer re-issues its frame here.
+     * Never fires on Wayland (no global positions; subsurfaces are
+     * parent-relative and follow for free).
+     */
+    fun registerOwnerMoveListener(
+        token: Any,
+        onMoved: () -> Unit,
+    )
+
+    fun unregisterOwnerMoveListener(token: Any)
+
+    /**
+     * Registers a callback invoked when a pointer press lands on the
+     * *parent* window while this layer is alive. Popup windows own their
+     * input region, so any press the parent scene receives is by
+     * definition outside every popup — the Linux stand-in for macOS's
+     * NSEvent monitor / Windows' WH_MOUSE_LL hook (neither of which has a
+     * Wayland equivalent).
+     */
+    fun registerOutsidePressListener(
+        token: Any,
+        onPress: (PointerButton?) -> Unit,
+    )
+
+    fun unregisterOutsidePressListener(token: Any)
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupSceneLayerLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoPopupSceneLayerLinux.kt
@@ -1,0 +1,485 @@
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asComposeCanvas
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.scene.CanvasLayersComposeScene
+import androidx.compose.ui.scene.ComposeScene
+import androidx.compose.ui.scene.ComposeSceneLayer
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import dev.nucleusframework.window.tao.NativeTaoBridge
+import dev.nucleusframework.window.tao.NativeTaoEglBridge
+import dev.nucleusframework.window.tao.TaoApplication
+import dev.nucleusframework.window.tao.TaoMouseButton
+import dev.nucleusframework.window.tao.TaoWindow
+import dev.nucleusframework.window.tao.toTaoCursorIconCode
+import org.jetbrains.skia.DirectContext
+import org.jetbrains.skia.GLAssembledInterface
+import org.jetbrains.skia.makeGLWithInterface
+import kotlin.math.roundToInt
+
+/**
+ * Linux popup layer backed by a real Tao popup window
+ * (`openWindow(popupOf = parent)`): GTK_WINDOW_POPUP, i.e. an
+ * override-redirect ARGB toplevel on X11 and a `wl_subsurface` of the
+ * parent on Wayland — the only client-positionable window kinds on each
+ * backend. Popup content can therefore extend beyond the owner window
+ * bounds on both display servers.
+ *
+ * The coordinate model mirrors [TaoPopupSceneLayerWindows]: `boundsInWindow`
+ * is the content rect in parent-window physical pixels, the inner scene is
+ * laid out at screen work-area size (see the "measurement chicken-and-egg"
+ * note on [TaoPopupSceneLayer]), and rendering translates by
+ * `-bounds.topLeft` into a window sized exactly to the content.
+ *
+ * Differences from Windows/macOS driven by platform reality:
+ *  - Window creation is asynchronous (Tao posts a CreateWindow user event);
+ *    EGL attaches on WINDOW_READY and everything set before that
+ *    (bounds, content) is applied then. Until ready the layer simply skips
+ *    its render callback — the popup appears one event-loop tick later.
+ *  - Rendering uses a private EGL context per attachment (the Linux
+ *    convention, see `nucleus_tao_egl.c`) with swap interval 0: presents
+ *    must never block the event-loop thread, and on Wayland the popup's
+ *    EGL child hangs off GDK's synchronized subsurface where FIFO frame
+ *    pacing is a fatal protocol error (see [TaoWindow.isPopup]).
+ *  - Popup windows never own keyboard focus (override-redirect / subsurface),
+ *    so key events keep arriving on the parent and are forwarded through
+ *    [TaoPopupHostLinux.registerKeyHandler] — the macOS piggy-back model.
+ *  - Outside-click detection has no global-hook equivalent (especially on
+ *    Wayland); presses reaching the *parent* scene are outside every popup
+ *    by construction and are forwarded via
+ *    [TaoPopupHostLinux.registerOutsidePressListener].
+ *
+ * Threading: every method must run on the Tao event-loop thread.
+ */
+@OptIn(InternalComposeUiApi::class)
+@Suppress("TooManyFunctions")
+internal class TaoPopupSceneLayerLinux(
+    private val host: TaoPopupHostLinux,
+    initialDensity: Density,
+    initialLayoutDirection: LayoutDirection,
+    initialFocusable: Boolean,
+    @Suppress("UNUSED_PARAMETER") parentCompositionContext: CompositionContext,
+) : ComposeSceneLayer {
+    private var _density = initialDensity
+    private var _layoutDirection = initialLayoutDirection
+    private var _focusable = initialFocusable
+    private var _bounds: IntRect = IntRect.Zero
+    private var _scrimColor: Color? = null
+    private var _compositionLocalContext: CompositionLocalContext? = null
+
+    private val rendererToken: Any = Any()
+    private val moveListenerToken: Any = Any()
+    private val keyHandlerToken: Any = Any()
+    private val outsidePressToken: Any = Any()
+
+    /**
+     * Set in [close] before the popup window is destroyed. Guards the
+     * render callback (the host drains a snapshot of its renderer map, so
+     * a layer closed by a sibling's recomposition can still see one late
+     * call) and the async WINDOW_READY attach.
+     */
+    private var released = false
+
+    /** EGL attachment ready — flips on WINDOW_READY once the GPU side is up. */
+    private var attachment: Long = 0
+    private var directContext: DirectContext? = null
+    private var shown = false
+
+    private val scale: Float = if (host.scale > 0f) host.scale else 1f
+
+    // Work-area sized (not parent-window sized) so a popup larger than its
+    // owner window lays out at full size — same contract as macOS/Windows.
+    private val sceneLayoutSize: IntSize =
+        host.workAreaSize.let {
+            IntSize(it.width.coerceAtLeast(1), it.height.coerceAtLeast(1))
+        }
+    private var widthPx: Int = 1
+    private var heightPx: Int = 1
+
+    /**
+     * The popup's Tao window. Created hidden at 1×1; the real frame is
+     * pushed by the first `boundsInWindow` write and the window is shown
+     * then. `popupOf` makes it override-redirect on X11 and a
+     * `wl_subsurface` on Wayland.
+     */
+    private val popupWindow: TaoWindow =
+        TaoApplication.openWindow(
+            title = "",
+            width = 1.0,
+            height = 1.0,
+            decorations = false,
+            resizable = false,
+            visible = false,
+            popupOf = host.parentWindow,
+        )
+
+    private val popupWindowInfo: androidx.compose.ui.platform.WindowInfo =
+        object : androidx.compose.ui.platform.WindowInfo {
+            override val isWindowFocused: Boolean = true
+            override val containerSize: IntSize get() = sceneLayoutSize
+        }
+
+    private val innerScene: ComposeScene =
+        CanvasLayersComposeScene(
+            density = _density,
+            layoutDirection = _layoutDirection,
+            size = sceneLayoutSize,
+            coroutineContext = host.sceneCoroutineContext,
+            platformContext =
+                object : PlatformContext.Empty() {
+                    override val windowInfo: androidx.compose.ui.platform.WindowInfo
+                        get() = popupWindowInfo
+
+                    override fun setPointerIcon(pointerIcon: PointerIcon) {
+                        if (released) return
+                        NativeTaoBridge.nativeSetCursorIcon(
+                            popupWindow.handle,
+                            pointerIcon.toTaoCursorIconCode(),
+                        )
+                    }
+                },
+            invalidate = { host.requestRedraw() },
+        )
+
+    private var onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null
+    private var onKeyEvent: ((KeyEvent) -> Boolean)? = null
+    private var onOutsidePointerEvent: ((PointerEventType, PointerButton?) -> Unit)? = null
+
+    init {
+        popupWindow.onWindowReady { _, _ -> attachGpu() }
+        // Compositor expose (X11) / re-map: repaint through the host pump.
+        popupWindow.onRedrawRequested { host.requestRedraw() }
+        registerInput()
+        host.registerRenderer(rendererToken) { renderFrame() }
+        host.registerKeyHandler(keyHandlerToken) { dispatchKey(it) }
+        host.registerOwnerMoveListener(moveListenerToken) {
+            if (_bounds != IntRect.Zero) updateNativeFrame()
+        }
+    }
+
+    /**
+     * EGL + Skia bring-up, deferred to WINDOW_READY (window creation is a
+     * posted user event). Mirrors [TaoComposeSceneHostLinux.attachGpu] with
+     * the popup-specific swap interval 0 on both backends.
+     */
+    private fun attachGpu() {
+        if (released) return
+        if (!NativeTaoEglBridge.isLoaded) return
+        val handles = NativeTaoBridge.nativeLinuxHandles(popupWindow.handle) ?: return
+        if (handles.size != HANDLE_TRIPLE_SIZE || handles[0].toInt() == 0) return
+        val kind = handles[0].toInt()
+        val display = handles[1]
+        val nativeWin = handles[2]
+        val w = widthPx.coerceAtLeast(1)
+        val h = heightPx.coerceAtLeast(1)
+        val handle =
+            when (kind) {
+                KIND_X11 ->
+                    NativeTaoEglBridge
+                        .nativeAttachX11(display, nativeWin, w, h)
+                        .also { if (it != 0L) NativeTaoEglBridge.nativeSetSwapInterval(it, 0) }
+                KIND_WAYLAND ->
+                    NativeTaoEglBridge.nativeAttachWayland(
+                        display,
+                        nativeWin,
+                        w,
+                        h,
+                        scale.roundToInt().coerceAtLeast(1),
+                        0,
+                    )
+                else -> 0L
+            }
+        if (handle == 0L) return
+        val fnPtr = NativeTaoEglBridge.nativeGetProcAddrFunctionPointer()
+        val ctx =
+            runCatching {
+                val iface = GLAssembledInterface.createFromNativePointers(0L, fnPtr)
+                DirectContext.makeGLWithInterface(iface)
+            }.getOrNull()
+        if (ctx == null) {
+            NativeTaoEglBridge.nativeDetach(handle)
+            return
+        }
+        NativeTaoEglBridge.nativeReleaseCurrent(handle)
+        attachment = handle
+        directContext = ctx
+        // Re-push any frame set before the window was ready, and paint.
+        if (_bounds != IntRect.Zero) updateNativeFrame()
+        host.requestRedraw()
+    }
+
+    // ── ComposeSceneLayer surface ──────────────────────────────────────
+
+    override var density: Density
+        get() = _density
+        set(value) {
+            _density = value
+            innerScene.density = value
+        }
+
+    override var layoutDirection: LayoutDirection
+        get() = _layoutDirection
+        set(value) {
+            _layoutDirection = value
+            innerScene.layoutDirection = value
+        }
+
+    override var boundsInWindow: IntRect
+        get() = _bounds
+        set(value) {
+            _bounds = value
+            updateNativeFrame()
+            host.requestRedraw()
+        }
+
+    override var compositionLocalContext: CompositionLocalContext?
+        get() = _compositionLocalContext
+        set(value) {
+            _compositionLocalContext = value
+        }
+
+    override var scrimColor: Color?
+        get() = _scrimColor
+        set(value) {
+            _scrimColor = value
+        }
+
+    override var focusable: Boolean
+        get() = _focusable
+        set(value) {
+            _focusable = value
+        }
+
+    override fun close() {
+        if (released) return
+        released = true
+        host.unregisterRenderer(rendererToken)
+        host.unregisterKeyHandler(keyHandlerToken)
+        host.unregisterOwnerMoveListener(moveListenerToken)
+        host.unregisterOutsidePressListener(outsidePressToken)
+        innerScene.close()
+        if (attachment != 0L) {
+            // The DirectContext must die on its own (thread-bound) EGL
+            // context — same protocol as the standalone popup host.
+            NativeTaoEglBridge.nativeMakeCurrent(attachment)
+            directContext?.close()
+            directContext = null
+            NativeTaoEglBridge.nativeReleaseCurrent(attachment)
+            NativeTaoEglBridge.nativeDetach(attachment)
+            attachment = 0
+        }
+        popupWindow.requestClose()
+    }
+
+    override fun setContent(content: @Composable () -> Unit) {
+        innerScene.setContent {
+            val locals = _compositionLocalContext
+            if (locals != null) {
+                CompositionLocalProvider(locals) { content() }
+            } else {
+                content()
+            }
+        }
+        host.requestRedraw()
+    }
+
+    override fun setKeyEventListener(
+        onPreviewKeyEvent: ((KeyEvent) -> Boolean)?,
+        onKeyEvent: ((KeyEvent) -> Boolean)?,
+    ) {
+        this.onPreviewKeyEvent = onPreviewKeyEvent
+        this.onKeyEvent = onKeyEvent
+    }
+
+    override fun setOutsidePointerEventListener(
+        onOutsidePointerEvent: ((eventType: PointerEventType, button: PointerButton?) -> Unit)?,
+    ) {
+        this.onOutsidePointerEvent = onOutsidePointerEvent
+        if (onOutsidePointerEvent != null) {
+            host.registerOutsidePressListener(outsidePressToken) { button ->
+                this.onOutsidePointerEvent?.invoke(PointerEventType.Press, button)
+            }
+        } else {
+            host.unregisterOutsidePressListener(outsidePressToken)
+        }
+    }
+
+    override fun calculateLocalPosition(positionInWindow: IntOffset): IntOffset = positionInWindow
+
+    // ── Native frame ───────────────────────────────────────────────────
+
+    /**
+     * Pushes `boundsInWindow` to the popup window. GTK positions in
+     * *logical* pixels: X11 popups in root coordinates (parent screen
+     * origin + window-relative bounds), Wayland subsurfaces relative to
+     * the parent surface ([TaoPopupHostLinux.parentScreenOriginPx] is
+     * zero there).
+     */
+    private fun updateNativeFrame() {
+        if (_bounds == IntRect.Zero || released) return
+        val origin = host.parentScreenOriginPx
+        val offset = host.coordinateOffset
+        val xPx = _bounds.left + offset.x + origin.x
+        val yPx = _bounds.top + offset.y + origin.y
+        val w = _bounds.width.coerceAtLeast(1)
+        val h = _bounds.height.coerceAtLeast(1)
+        popupWindow.setOuterPosition((xPx / scale).toDouble(), (yPx / scale).toDouble())
+        popupWindow.setInnerSize((w / scale).toDouble(), (h / scale).toDouble())
+        if (w != widthPx || h != heightPx) {
+            widthPx = w
+            heightPx = h
+            if (attachment != 0L) {
+                NativeTaoEglBridge.nativeResize(attachment, w, h, scale)
+            }
+        }
+        if (!shown) {
+            shown = true
+            popupWindow.show()
+        }
+    }
+
+    // ── Per-frame render — driven by the host's redraw pump ───────────────
+
+    private fun renderFrame() {
+        if (released || attachment == 0L) return
+        if (widthPx <= 0 || heightPx <= 0) return
+        val ctx = directContext ?: return
+        // Render even while `boundsInWindow` is still Zero (surface is 1×1
+        // and the window unmapped): the first `innerScene.render` is what
+        // drives Compose's measure pass, and that measure is what writes
+        // `boundsInWindow` in the first place — skipping it would deadlock
+        // the popup at zero bounds forever. Same bootstrap as the Windows
+        // layer's 1×1 initial drawBounds. The present is skipped until the
+        // frame is real; nothing is on screen yet anyway.
+        val frame = _bounds
+        NativeTaoEglBridge.nativeMakeCurrent(attachment)
+        // Private EGL context — no resetGLAll needed (unlike the Windows
+        // shared-process-context path).
+        renderGlFrame(
+            widthPx = widthPx,
+            heightPx = heightPx,
+            directContext = ctx,
+            clearColorArgb = 0x00000000,
+            present = {
+                if (frame != IntRect.Zero) NativeTaoEglBridge.nativePresent(attachment)
+            },
+        ) { canvas, nanoTime ->
+            canvas.save()
+            try {
+                canvas.translate(-frame.left.toFloat(), -frame.top.toFloat())
+                innerScene.render(canvas.asComposeCanvas(), nanoTime)
+            } finally {
+                canvas.restore()
+            }
+        }
+        NativeTaoEglBridge.nativeReleaseCurrent(attachment)
+    }
+
+    // ── Input — the popup window receives its own pointer events ──────────
+
+    private fun registerInput() {
+        popupWindow.onPointerMoved { xFixed, yFixed ->
+            sendPointer(PointerEventType.Move, xFixed / POSITION_SCALE, yFixed / POSITION_SCALE, null)
+        }
+        popupWindow.onPointerButton { code, pressed ->
+            sendPointer(
+                if (pressed) PointerEventType.Press else PointerEventType.Release,
+                lastX,
+                lastY,
+                mapButton(code),
+            )
+        }
+        popupWindow.onPointerScroll { event ->
+            if (released) return@onPointerScroll
+            val modifiers = taoKeyboardModifiers(host.parentWindow.modifierState)
+            innerScene.sendPointerEvent(
+                eventType = PointerEventType.Scroll,
+                position = scenePosition(lastX, lastY),
+                scrollDelta = Offset(event.dxAwt, event.dyAwt),
+                type = PointerType.Mouse,
+                keyboardModifiers = modifiers,
+                nativeEvent =
+                    TaoSyntheticMouseWheelEvent.create(
+                        event = event,
+                        x = lastX,
+                        y = lastY,
+                        keyboardModifiers = modifiers,
+                    ),
+            )
+        }
+    }
+
+    private var lastX = 0f
+    private var lastY = 0f
+
+    private fun sendPointer(
+        eventType: PointerEventType,
+        xPx: Float,
+        yPx: Float,
+        button: PointerButton?,
+    ) {
+        if (released) return
+        lastX = xPx
+        lastY = yPx
+        innerScene.sendPointerEvent(
+            eventType = eventType,
+            position = scenePosition(xPx, yPx),
+            type = PointerType.Mouse,
+            keyboardModifiers = taoKeyboardModifiers(host.parentWindow.modifierState),
+            button = button,
+        )
+    }
+
+    /** Popup-window-local physical px → inner-scene (parent-window) coords. */
+    private fun scenePosition(
+        x: Float,
+        y: Float,
+    ): Offset = Offset(x + _bounds.left, y + _bounds.top)
+
+    private fun mapButton(code: Int): PointerButton =
+        when (code) {
+            TaoMouseButton.RIGHT -> PointerButton.Secondary
+            TaoMouseButton.MIDDLE -> PointerButton.Tertiary
+            else -> PointerButton.Primary
+        }
+
+    /**
+     * Key events forwarded by the host (the parent window keeps keyboard
+     * focus — see the class doc). Preview/scene/post ordering mirrors
+     * `ComposeScene.dispatchNativeKeyEvent`; the scene only sees keys when
+     * the popup is focusable, so tooltips never swallow typing.
+     */
+    private fun dispatchKey(event: KeyEvent): Boolean {
+        if (released) return false
+        if (onPreviewKeyEvent?.invoke(event) == true) return true
+        if (_focusable && innerScene.sendKeyEvent(event)) return true
+        return onKeyEvent?.invoke(event) == true
+    }
+
+    private companion object {
+        // Wire scale — must match Rust `CURSOR_FIXED_SCALE`.
+        private const val POSITION_SCALE: Float = 1024f
+
+        // Backend kinds from NativeTaoBridge.nativeLinuxHandles — the
+        // bridge returns a (kind, display, native_window) triple.
+        private const val HANDLE_TRIPLE_SIZE: Int = 3
+        private const val KIND_X11: Int = 1
+        private const val KIND_WAYLAND: Int = 2
+    }
+}

--- a/example/src/main/kotlin/com/example/demo/Main.kt
+++ b/example/src/main/kotlin/com/example/demo/Main.kt
@@ -147,6 +147,7 @@ fun main(args: Array<String>) =
                 onCloseRequest = ::exitApplication,
                 title = "Nucleus Demo",
                 minimumSize = DpSize(1300.dp, 480.dp),
+                nativePopupLayers = true,
             ) {
                 CompositionLocalProvider(
                     LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/DecoratedWindow.kt
@@ -41,8 +41,8 @@ fun NucleusApplicationScope.DecoratedWindow(
     popupFor: NucleusWindow? = null,
     // Materialise Compose Popup layers as native transparent windows
     // (NSPanel / WS_POPUP HWND) instead of drawing them inline in this
-    // window's render target. Honoured by the Tao backend on Windows/macOS;
-    // ignored by AWT and on Linux.
+    // window's render target. Honoured by the Tao backend on all three
+    // platforms; ignored by AWT.
     nativePopupLayers: Boolean = false,
     minimumSize: DpSize? = null,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },


### PR DESCRIPTION
## Summary

- Implements `nativePopupLayers` for the Linux Tao backend, completing the trio: Compose `Popup` / `DropdownMenu` / `Tooltip` layers materialise as native windows that can extend beyond — and float independently of — the owner window bounds, like NSPanel on macOS and WS_POPUP HWNDs on Windows.
- Each `ComposeSceneLayer` becomes a Tao popup window (`openWindow(popupOf = parent)`): **override-redirect on X11** (positioned in root coordinates from the parent's window rect) and **`wl_subsurface` on Wayland** (parent-relative positioning, so no global coordinates are needed) — a single code path covers both display servers.
- New `TaoPopupHostLinux` + `TaoComposeSceneContextLinux` + `TaoPopupSceneLayerLinux` mirror the Windows/macOS layer contracts: inner scene laid out at screen work-area size, `boundsInWindow` in parent-window physical pixels, render translated by `-bounds.topLeft`.
- Platform-driven differences from Windows/macOS:
  - EGL attaches on `WINDOW_READY` (Tao window creation is asynchronous); private EGL context per attachment with **swap interval 0** — presents never block the event loop, and FIFO frame pacing on GDK's synchronized Wayland subsurface is a fatal `wp_commit_timer_v1` protocol error.
  - Popup windows never own keyboard focus on Linux (override-redirect / subsurface), so keys are forwarded from the parent through a `popupKeyHandlers` chain — the macOS piggy-back model.
  - Outside-click dismissal forwards presses that reach the *parent* scene (they are outside every popup by construction, since popups own their input region) — the Linux stand-in for the NSEvent monitor / `WH_MOUSE_LL` hook, and the only mechanism available on Wayland.
- The layer renders from the first frame even at zero bounds (1×1, unmapped window): the first `innerScene.render` drives the Compose measure pass that writes `boundsInWindow` in the first place; the present is skipped until the frame is real. Same bootstrap as the Windows layer's 1×1 initial `drawBounds`.
- `TaoComposeSceneHostLinux.detach()` now closes the scene *before* re-binding the host EGL context, so popup-layer teardown (which binds its own context) can't leave the host's Skia releases on the wrong context.
- Wires the flag through `openDecoratedWindowLinux`, updates the "Windows/macOS only" docs across the wrappers, and enables it in the example app.

## Known limitations (inherited from the Windows/macOS model)

- `scrimColor` is stored but not rendered.
- On Wayland, a click in *another application* does not dismiss the popup (no global input hook exists); clicks anywhere in the parent window dismiss correctly.

## Test plan

- [x] X11 (XWayland, `NUCLEUS_TAO_LINUX_RENDERER=x11`): popup layer appears, positioned relative to the window, extends past the window edge
- [x] Native Wayland (GNOME): popup layer appears as a subsurface, no compositor protocol errors (no `Error 71` / commit-timer crash)
- [x] Multiple simultaneous layers (popup + tooltips) attach and tear down cleanly
- [x] `:decorated-window-tao:compileKotlin ktlintCheck detekt` and all touched modules compile
- [ ] Regression pass on Windows/macOS `nativePopupLayers` samples (no code paths touched, flag plumbing only)