### PR TITLE
fix: allow overriding snap name independently of packageName (#244)

### DIFF
--- a/examples/nucleus-demo/build.gradle.kts
+++ b/examples/nucleus-demo/build.gradle.kts
@@ -210,6 +210,8 @@ nucleus.application {
 
             // --- Snap (NEW) ---
             snap {
+                // Override the Snap Store name when it differs from packageName (defaults to packageName).
+                // name = "nucleus-demo"
                 confinement = SnapConfinement.Strict
                 grade = SnapGrade.Stable
                 summary = "Nucleus demo"

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/SnapSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/SnapSettings.kt
@@ -7,6 +7,18 @@ package dev.nucleusframework.desktop.application.dsl
 
 @Suppress("UnnecessaryAbstractClass") // Required abstract for Gradle ObjectFactory.newInstance()
 abstract class SnapSettings {
+    /**
+     * Snap name used in `meta/snap.yaml` and the Snap Store namespace.
+     *
+     * Defaults to the app's `packageName` when null. Set this when the Snap Store
+     * registration uses a name distinct from `packageName`.
+     *
+     * Note: electron-builder 26.x derives the snap name from the Linux `executableName`,
+     * so overriding this also renames the snap's launcher command and desktop entry.
+     * Must be a valid snap name (lowercase letters, digits and hyphens).
+     */
+    var name: String? = null
+
     /** Confinement level. Default: [SnapConfinement.Strict] */
     var confinement: SnapConfinement = SnapConfinement.Strict
 

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -1101,10 +1101,11 @@ abstract class AbstractElectronBuilderPackageTask
 
             return when (targetFormat) {
                 TargetFormat.Snap -> {
-                    if (!isCommandAvailable("snapcraft")) {
-                        logger.lifecycle("Skipping Snap packaging: 'snapcraft' is not available on this runner.")
-                        true
-                    } else if (currentArch == Arch.Arm64) {
+                    // electron-builder builds snaps with its bundled `app-builder` tool (downloading
+                    // its own snap template), and never invokes the `snapcraft` binary — so snapcraft
+                    // is not a prerequisite. arm64 stays unsupported because that template
+                    // (gnome-3-28-1804 build-snaps) is unavailable for the arch.
+                    if (currentArch == Arch.Arm64) {
                         logger.lifecycle(
                             "Skipping Snap packaging on arm64: electron-builder uses " +
                                 "build-snaps (gnome-3-28-1804) unavailable for arm64.",

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -413,7 +413,7 @@ abstract class AbstractElectronBuilderPackageTask
                     linuxIconOverride = linuxIconOverride,
                     windowsIconOverride = windowsIconOverride,
                     linuxAfterInstallTemplate = linuxAfterInstallTemplate,
-                    executableName = executableName.orNull,
+                    executableName = resolveExecutableName(),
                     dmgBackgroundOverride = dmgBackgroundOverride,
                     dmgWindowOverride = dmgWindowOverride,
                     nsisProtocolInclude = nsisProtocolInclude,
@@ -1302,6 +1302,13 @@ abstract class AbstractElectronBuilderPackageTask
                 .imageType(BufferedImage.TYPE_INT_ARGB)
                 .asBufferedImage()
 
+        private fun resolveExecutableName(): String? =
+            resolveLinuxExecutableName(
+                targetFormat = targetFormat,
+                snapName = distributions?.linux?.snap?.name,
+                executableName = executableName.orNull,
+            )
+
         private fun ensureLinuxExecutableAlias(appDir: File) {
             if (currentOS != OS.Linux) return
 
@@ -1331,7 +1338,7 @@ abstract class AbstractElectronBuilderPackageTask
 
             val relativePath = launcher.relativeTo(appDir).path
 
-            val aliasName = executableName.orNull ?: launcherName.toNpmPackageName()
+            val aliasName = resolveExecutableName() ?: launcherName.toNpmPackageName()
             val aliasFile = appDir.resolve(aliasName)
             if (aliasFile.exists()) return
 
@@ -1509,6 +1516,20 @@ abstract class AbstractElectronBuilderPackageTask
             return listOf(platformFlag, targetFormat.electronBuilderTarget)
         }
     }
+
+/**
+ * Resolves the Linux `executableName` handed to electron-builder.
+ *
+ * For the Snap target, a non-blank [snapName] takes precedence: electron-builder 26.x derives the
+ * snap name (`meta/snap.yaml` `name:` and the Snap Store namespace) from the executable name, so it
+ * is the only lever that renames the snap independently of `packageName`. See issue #244.
+ */
+internal fun resolveLinuxExecutableName(
+    targetFormat: TargetFormat,
+    snapName: String?,
+    executableName: String?,
+): String? =
+    if (targetFormat == TargetFormat.Snap && !snapName.isNullOrBlank()) snapName else executableName
 
 /**
  * Creates a task-private copy of the app image directory so that parallel

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/ResolveLinuxExecutableNameTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/ResolveLinuxExecutableNameTest.kt
@@ -1,0 +1,51 @@
+package dev.nucleusframework.desktop.application.tasks
+
+import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Locks in issue #244: the snap name must be overridable independently of packageName.
+ * electron-builder 26.x derives the snap name from the Linux executableName, so a
+ * [dev.nucleusframework.desktop.application.dsl.SnapSettings.name] override must win for the
+ * Snap target and be ignored for every other target.
+ */
+class ResolveLinuxExecutableNameTest {
+    @Test
+    fun `snap name overrides executableName for the snap target`() {
+        assertEquals(
+            "my-cool-app",
+            resolveLinuxExecutableName(TargetFormat.Snap, snapName = "my-cool-app", executableName = "mypkg"),
+        )
+    }
+
+    @Test
+    fun `snap name is ignored for non-snap targets`() {
+        assertEquals(
+            "mypkg",
+            resolveLinuxExecutableName(TargetFormat.Deb, snapName = "my-cool-app", executableName = "mypkg"),
+        )
+    }
+
+    @Test
+    fun `blank snap name falls back to executableName`() {
+        assertEquals(
+            "mypkg",
+            resolveLinuxExecutableName(TargetFormat.Snap, snapName = "  ", executableName = "mypkg"),
+        )
+    }
+
+    @Test
+    fun `null snap name falls back to executableName for the snap target`() {
+        assertEquals(
+            "mypkg",
+            resolveLinuxExecutableName(TargetFormat.Snap, snapName = null, executableName = "mypkg"),
+        )
+    }
+
+    @Test
+    fun `null executableName and no snap name resolves to null`() {
+        assertNull(resolveLinuxExecutableName(TargetFormat.Snap, snapName = null, executableName = null))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #244 — the snap's `meta/snap.yaml` `name:` (and Snap Store namespace) could not be set independently of `packageName`, blocking projects whose Snap Store registration uses a different name.

- **`SnapSettings.name: String?`** — new DSL property (`linux.snap { name = "..." }`), defaults to `packageName` when null.
- electron-builder 26.x derives the snap name from the Linux `executableName`, so the override is threaded through both the generated `linux.executableName` config and the launcher alias (`resolveLinuxExecutableName`).
- **Drop the `snapcraft` prerequisite check.** electron-builder builds snaps with its bundled `app-builder` tool (downloading its own snap template) and never invokes the `snapcraft` binary, so requiring it on PATH only caused false skips. The arm64 skip is kept (template unavailable there).
- Unit test + commented example in `nucleus-demo`.

> Note: because electron-builder couples the two, overriding the snap name also renames the snap's launcher command and `.desktop` entry — unavoidable in eb 26.x, documented in the KDoc.

## Test plan

- [x] `:plugin:test` (incl. new `ResolveLinuxExecutableNameTest`), `:plugin:ktlintCheck`, `:plugin:detekt` — green
- [x] End-to-end via `:examples:nucleus-demo:packageSnap` (no snapcraft installed):
  - `snap { name = "my-cool-nucleus" }` → produced `.snap` with `name: my-cool-nucleus`
  - default (no override) → `name: nucleusdemo`, and no more "Skipping Snap packaging" message