### PR TITLE
feat(app): add dockIconFollowsWindows for menu-bar / tray apps

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindowComposable.kt
@@ -343,6 +343,17 @@ fun ApplicationScope.DecoratedWindow(
             window.hide()
         }
     }
+    // Dock-icon reference counting (macOS): a window that isn't hiddenFromDock
+    // contributes to the app's Dock icon while it is visible, so a menu-bar /
+    // agent app (nucleusApplication(dockIconFollowsWindows = true)) surfaces in
+    // the Dock only while a real window is on screen. Idle unless that opt-in is
+    // active; [TaoStandalonePopup] tray popups never route through here.
+    if (Platform.Current == Platform.MacOS && !hiddenFromDock) {
+        DisposableEffect(visible) {
+            if (visible) TaoDockPolicy.onWindowShown()
+            onDispose { if (visible) TaoDockPolicy.onWindowHidden() }
+        }
+    }
     LaunchedEffect(window, minimumSize) {
         if (minimumSize != null) {
             window.setMinimumSize(

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoDockPolicy.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoDockPolicy.kt
@@ -1,0 +1,59 @@
+package dev.nucleusframework.window.tao
+
+import dev.nucleusframework.core.runtime.Platform
+
+/**
+ * Process-wide controller for the macOS Dock icon when an app opted into
+ * `nucleusApplication(dockIconFollowsWindows = true)`.
+ *
+ * Reference-counts the visible, dock-contributing [DecoratedWindow]s (those
+ * created with `hiddenFromDock = false`). The app runs as an accessory (no Dock
+ * icon, no menu bar) while the count is zero and switches to a regular app
+ * while at least one such window is visible — mirroring a menu-bar / agent app
+ * that only appears in the Dock while it has a real window on screen. Standalone
+ * tray popups ([TaoStandalonePopup]) are non-activating panels and never
+ * contribute, so a tray-only app stays out of the Dock.
+ *
+ * No-op off macOS: Windows has no Dock, and Linux taskbar exclusion is
+ * per-window via `hiddenFromDock`. Every entry point runs on the Tao main
+ * thread (the Compose dispatcher), which is the macOS main thread the native
+ * activation-policy switch requires — so the shared state needs no locking.
+ *
+ * Public because [dev.nucleusframework.application.nucleusApplication] wires the
+ * opt-in from another module; not intended for direct use by applications.
+ */
+object TaoDockPolicy {
+    private var enabled = false
+    private var visibleWindowCount = 0
+
+    /**
+     * Enables (or disables) Dock-follows-windows and applies the policy for the
+     * current window count. Called once at startup from the Tao launcher's root
+     * composition, so a tray-only app drops out of the Dock immediately.
+     */
+    fun setEnabled(value: Boolean) {
+        if (Platform.Current != Platform.MacOS) return
+        enabled = value
+        if (enabled) applyPolicy(dockVisible = visibleWindowCount > 0)
+    }
+
+    /** A dock-contributing window became visible. */
+    fun onWindowShown() {
+        if (Platform.Current != Platform.MacOS) return
+        visibleWindowCount++
+        if (enabled && visibleWindowCount == 1) applyPolicy(dockVisible = true)
+    }
+
+    /** A dock-contributing window was hidden or left the composition. */
+    fun onWindowHidden() {
+        if (Platform.Current != Platform.MacOS) return
+        if (visibleWindowCount > 0) visibleWindowCount--
+        if (enabled && visibleWindowCount == 0) applyPolicy(dockVisible = false)
+    }
+
+    private fun applyPolicy(dockVisible: Boolean) {
+        if (NativeTaoMacOsDecoBridge.isLoaded) {
+            NativeTaoMacOsDecoBridge.nativeSetHiddenFromDock(!dockVisible)
+        }
+    }
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/NucleusApplication.kt
@@ -41,6 +41,13 @@ fun nucleusApplication(
     backend: NucleusBackend = NucleusBackend.Auto,
     enableSingleInstance: Boolean = true,
     defaultLocale: Locale? = null,
+    // macOS + Tao backend only: run as a menu-bar / agent app whose Dock icon
+    // tracks window visibility. The app starts without a Dock icon (accessory
+    // policy) and shows one only while at least one [DecoratedWindow] with
+    // `hiddenFromDock = false` is visible; closing the last such window drops it
+    // back out of the Dock. Standalone tray popups never count. Ignored on the
+    // AWT backend and off macOS.
+    dockIconFollowsWindows: Boolean = false,
     content: @Composable NucleusApplicationScope.() -> Unit,
 ) {
     GraalVmInitializer.initialize()
@@ -78,7 +85,7 @@ fun nucleusApplication(
     )
 
     when (resolved) {
-        NucleusBackend.Tao -> TaoLauncher.run(args, content)
+        NucleusBackend.Tao -> TaoLauncher.run(args, dockIconFollowsWindows, content)
         NucleusBackend.Awt, NucleusBackend.Auto ->
             application {
                 val nucleusScope = AwtNucleusApplicationScope(this, args)

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoLauncher.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoLauncher.kt
@@ -2,10 +2,12 @@ package dev.nucleusframework.application.internal
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import dev.nucleusframework.application.LocalNucleusBackend
 import dev.nucleusframework.application.NucleusApplicationScope
 import dev.nucleusframework.application.NucleusBackend
 import dev.nucleusframework.application.TaoNucleusApplicationScope
+import dev.nucleusframework.window.tao.TaoDockPolicy
 import dev.nucleusframework.window.tao.taoApplication
 
 /**
@@ -16,6 +18,7 @@ import dev.nucleusframework.window.tao.taoApplication
 internal object TaoLauncher {
     fun run(
         args: Array<String>,
+        dockIconFollowsWindows: Boolean,
         content: @Composable NucleusApplicationScope.() -> Unit,
     ) {
         // macOS deep links arrive through Tao's `application:openURLs:` delegate
@@ -25,6 +28,12 @@ internal object TaoLauncher {
         taoApplication {
             val scope = TaoNucleusApplicationScope(this, args)
             CompositionLocalProvider(LocalNucleusBackend provides NucleusBackend.Tao) {
+                // Apply the Dock-follows-windows opt-in on the Tao main thread
+                // (this composition) so a tray-only app drops out of the Dock at
+                // startup; visible DecoratedWindows then promote it as needed.
+                LaunchedEffect(dockIconFollowsWindows) {
+                    TaoDockPolicy.setEnabled(dockIconFollowsWindows)
+                }
                 scope.content()
             }
         }


### PR DESCRIPTION
## Summary
- Adds `nucleusApplication(dockIconFollowsWindows = true)`: the app runs as a macOS accessory (no Dock icon, no menu bar) while no dockable window is visible, and switches to a regular app while at least one is — mirroring the pre-Tao `WindowVisibilityMonitor` behavior, driven natively.
- New `TaoDockPolicy` reference-counts visible `DecoratedWindow`s created with `hiddenFromDock = false` and flips the activation policy via `NativeTaoMacOsDecoBridge.nativeSetHiddenFromDock` on the 0↔1 transition.
- `DecoratedWindow` counts in/out via a `DisposableEffect(visible)`; standalone `TaoStandalonePopup` tray popups never contribute, so a tray-only app stays out of the Dock.
- `TaoLauncher` applies the opt-in from the root composition (Tao main thread) so a tray-only app drops out of the Dock at startup.

## Platform notes
- **macOS**-only in effect: only macOS keeps an app-level Dock icon that persists without windows, so it needs the app-wide activation-policy toggle.
- **Windows / Linux**: the taskbar is per-window and the standalone popup already opts out (`WS_EX_TOOLWINDOW` / override-redirect), so "taskbar entry ⟺ real window visible" is the native behavior there — the flag is a no-op by design.

## Test plan
- [x] Tray-only app (no `DecoratedWindow`) → no Dock icon at startup or ever
- [x] Tray + window: window visible → Dock icon; close window → icon disappears; reopen → icon returns
- [x] Tray popup alone (window closed) does not bring back the Dock icon
- [x] `dockIconFollowsWindows = false` (default) → unchanged (regular app keeps its Dock icon)
- [x] Windows / Linux X11 unaffected (taskbar already per-window)
