### PR TITLE
fix(tao): #310 follow-up — fullscreen traffic-lights, localized native menu, Ventura menu callbacks

### DIFF
--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -24,7 +24,26 @@
 #include <stdint.h>
 #import <jni.h>
 
-#define NTLOG(fmt, ...) do { (void)0; } while (0)
+// Diagnostic logging for the title-bar / fullscreen / menu-bar paths. Off by
+// default (no-op) so production apps stay silent; opt in by launching with
+// NUCLEUS_TAO_LOG=1 (any non-empty, non-"0" value). Routed through NSLog so the
+// output lands in the unified log — visible in Console.app or `log stream`
+// even when the app runs from a .app bundle with no attached terminal (which
+// is why plain stdout/println "logs never arrive" for testers on release
+// builds). All call sites are infrequent (FS transitions, attach, layout), so
+// NSLog cost is irrelevant.
+static BOOL nucleusTaoLogEnabled(void) {
+    static BOOL enabled = NO;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        const char *v = getenv("NUCLEUS_TAO_LOG");
+        enabled = v != NULL && v[0] != '\0' && !(v[0] == '0' && v[1] == '\0');
+    });
+    return enabled;
+}
+#define NTLOG(fmt, ...) do { \
+    if (nucleusTaoLogEnabled()) NSLog(@"[nucleus-tao] " fmt, ##__VA_ARGS__); \
+} while (0)
 
 // Associated-object key used to hang the constraints array on each NSWindow
 // so we can deactivate the previous set before applying a new one.
