### PR TITLE
fix(tao-windows): per-host EGL registry so popups survive DecoratedDialog attach/detach

### DIFF
--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_gl.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_gl.c
@@ -229,9 +229,91 @@ static HWND createRenderSurface(HWND parent) {
 /*  GetProcAddress on this DLL.                                        */
 /* ================================================================== */
 
-static EGLDisplay sHostEglDisplay = EGL_NO_DISPLAY;
-static EGLContext sHostEglContext = EGL_NO_CONTEXT;
-static EGLConfig  sHostEglConfig  = NULL;
+/* Multi-host registry. Each TaoComposeSceneHostWindows attaches its own
+ * EGLContext; the overlay/popup bridge (overlay_dcomp.cpp) borrows a host
+ * context to bind its d3d-texture pbuffers. A single global trio is not
+ * enough when more than one host coexists (a DecoratedDialog over a
+ * DecoratedWindow): the dialog overwrites the global on attach and clears
+ * it on detach, leaving the still-alive main window's popups with
+ * EGL_NO_CONTEXT. Registered by HWND on nativeAttach, looked up by the
+ * popup/overlay's parent host HWND (nucleus_tao_host_egl_for_hwnd).
+ * Unbounded linked list (same pattern as overlay.c's sOwnerList) — a
+ * fixed slot array would silently drop hosts past the cap.
+ *
+ * The headless bootstrap context (nativeEnsureHeadlessContext) lives in
+ * its own statics, NOT the registry: it has no HWND, is never destroyed,
+ * and must survive any window host's attach/detach cycle. Ownerless
+ * (tray) panels resolve headless-first via the global accessors so they
+ * never borrow a window context that a later nativeDetach destroys.
+ *
+ * All access runs on the single Tao event-loop thread; no lock needed. */
+typedef struct HostEglEntry HostEglEntry;
+struct HostEglEntry {
+    HWND hwnd;
+    EGLDisplay dpy;
+    EGLContext ctx;
+    EGLConfig  cfg;
+    HostEglEntry *next;
+};
+static HostEglEntry *sHostEglList = NULL;
+
+static EGLDisplay sHeadlessEglDisplay = EGL_NO_DISPLAY;
+static EGLContext sHeadlessEglContext = EGL_NO_CONTEXT;
+static EGLConfig  sHeadlessEglConfig  = NULL;
+
+static void registerHostEgl(HWND hwnd, EGLDisplay dpy, EGLContext ctx, EGLConfig cfg) {
+    if (!hwnd) {
+        sHeadlessEglDisplay = dpy;
+        sHeadlessEglContext = ctx;
+        sHeadlessEglConfig = cfg;
+        return;
+    }
+    for (HostEglEntry *e = sHostEglList; e; e = e->next) {
+        if (e->hwnd == hwnd) {
+            e->dpy = dpy; e->ctx = ctx; e->cfg = cfg;
+            return;
+        }
+    }
+    HostEglEntry *e = (HostEglEntry *)HeapAlloc(
+        GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(HostEglEntry));
+    if (!e) return;
+    e->hwnd = hwnd;
+    e->dpy = dpy; e->ctx = ctx; e->cfg = cfg;
+    e->next = sHostEglList;
+    sHostEglList = e;
+}
+
+static void unregisterHostEgl(HWND hwnd) {
+    if (!hwnd) return;
+    HostEglEntry **pp = &sHostEglList;
+    while (*pp && (*pp)->hwnd != hwnd) pp = &(*pp)->next;
+    if (*pp) {
+        HostEglEntry *e = *pp;
+        *pp = e->next;
+        HeapFree(GetProcessHeap(), 0, e);
+    }
+}
+
+/* Global fallback for ownerless (tray) panels: prefer the headless trio
+ * — it is never destroyed, so a panel that binds it can't be orphaned by
+ * a window host's nativeDetach. Fall back to any live window host. */
+static void resolveFallbackEgl(EGLDisplay *dpy, EGLContext *ctx, EGLConfig *cfg) {
+    if (sHeadlessEglContext != EGL_NO_CONTEXT) {
+        *dpy = sHeadlessEglDisplay;
+        *ctx = sHeadlessEglContext;
+        *cfg = sHeadlessEglConfig;
+        return;
+    }
+    if (sHostEglList) {
+        *dpy = sHostEglList->dpy;
+        *ctx = sHostEglList->ctx;
+        *cfg = sHostEglList->cfg;
+        return;
+    }
+    *dpy = EGL_NO_DISPLAY;
+    *ctx = EGL_NO_CONTEXT;
+    *cfg = NULL;
+}
 
 /* Historical values: 0 = WGL (removed), 1 = EGL/ANGLE. Kept exported so
  * the overlay DLL's backend probe stays a stable cross-DLL contract. */
@@ -240,15 +322,40 @@ __declspec(dllexport) int nucleus_tao_host_backend(void) {
 }
 
 __declspec(dllexport) void *nucleus_tao_host_egl_display(void) {
-    return (void *)sHostEglDisplay;
+    EGLDisplay dpy; EGLContext ctx; EGLConfig cfg;
+    resolveFallbackEgl(&dpy, &ctx, &cfg);
+    return (void *)dpy;
 }
 
 __declspec(dllexport) void *nucleus_tao_host_egl_context(void) {
-    return (void *)sHostEglContext;
+    EGLDisplay dpy; EGLContext ctx; EGLConfig cfg;
+    resolveFallbackEgl(&dpy, &ctx, &cfg);
+    return (void *)ctx;
 }
 
 __declspec(dllexport) void *nucleus_tao_host_egl_config(void) {
-    return (void *)sHostEglConfig;
+    EGLDisplay dpy; EGLContext ctx; EGLConfig cfg;
+    resolveFallbackEgl(&dpy, &ctx, &cfg);
+    return (void *)cfg;
+}
+
+/* Resolves the EGL trio registered for [hwnd] (the popup/overlay's parent
+ * host window). Out-params are only written on a hit (return 1). Returns 0
+ * when [hwnd] is NULL or not registered — callers fall back to the global
+ * accessors (ownerless panel / headless context). */
+__declspec(dllexport) int nucleus_tao_host_egl_for_hwnd(
+    void *hwndVoid, void **dpyOut, void **ctxOut, void **cfgOut) {
+    HWND hwnd = (HWND)hwndVoid;
+    if (!hwnd) return 0;
+    for (HostEglEntry *e = sHostEglList; e; e = e->next) {
+        if (e->hwnd == hwnd) {
+            if (dpyOut) *dpyOut = (void *)e->dpy;
+            if (ctxOut) *ctxOut = (void *)e->ctx;
+            if (cfgOut) *cfgOut = (void *)e->cfg;
+            return 1;
+        }
+    }
+    return 0;
 }
 
 /* Resolves an EGL entry point through the already-loaded libEGL.dll.
@@ -378,9 +485,7 @@ static GlAttachment *attachEgl(HWND hwnd) {
     att->eglConfig = config;
     att->scale = 1.0f;
 
-    sHostEglDisplay = dpy;
-    sHostEglContext = ctx;
-    sHostEglConfig = config;
+    registerHostEgl(hwnd, dpy, ctx, config);
     return att;
 }
 
@@ -418,14 +523,19 @@ Java_dev_nucleusframework_window_tao_NativeTaoGlBridge_nativeDetach(
     GlAttachment *att = (GlAttachment *)(uintptr_t)handle;
     if (!att) return;
 
+    HWND hostHwnd = att->hwnd;
     /* The EGLDisplay is process-wide (shared with overlays); never
      * eglTerminate it here — just drop this window's context + surface. */
     pEglMakeCurrent(att->eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-    if (sHostEglContext == att->eglContext) sHostEglContext = EGL_NO_CONTEXT;
     pEglDestroyContext(att->eglDisplay, att->eglContext);
     pEglDestroySurface(att->eglDisplay, att->eglSurface);
     if (IsWindow(att->surfaceHwnd)) DestroyWindow(att->surfaceHwnd);
     HeapFree(GetProcessHeap(), 0, att);
+    /* Unregister after freeing att: recompute the global trio to a
+     * still-alive host so sibling hosts' popups/overlays keep a live
+     * context (a DecoratedDialog detaching must not wipe the main
+     * window's). */
+    unregisterHostEgl(hostHwnd);
 }
 
 JNIEXPORT void JNICALL
@@ -524,7 +634,12 @@ Java_dev_nucleusframework_window_tao_NativeTaoGlBridge_nativeEnsureHeadlessConte
     JNIEnv *env, jclass clazz)
 {
     (void)env; (void)clazz;
-    if (sHostEglContext != EGL_NO_CONTEXT) return JNI_TRUE;
+    /* Only the HEADLESS context short-circuits. A live window host is not
+     * enough: its context dies with its nativeDetach, and an ownerless
+     * panel that borrowed it would be left bound to a destroyed context.
+     * The headless context is never destroyed, so ownerless panels always
+     * get a stable trio (resolveFallbackEgl prefers it). */
+    if (sHeadlessEglContext != EGL_NO_CONTEXT) return JNI_TRUE;
     loadEgl();
     if (!eglAvailable || !pEglGetPlatformDisplayEXT) return JNI_FALSE;
 
@@ -583,8 +698,8 @@ Java_dev_nucleusframework_window_tao_NativeTaoGlBridge_nativeEnsureHeadlessConte
         pEglDestroySurface(dpy, surface);
         return JNI_FALSE;
     }
