### PR TITLE
fix(window): correct pre-Tahoe traffic light size in fullscreen

### DIFF
--- a/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
+++ b/decorated-window-tao/src/main/native/macos/NucleusTaoMetal.m
@@ -404,18 +404,18 @@ static void computeButtonMetrics(float titleBarHeight,
                                  float *outBtnWidth, float *outBtnHeight,
                                  float *outOffset) {
     float shrinkFactor = fminf(titleBarHeight / kMinHeightForFullSize, 1.0f);
-    // Traffic-lights are a fixed native size on macOS — they never scale with
-    // the title-bar height. Pinning the width to the native 14 pt (instead of
-    // titleBarHeight * 0.5) keeps them identical to windowed mode. Scaling the
-    // width down for a shorter fullscreen title bar combined with the -2 pt
-    // constant below flipped the aspect and stretched the pills horizontally
-    // (issue #310 follow-up: windowed was round via Auto Layout's intrinsic
-    // width, fullscreen forced a too-small frame).
-    *outBtnWidth  = kMinHeightForFullSize * 0.5f;
-    // JBR's correction: AppKit adds a constant 2 pt to the resulting frame
-    // height, so width * 14/12 - 2 keeps the circle perfectly round. Only
-    // valid at the native width, which is why the width is pinned above.
-    *outBtnHeight = (*outBtnWidth) * (14.0f / 12.0f) - 2.0f;
+    // Traffic-lights size adapts to the title-bar height, capped at the
+    // native 14 pt width. Mirrors decorated-window-jni's implementation.
+    *outBtnWidth  = fminf(titleBarHeight * 0.5f, kMinHeightForFullSize * 0.5f);
+    if (isTahoeOrLater()) {
+        // JBR's correction: AppKit adds a constant 2 pt to the resulting frame
+        // height, so width * 14/12 - 2 keeps the circle perfectly round.
+        *outBtnHeight = (*outBtnWidth) * (14.0f / 12.0f) - 2.0f;
+    } else {
+        // Keep the pre-Tahoe native 14x16 pt aspect so the glyphs aren't
+        // squashed on older macOS.
+        *outBtnHeight = (*outBtnWidth) * (16.0f / 14.0f);
+    }
     *outOffset    = shrinkFactor * defaultButtonOffset();
 }
 

--- a/launcher-macos/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.launcher-macos/reachability-metadata.json
+++ b/launcher-macos/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.launcher-macos/reachability-metadata.json
@@ -1,0 +1,14 @@
+{
+    "reflection": [
+        {
+            "type": "dev.nucleusframework.launcher.macos.NativeMacOsDockMenuBridge",
+            "jniAccessible": true,
+            "methods": [
+                {
+                    "name": "onMenuItemClicked",
+                    "parameterTypes": ["int"]
+                }
+            ]
+        }
+    ]
+}

--- a/plugin-build/plugin/src/main/resources/default-compose-desktop-rules.pro
+++ b/plugin-build/plugin/src/main/resources/default-compose-desktop-rules.pro
@@ -252,7 +252,7 @@
 -keep class dev.nucleusframework.notification.common.** { *; }
 
 # Nucleus media-control JNI — native code uses FindClass(BRIDGE_CLASS) + static callbacks
--keep class dev.nucleusframework.mediacontrol.** { *; }
+-keep class dev.nucleusframework.media.control.** { *; }
 
 # Nucleus scheduler JNI
 -keep class dev.nucleusframework.scheduler.** { *; }
@@ -280,6 +280,28 @@
 }
 -keep class * implements dev.nucleusframework.launcher.windows.ThumbBarClickListener {
     void onThumbButtonClick(int);
+}
+
+# Nucleus menu-macos JNI — NativeNsMenuBridge is looked up by name from native
+# code (FindClass + GetStaticMethodID). The menu action/delegate callbacks fire
+# from AppKit into these @JvmStatic methods, so both the class name and the
+# method names must survive shrinking/obfuscation.
+-keep class dev.nucleusframework.menu.macos.NativeNsMenuBridge {
+    native <methods>;
+    static void onMenuItemAction(long);
+    static void onMenuWillOpen(long);
+    static void onMenuDidClose(long);
+    static void onMenuNeedsUpdate(long);
+    static void onMenuWillHighlightItem(long, long);
+    static int onNumberOfItemsInMenu(long);
+}
+
+# Nucleus launcher-macos JNI — NativeMacOsDockMenuBridge is looked up by name
+# from native code (FindClass + GetStaticMethodID); onMenuItemClicked is the
+# dock-menu action callback invoked from AppKit.
+-keep class dev.nucleusframework.launcher.macos.NativeMacOsDockMenuBridge {
+    native <methods>;
+    static void onMenuItemClicked(int);
 }
 
 -dontwarn sun.misc.Unsafe


### PR DESCRIPTION
Closes #310.

Two parts, both required to fully resolve #310 on the Tao backend.

## 1. Pre-Tahoe traffic light size in fullscreen

On pre-Tahoe macOS, the traffic-light (window control) buttons stretched horizontally when entering full screen. Windowed mode was round (Auto Layout's intrinsic width), but full screen forced a too-small frame: pinning the width to the native 14 pt combined with the `-2 pt` JBR correction flipped the aspect and turned the circles into pills.

In `computeButtonMetrics` (`decorated-window-tao/.../NucleusTaoMetal.m`):

- Adapt the button **width** to the title-bar height, capped at the native 14 pt (`fminf(titleBarHeight * 0.5f, kMinHeightForFullSize * 0.5f)`) — mirroring `decorated-window-jni`.
- Branch the **height** aspect by OS version:
  - **Tahoe+**: keep JBR's `width * 14/12 - 2` correction.
  - **pre-Tahoe**: use the native `14x16 pt` aspect (`width * 16/14`) so the glyphs aren't squashed.

## 2. ProGuard rules for macOS menu JNI callbacks

The native macOS menu bar (`menu-macos`) and dock menu (`launcher-macos`) bridges are looked up by name from ObjC via `FindClass` + `GetStaticMethodID`. In release builds ProGuard renamed/stripped the bridge classes and their `@JvmStatic` callbacks, so the lookups returned null and menu actions / delegate events were silently dropped (the exact failure `NativeNsMenuBridge` documents for #310).

- Add `-keep` rules for `NativeNsMenuBridge` (`onMenuItemAction`, `onMenuWillOpen`, `onMenuDidClose`, `onMenuNeedsUpdate`, `onMenuWillHighlightItem`, `onNumberOfItemsInMenu`) and `NativeMacOsDockMenuBridge` (`onMenuItemClicked`).
- Add the missing GraalVM reachability metadata for `launcher-macos` so the dock-menu callback survives native-image too.
- Fix the media-control keep rule: package is `media.control`, not `mediacontrol` — the previous rule matched nothing.

Tao backend only; `decorated-window-jni` already had the correct behavior.