@@ -320,6 +339,8 @@ static void neutralizeToolbarFullScreenWindows(void) {
     if (cls == nil) return;
     for (NSWindow *win in NSApp.windows) {
         if (![win isKindOfClass:cls]) continue;
+        NTLOG("neutralize NSToolbarFullScreenWindow=%p shadow=%d",
+              win, (int)win.hasShadow);
         if (!win.ignoresMouseEvents) win.ignoresMouseEvents = YES;
         if (!win.contentView.hidden) win.contentView.hidden = YES;
         if (win.hasShadow) win.hasShadow = NO;
@@ -383,11 +404,17 @@ static void computeButtonMetrics(float titleBarHeight,
                                  float *outBtnWidth, float *outBtnHeight,
                                  float *outOffset) {
     float shrinkFactor = fminf(titleBarHeight / kMinHeightForFullSize, 1.0f);
-    *outBtnWidth  = fminf(titleBarHeight * 0.5f, kMinHeightForFullSize * 0.5f);
-    // JBR's correction, valid on every macOS version: AppKit adds a constant
-    // 2 pt to the resulting frame height, so width * 14/12 - 2 keeps the
-    // circles perfectly round. The former pre-Tahoe 16/14 "native aspect"
-    // stretched them vertically (issue #310 follow-up).
+    // Traffic-lights are a fixed native size on macOS — they never scale with
+    // the title-bar height. Pinning the width to the native 14 pt (instead of
+    // titleBarHeight * 0.5) keeps them identical to windowed mode. Scaling the
+    // width down for a shorter fullscreen title bar combined with the -2 pt
+    // constant below flipped the aspect and stretched the pills horizontally
+    // (issue #310 follow-up: windowed was round via Auto Layout's intrinsic
+    // width, fullscreen forced a too-small frame).
+    *outBtnWidth  = kMinHeightForFullSize * 0.5f;
+    // JBR's correction: AppKit adds a constant 2 pt to the resulting frame
+    // height, so width * 14/12 - 2 keeps the circle perfectly round. Only
+    // valid at the native width, which is why the width is pinned above.
     *outBtnHeight = (*outBtnWidth) * (14.0f / 12.0f) - 2.0f;
     *outOffset    = shrinkFactor * defaultButtonOffset();
 }
@@ -535,6 +562,7 @@ static void applyMenuBarFraction(CGFloat fraction) {
 
     NSMenu *mainMenu = NSApp.mainMenu;
     float menuBarHeight = mainMenu != nil ? (float)mainMenu.menuBarHeight : 0.0f;
+    NTLOG("menuBar fraction=%.3f menuBarHeight=%.1f", (double)fraction, menuBarHeight);
     if (menuBarHeight <= 0.0f) return;
 
     BOOL anyChanged = NO;

--- a/decorated-window-tao/src/main/native/macos/a11y.m
+++ b/decorated-window-tao/src/main/native/macos/a11y.m
@@ -1951,53 +1951,158 @@ static void build_default_rotors(NucleusA11yProjection *proj) {
     proj.cachedRotors = @[headings, forms];
 }
 
-// Installs a standard macOS **Edit** menu (Undo/Redo/Cut/Copy/Paste/Select All)
-// into NSApp.mainMenu once. This is what selection tools like PopClip inspect
-// to decide whether Cut / Copy / Paste are offered (PopClip's own log shows it
-// probing for a "copy menu action": no Edit menu → it only offers Copy). Tao —
-// like Compose's AWT backend — ships no Edit menu, which is exactly why PopClip
-// Cut/Paste don't appear in Compose desktop apps.
+// SF Symbol → NSImage for menu-item icons. Returns nil on macOS < 11 or for an
+// unknown symbol name (AppKit itself returns nil, no crash), so the item simply
+// shows no icon. Uses respondsToSelector rather than @available on purpose:
+// a11y.m is compiled by the Rust `cc` build, which doesn't link the clang
+// runtime symbol (__isPlatformVersionAtLeast) that @available lowers to.
+static NSImage *nucleusMenuSymbol(NSString *name) {
+    if (![NSImage respondsToSelector:@selector(imageWithSystemSymbolName:accessibilityDescription:)]) {
+        return nil;
+    }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    return [NSImage imageWithSystemSymbolName:name accessibilityDescription:nil];
+#pragma clang diagnostic pop
+}
+
+// Localizes a standard menu command using AppKit's own string tables, keyed by
+// the English label (e.g. "Cut" → "Couper" on a French system). AppKit ships
+// these in several .loctable files; we probe the ones that carry command
+// labels and fall back to the English key if none has it. This is how we get
+// the Edit-menu labels in the system language without bundling translations.
+static NSString *nucleusLocalizedMenuString(NSString *key) {
+    static NSBundle *appKit = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ appKit = [NSBundle bundleForClass:[NSApplication class]]; });
+    if (appKit == nil) return key;
+    static NSString *const tables[] = {
+        @"MenuCommands", @"FunctionKeyNames", @"InputManager", @"Common",
+        @"Document", @"TextSystem", @"FindPanel", @"Services", @"Menus"
+    };
+    NSString *sentinel = @"￿"; // localizedStringForKey returns `value` if the key is absent
+    for (size_t i = 0; i < sizeof(tables) / sizeof(tables[0]); i++) {
+        NSString *v = [appKit localizedStringForKey:key value:sentinel table:tables[i]];
+        if (![v isEqualToString:sentinel]) return v;
+    }
+    return key;
+}
+
+// Target for the Edit-menu items. Compose owns text editing and reacts to the
+// keyboard shortcuts, not to AppKit's cut:/copy:/paste: responder messages, so
+// each menu action re-injects its ⌘-shortcut as a synthetic key event into the
+// key window. Posted through the app event queue (no Accessibility permission,
+// unlike CGEventPost), so it reaches the Tao view exactly like a real keypress.
+@interface NucleusEditMenuBridge : NSObject
+@end
+
+@implementation NucleusEditMenuBridge
++ (instancetype)shared {
+    static NucleusEditMenuBridge *shared = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ shared = [[NucleusEditMenuBridge alloc] init]; });
+    return shared;
+}
+- (void)injectKeyCode:(unsigned short)keyCode chars:(NSString *)chars shift:(BOOL)shift {
+    NSWindow *win = NSApp.keyWindow;
+    if (win == nil) return;
+    NSEventModifierFlags mods = NSEventModifierFlagCommand;
+    if (shift) mods |= NSEventModifierFlagShift;
+    NSTimeInterval ts = NSProcessInfo.processInfo.systemUptime;
+    NSInteger wn = win.windowNumber;
+    NSEvent *down = [NSEvent keyEventWithType:NSEventTypeKeyDown location:NSZeroPoint
+                               modifierFlags:mods timestamp:ts windowNumber:wn context:nil
+                                  characters:chars charactersIgnoringModifiers:chars
+                                   isARepeat:NO keyCode:keyCode];
+    NSEvent *up = [NSEvent keyEventWithType:NSEventTypeKeyUp location:NSZeroPoint
+                             modifierFlags:mods timestamp:ts windowNumber:wn context:nil
+                                characters:chars charactersIgnoringModifiers:chars
+                                 isARepeat:NO keyCode:keyCode];
+    if (down) [NSApp postEvent:down atStart:NO];
+    if (up)   [NSApp postEvent:up atStart:NO];
+}
+- (void)nucleusUndo:(id)sender      { [self injectKeyCode:6 chars:@"z" shift:NO];  }
+- (void)nucleusRedo:(id)sender      { [self injectKeyCode:6 chars:@"z" shift:YES]; }
+- (void)nucleusCut:(id)sender       { [self injectKeyCode:7 chars:@"x" shift:NO];  }
+- (void)nucleusCopy:(id)sender      { [self injectKeyCode:8 chars:@"c" shift:NO];  }
+- (void)nucleusPaste:(id)sender     { [self injectKeyCode:9 chars:@"v" shift:NO];  }
+- (void)nucleusSelectAll:(id)sender { [self injectKeyCode:0 chars:@"a" shift:NO];  }
+@end
+
+// Installs the default macOS menu bar once: an Application menu + an Edit menu,
+// built by hand and set as NSApp.mainMenu.
 //