-    sHostEglDisplay = dpy;
-    sHostEglContext = ctx;
-    sHostEglConfig  = config;
+    /* No HWND (headless) — primes the global fallback only, not the
+     * per-HWND registry. registerHostEgl(NULL,...) handles that branch. */
+    registerHostEgl(NULL, dpy, ctx, config);
     return JNI_TRUE;
 }

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay.c
@@ -492,6 +492,10 @@ Java_dev_nucleusframework_window_tao_NativeTaoWindowsOverlayBridge_nativeCreateO
      * polish (rounded corners, dark mode, extended frame for shadow) is
      * in effect on the very first paint. */
     s->gl.hwnd = hwnd;
+    /* Borrow the EGL trio of this overlay's owner host window, resolved
+     * per-HWND (see createSurface) so a sibling DecoratedDialog's
+     * attach/detach can't wipe it. */
+    s->gl.hostHwnd = owner;
     if (!nucleus_tao_overlay_gl_init(&s->gl, TRUE)) {
         /* Init failed — tear down everything we created and return 0. */
         unregisterOverlayFromOwner(s);

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay_dcomp.cpp
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay_dcomp.cpp
@@ -88,11 +88,14 @@ typedef void *(*PFN_host_egl_display)(void);
 typedef void *(*PFN_host_egl_context)(void);
 typedef void *(*PFN_host_egl_config)(void);
 typedef void *(*PFN_host_egl_proc)(const char *name);
+/* Per-HWND host trio lookup (nucleus_tao_gl.c). Returns 1 on hit. */
+typedef int  (*PFN_host_egl_for_hwnd)(void *hwnd, void **dpy, void **ctx, void **cfg);
 
 static PFN_host_egl_display pHostEglDisplay = NULL;
 static PFN_host_egl_context pHostEglContext = NULL;
 static PFN_host_egl_config  pHostEglConfig  = NULL;
 static PFN_host_egl_proc    pHostEglProc    = NULL;
+static PFN_host_egl_for_hwnd pHostEglForHwnd = NULL;
 static BOOL sHostResolved = FALSE;
 
 /* EGL entry points, resolved through the host bridge. */
@@ -119,6 +122,7 @@ static void resolveHost(void) {
     pHostEglContext = (PFN_host_egl_context)GetProcAddress(m, "nucleus_tao_host_egl_context");
     pHostEglConfig  = (PFN_host_egl_config) GetProcAddress(m, "nucleus_tao_host_egl_config");
     pHostEglProc    = (PFN_host_egl_proc)   GetProcAddress(m, "nucleus_tao_host_egl_proc");
+    pHostEglForHwnd = (PFN_host_egl_for_hwnd)GetProcAddress(m, "nucleus_tao_host_egl_for_hwnd");
     if (!pHostEglProc) return;
 
     pEglQueryDisplayAttribEXT = (PFNEGLQUERYDISPLAYATTRIBEXTPROC)
@@ -289,7 +293,7 @@ static void destroySurface(DcompSurface *s) {
     HeapFree(GetProcessHeap(), 0, s);
 }
 
-static DcompSurface *createSurface(HWND hwnd) {
+static DcompSurface *createSurface(GlSurface *gl) {
     resolveHost();
     if (!pHostEglDisplay || !pHostEglContext || !pHostEglConfig ||
         !pEglCreatePbufferFromClientBuffer || !pEglMakeCurrent ||
@@ -298,9 +302,25 @@ static DcompSurface *createSurface(HWND hwnd) {
         return NULL;
     }
 
-    EGLDisplay dpy = (EGLDisplay)pHostEglDisplay();
-    EGLContext ctx = (EGLContext)pHostEglContext();
-    EGLConfig  cfg = (EGLConfig)pHostEglConfig();
+    HWND hwnd = gl->hwnd;
+    /* Resolve the EGL trio belonging to THIS surface's parent host window
+     * — not the single global, which a sibling host (DecoratedDialog) may
+     * have overwritten and then cleared on detach. Falls back to the
+     * global for ownerless (tray) panels whose hostHwnd is 0. */
+    EGLDisplay dpy = EGL_NO_DISPLAY;
+    EGLContext ctx = EGL_NO_CONTEXT;
+    EGLConfig  cfg = NULL;
+    void *pdpy = NULL, *pctx = NULL, *pcfg = NULL;
+    if (pHostEglForHwnd && gl->hostHwnd &&
+        pHostEglForHwnd((void *)gl->hostHwnd, &pdpy, &pctx, &pcfg)) {
+        dpy = (EGLDisplay)pdpy;
+        ctx = (EGLContext)pctx;
+        cfg = (EGLConfig)pcfg;
+    } else {
+        dpy = (EGLDisplay)pHostEglDisplay();
+        ctx = (EGLContext)pHostEglContext();
+        cfg = (EGLConfig)pHostEglConfig();
+    }
     if (dpy == EGL_NO_DISPLAY || ctx == EGL_NO_CONTEXT || !cfg) return NULL;
 
     /* ANGLE's own D3D11 device — textures the pbuffer extension accepts
@@ -390,7 +410,7 @@ static DcompSurface *createSurface(HWND hwnd) {
 
 extern "C" BOOL nucleus_tao_overlay_gl_init(GlSurface *gl, BOOL nativeWindowPolish) {
     if (!gl || !gl->hwnd) return FALSE;
-    gl->dcomp = createSurface(gl->hwnd);
+    gl->dcomp = createSurface(gl);
     if (!gl->dcomp) return FALSE;
     if (nativeWindowPolish) {
         applyDwmPolish(gl->hwnd);

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay_internal.h
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_overlay_internal.h
@@ -27,6 +27,11 @@ extern "C" {
 
 typedef struct {
     HWND  hwnd;
+    /* The parent host window HWND this surface borrows its EGLContext
+     * from (the Tao main window that called nativeAttach). 0 for
+     * ownerless (tray) panels → createSurface falls back to the global
+     * host trio. Set by the caller before nucleus_tao_overlay_gl_init. */
+    HWND  hostHwnd;
     /* Opaque DcompSurface* owned by overlay_dcomp.cpp. */
     void *dcomp;
 } GlSurface;

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_popup.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_windows_popup.c
@@ -640,6 +640,10 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridgeWindows_nativeCreatePanel(
     if (!p) { DestroyWindow(hwnd); return 0; }
     p->parent = parent;
     p->gl.hwnd = hwnd;
+    /* Borrow the EGL trio of THIS popup's parent host window (resolved
+     * per-HWND in createSurface), not the global — survives a sibling
+     * DecoratedDialog's attach/detach which would otherwise wipe it. */
+    p->gl.hostHwnd = parent;
     p->focusable = FALSE;
     p->contentX = 0;
     p->contentY = 0;


### PR DESCRIPTION
## Summary

- **Bug**: after opening then closing a `DecoratedDialog`, no popup could be created anymore — `Nucleus: nativeCreatePanel returned 0 (parentHwnd=...)` on every attempt. Root cause: the host EGL trio (display/context/config) was a **single global** in `nucleus_tao_gl.c`; every `nativeAttach` overwrote it and `nativeDetach` cleared it, so the dialog's detach wiped the still-alive main window's trio and `createSurface` bailed on `EGL_NO_CONTEXT`.
- Replace the global with a **per-HWND registry** (unbounded linked list, same pattern as `overlay.c`'s `sOwnerList`). `attachEgl` registers the trio under the host HWND; `nativeDetach` unregisters it. `GlSurface` gains a `hostHwnd` field (set by popup.c / overlay.c to the parent/owner host window) and `createSurface` resolves the trio for **that** host via a new `nucleus_tao_host_egl_for_hwnd` export — a sibling host's lifecycle can no longer wipe it.
- The **headless bootstrap context** lives in its own statics, outside the registry: it is never destroyed, so ownerless (tray) panels resolve headless-first via the global accessors and can't be left bound to a context that a window's `nativeDetach` destroys. The `nativeEnsureHeadlessContext` guard now checks the headless context specifically — previously a live window context short-circuited the bootstrap, and a later detach orphaned the trio and leaked a re-created headless context per window open/close cycle.
- Single Tao event-loop thread (all hosts, popups, overlays) — no locking needed.

Adversarially reviewed: the initial fixed-slot-array + synced-globals version had a registry-full overwrite edge and the headless-leak edge; both are eliminated by the linked list + headless-first fallback in this version.

## Test plan

- [ ] Run the example app with `nativePopupLayers = true` on Windows
- [ ] Open the info `DecoratedDialog`, close it, then hover the theme toggle — tooltip popup appears (no `nativeCreatePanel returned 0`)
- [ ] Repeat dialog open/close several times — popups keep working
- [ ] Popups opened **while** the dialog is open bind the correct host context (main-window tooltips and dialog-side popups both render)
- [ ] Native rebuild: `build.bat` passes x64 + ARM64 (done locally, EXIT=0)