### PR TITLE
fix(graalvm): default march to compatibility for portable binaries

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -25,7 +25,10 @@ abstract class GraalvmSettings
         val javaLanguageVersion: Property<Int> = objects.notNullProperty(25)
         val jvmVendor: Property<JvmVendorSpec> = objects.nullableProperty()
         val imageName: Property<String> = objects.nullableProperty()
-        val march: Property<String> = objects.notNullProperty("native")
+        // Portable ISA baseline by default: the produced binary is meant to be distributed, so it
+        // must run on any x86-64 CPU. "native" optimizes for the build machine only and crashes on
+        // older CPUs ("does not support all of the following CPU features"). Override for local perf.
+        val march: Property<String> = objects.notNullProperty("compatibility")
         val buildArgs: ListProperty<String> = objects.listProperty(String::class.java)
         val nativeImageConfigBaseDir: DirectoryProperty = objects.directoryProperty()
         val macOS: GraalvmMacOSSettings = objects.new()


### PR DESCRIPTION
## Summary
- Change the default GraalVM `march` from `native` to `compatibility`.
- `-march=native` optimizes for the build machine's CPU, so the produced binary crashes on any older/different x86-64 CPU with *"does not support all of the following CPU features"*.
- Native images built by Nucleus are meant to be **distributed**, so a portable ISA baseline is the correct default. Users who want machine-specific perf can still override (e.g. `-PnativeMarch=native` or `march = ...` in the DSL).

## Test plan
- [ ] Build a native image with default settings and confirm it runs on a CPU without AVX2/SHA/etc.
- [ ] Verify `-PnativeMarch=native` / DSL override still takes effect.