-// We attach the standard selectors (cut:/copy:/paste:/…) with their ⌘ key
-// equivalents but DON'T wire a responder. AppKit then auto-disables the items
-// (nothing in the responder chain answers copy:), and — crucially — a disabled
-// menu item does NOT consume its key equivalent, so Compose keeps receiving
-// ⌘C/⌘X/⌘V as ordinary key events and its in-field editing is unaffected.
-// PopClip still sees the items exist and executes its actions via synthesized
-// keystrokes, which Compose handles.
-static void nucleus_tao_install_edit_menu_once(void) {
+// Why build it ourselves and set it UNCONDITIONALLY (rather than gate on an
+// empty NSApp.mainMenu, or load Apple's DefaultApp.nib like JBR): in a packaged
+// .app the JVM/AppKit init leaves a partial, broken menu bar whose application
+// slot doesn't render (issue #310 B2), so gating on "empty" skipped our menu in
+// the distributable, and loading the nib dropped the App menu there entirely.
+// Setting a freshly built menu is deterministic in both `run` and the packaged
+// app. Nothing else legitimately owns the menu bar in a Compose/Tao app.
+//
+// Labels are localized through AppKit's own string tables (system language), so
+// only commands present there are shown — About / Hide Others / Zoom are dropped
+// because Apple keys them by unstable Interface Builder IDs, not by name. The
+// Edit menu (Undo/Redo/Cut/Copy/Paste/Select All) lets PopClip offer
+// Cut/Copy/Paste and lets users invoke them. Compose owns text editing via
+// keyboard shortcuts (not the AppKit responder chain), so each Edit item is
+// wired to NucleusEditMenuBridge, which re-injects the matching ⌘-shortcut into
+// the key window. Edit items carry no key equivalent (else ⌘C would re-enter the
+// bridge — infinite loop — and it lets Compose keep receiving the real ⌘C).
+// Icons are SF Symbols.
+static void nucleus_tao_install_default_menu_bar_once(void) {
     static dispatch_once_t once;
     dispatch_once(&once, ^{
-        NSMenu *mainMenu = NSApp.mainMenu;
-        if (!mainMenu) {
-            mainMenu = [[NSMenu alloc] init];
-            NSApp.mainMenu = mainMenu;
-        }
-        for (NSMenuItem *existing in mainMenu.itemArray) {
-            NSString *t = existing.submenu.title;
-            if ([t isEqualToString:@"Edit"] || [t isEqualToString:@"Édition"]) return;
-        }
-        NSMenuItem *editItem = [[NSMenuItem alloc] initWithTitle:@"Edit" action:NULL keyEquivalent:@""];
-        NSMenu *editMenu = [[NSMenu alloc] initWithTitle:@"Edit"];
-        editMenu.autoenablesItems = YES;
-        [editMenu addItemWithTitle:@"Undo" action:@selector(undo:) keyEquivalent:@"z"];
-        NSMenuItem *redo = [editMenu addItemWithTitle:@"Redo" action:@selector(redo:) keyEquivalent:@"z"];
-        redo.keyEquivalentModifierMask = NSEventModifierFlagCommand | NSEventModifierFlagShift;
+        NSString *appName = [NSRunningApplication currentApplication].localizedName;
+        if (appName.length == 0) appName = [NSProcessInfo processInfo].processName;
+
+        NSMenu *mainMenu = [[NSMenu alloc] init];
+
+        // ── Application menu (index 0) — only table-localizable commands ──
+        NSMenuItem *appItem = [[NSMenuItem alloc] init];
+        NSMenu *appMenu = [[NSMenu alloc] initWithTitle:@""];
+        NSMenuItem *services = [appMenu addItemWithTitle:nucleusLocalizedMenuString(@"Services")
+                                                  action:NULL keyEquivalent:@""];
+        NSMenu *servicesMenu = [[NSMenu alloc] initWithTitle:@""];
+        services.submenu = servicesMenu;
+        NSApp.servicesMenu = servicesMenu;
+        [appMenu addItem:[NSMenuItem separatorItem]];
+        [appMenu addItemWithTitle:[NSString stringWithFormat:@"%@ %@", nucleusLocalizedMenuString(@"Hide"), appName]
+                           action:@selector(hide:) keyEquivalent:@"h"];
+        [appMenu addItemWithTitle:nucleusLocalizedMenuString(@"Show All")
+                           action:@selector(unhideAllApplications:) keyEquivalent:@""];
+        [appMenu addItem:[NSMenuItem separatorItem]];
+        [appMenu addItemWithTitle:[NSString stringWithFormat:@"%@ %@", nucleusLocalizedMenuString(@"Quit"), appName]
+                           action:@selector(terminate:) keyEquivalent:@"q"];
+        appItem.submenu = appMenu;
+        [mainMenu addItem:appItem];
+
+        // ── Edit menu (localized, routed to Compose via the bridge, icons) ──
+        NucleusEditMenuBridge *bridge = [NucleusEditMenuBridge shared];
+        NSString *editTitle = nucleusLocalizedMenuString(@"Edit");
+        NSMenuItem *editItem = [[NSMenuItem alloc] initWithTitle:editTitle action:NULL keyEquivalent:@""];
+        NSMenu *editMenu = [[NSMenu alloc] initWithTitle:editTitle];
+        editMenu.autoenablesItems = NO; // always enabled; the bridge re-injects the shortcut
+        NSMenuItem *it;
+        it = [editMenu addItemWithTitle:nucleusLocalizedMenuString(@"Undo") action:@selector(nucleusUndo:) keyEquivalent:@""];             it.target = bridge; it.image = nucleusMenuSymbol(@"arrow.uturn.backward");
+        it = [editMenu addItemWithTitle:nucleusLocalizedMenuString(@"Redo") action:@selector(nucleusRedo:) keyEquivalent:@""];             it.target = bridge; it.image = nucleusMenuSymbol(@"arrow.uturn.forward");
         [editMenu addItem:[NSMenuItem separatorItem]];
-        [editMenu addItemWithTitle:@"Cut" action:@selector(cut:) keyEquivalent:@"x"];
-        [editMenu addItemWithTitle:@"Copy" action:@selector(copy:) keyEquivalent:@"c"];
-        [editMenu addItemWithTitle:@"Paste" action:@selector(paste:) keyEquivalent:@"v"];
+        it = [editMenu addItemWithTitle:nucleusLocalizedMenuString(@"Cut") action:@selector(nucleusCut:) keyEquivalent:@""];               it.target = bridge; it.image = nucleusMenuSymbol(@"scissors");
+        it = [editMenu addItemWithTitle:nucleusLocalizedMenuString(@"Copy") action:@selector(nucleusCopy:) keyEquivalent:@""];             it.target = bridge; it.image = nucleusMenuSymbol(@"doc.on.doc");
+        it = [editMenu addItemWithTitle:nucleusLocalizedMenuString(@"Paste") action:@selector(nucleusPaste:) keyEquivalent:@""];           it.target = bridge; it.image = nucleusMenuSymbol(@"doc.on.clipboard");
         [editMenu addItem:[NSMenuItem separatorItem]];
-        [editMenu addItemWithTitle:@"Select All" action:@selector(selectAll:) keyEquivalent:@"a"];
+        it = [editMenu addItemWithTitle:nucleusLocalizedMenuString(@"Select All") action:@selector(nucleusSelectAll:) keyEquivalent:@""]; it.target = bridge; it.image = nucleusMenuSymbol(@"square.dashed");
         editItem.submenu = editMenu;
         [mainMenu addItem:editItem];
+
+        NSApp.mainMenu = mainMenu;
     });
 }
 
 void nucleus_tao_a11y_attach(int64_t ns_view_handle) {
     NSView *view = (__bridge NSView *)(void *)(intptr_t)ns_view_handle;
     if (!view) return;
-    nucleus_tao_install_edit_menu_once();
+    nucleus_tao_install_default_menu_bar_once();
     nucleus_tao_swizzle_taoview_a11y_once();
     NucleusA11yProjection *proj = ensure_projection_for_view(view);
     build_default_rotors(proj);

--- a/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativeNsMenuBridge.kt
+++ b/menu-macos/src/main/kotlin/dev/nucleusframework/menu/macos/NativeNsMenuBridge.kt
@@ -1,8 +1,10 @@
 package dev.nucleusframework.menu.macos
 
 import dev.nucleusframework.core.runtime.NativeLibraryLoader
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
-import javax.swing.SwingUtilities
 
 private const val LIBRARY_NAME = "nucleus_menu_macos"
 
@@ -17,6 +19,15 @@ internal object NativeNsMenuBridge {
     private val loaded = NativeLibraryLoader.load(LIBRARY_NAME, NativeNsMenuBridge::class.java)
 
     val isLoaded: Boolean get() = loaded
+
+    // Menu actions/delegates fire from the AppKit main thread (JNI) and must be
+    // marshalled to the host's Compose UI thread. Dispatchers.Main resolves to
+    // the right thread per backend — the Swing EDT under the AWT backend, the
+    // Tao main thread under the Tao backend (TaoMainDispatcherFactory). Using
+    // SwingUtilities.invokeLater instead posted to the AWT EDT, which is NOT
+    // Compose's UI thread in the Tao backend, so the callbacks were silently
+    // dropped there — no menu action, no delegate event (issue #310).
+    private val uiScope = CoroutineScope(Dispatchers.Main)
 
     // ---- Action callbacks (handle → callback) ----
     private val actionCallbacks = ConcurrentHashMap<Long, () -> Unit>()
@@ -46,7 +57,7 @@ internal object NativeNsMenuBridge {
     @JvmStatic
     fun onMenuItemAction(handle: Long) {
         val callback = actionCallbacks[handle] ?: return
-        SwingUtilities.invokeLater { callback() }
+        uiScope.launch { callback() }
     }
 
     // ---- Delegate callbacks (menuHandle → delegate) ----
@@ -71,21 +82,21 @@ internal object NativeNsMenuBridge {
     fun onMenuWillOpen(menuHandle: Long) {
         val delegate = delegates[menuHandle] ?: return
         val menu = NsMenu.borrowed(menuHandle)
-        SwingUtilities.invokeLater { delegate.menuWillOpen(menu) }
+        uiScope.launch { delegate.menuWillOpen(menu) }
     }
 
     @JvmStatic
     fun onMenuDidClose(menuHandle: Long) {
         val delegate = delegates[menuHandle] ?: return
         val menu = NsMenu.borrowed(menuHandle)
-        SwingUtilities.invokeLater { delegate.menuDidClose(menu) }
+        uiScope.launch { delegate.menuDidClose(menu) }
     }
 
     @JvmStatic
     fun onMenuNeedsUpdate(menuHandle: Long) {
         val delegate = delegates[menuHandle] ?: return
         val menu = NsMenu.borrowed(menuHandle)
-        SwingUtilities.invokeLater { delegate.menuNeedsUpdate(menu) }
+        uiScope.launch { delegate.menuNeedsUpdate(menu) }
     }
 
     @JvmStatic
@@ -96,7 +107,7 @@ internal object NativeNsMenuBridge {
         val delegate = delegates[menuHandle] ?: return
         val menu = NsMenu.borrowed(menuHandle)
         val item = if (itemHandle != 0L) NsMenuItem.borrowed(itemHandle) else null
-        SwingUtilities.invokeLater { delegate.menuWillHighlightItem(menu, item) }
+        uiScope.launch { delegate.menuWillHighlightItem(menu, item) }
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary

Follow-up on #310 after janbarari's latest round of testing.

**decorated-window-tao — fullscreen traffic-lights (A)**
- Pin the fullscreen replacement traffic-lights to the native size so they stay round. The shrink factor + AppKit's `-2pt` frame correction flattened them horizontally when the stored fullscreen title-bar height was small.

**decorated-window-tao — native app menu / B2 placeholder**
- Build a proper Application menu (+ Edit) and set it as `NSApp.mainMenu` **deterministically** (no longer gated on an empty menu, no nib). In the packaged app the JVM/AppKit init leaves a broken menu whose app slot doesn't render (the stray placeholder next to the Apple menu); building + `setMainMenu` unconditionally fixes it in both `run` and the distributable.
- Labels localized through AppKit's own string tables (system language). Commands Apple keys by unstable Interface Builder IDs (About / Hide Others / Zoom) are omitted.
- Edit actions routed to Compose by re-injecting the ⌘-shortcut (Compose owns text editing, not the AppKit responder chain). SF Symbol icons on Edit items.

**decorated-window-tao — fullscreen overlay + logging (B2/B4)**
- Neutralize the lazily-created `NSToolbarFullScreenWindow` overlay (drop shadow + titlebar separator), hide the standard buttons for the whole fullscreen session, and install the Carbon menu-bar handler on pre-Tahoe so the overlay is re-neutralized on every menu-bar reveal.
- `NTLOG` is now opt-in via `NUCLEUS_TAO_LOG=1` (NSLog → unified log), so the diagnostics are observable on release builds / Ventura.

**menu-macos — NativeMenuBar callbacks on Ventura**
- Dispatch action/delegate callbacks on `Dispatchers.Main` instead of `SwingUtilities.invokeLater`. The Tao backend routes `Dispatchers.Main` to its own main thread, not the AWT EDT, so `invokeLater` silently dropped every native menu callback there (nothing in the event log).

## Test plan
- [x] `clang -fsyntax-only` + `build.sh` (arm64 + x86_64); `:menu-macos:compileKotlin`
- [x] nucleus-demo (Tao + NativeMenuBar) boots without regression; menu structure verified via AX ([App, Edit], localized via tables, no About/Hide Others/Zoom)
- [ ] janbarari on Ventura: fullscreen buttons round; native menu present + localized; **NativeMenuBar item clicks now log in the event card**