### PR TITLE
fix(tao-macos): drop native shadow on popup panels

### DIFF
--- a/decorated-window-tao/src/main/native/macos/popup_panel.m
+++ b/decorated-window-tao/src/main/native/macos/popup_panel.m
@@ -447,7 +447,12 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeCreatePanel(
         panel.canKey = NO; // toggled via nativeSetFocusable
         panel.opaque = NO;
         panel.backgroundColor = [NSColor clearColor];
-        panel.hasShadow = YES;
+        // No native shadow: AppKit derives it from the opaque pixels and never
+        // recomputes it for CAMetalLayer content (would need invalidateShadow
+        // after every present), so it lags the fade-in and doubles whatever
+        // shadow the Compose content draws. Parity with the Windows panel,
+        // which has none either — content owns its shadow.
+        panel.hasShadow = NO;
         panel.level = NSPopUpMenuWindowLevel;
         panel.hidesOnDeactivate = NO;
         panel.animationBehavior = NSWindowAnimationBehaviorNone;
@@ -484,7 +489,8 @@ Java_dev_nucleusframework_window_tao_PopupNativeBridge_nativeCreatePanel(
     panel.canKey = NO; // toggled via nativeSetFocusable
     panel.opaque = NO;
     panel.backgroundColor = [NSColor clearColor];
-    panel.hasShadow = YES;
+    // Same rationale as the standalone branch: no stale Metal-content shadow.
+    panel.hasShadow = NO;
     panel.level = NSPopUpMenuWindowLevel;
     panel.hidesOnDeactivate = NO;
     panel.animationBehavior = NSWindowAnimationBehaviorNone;


### PR DESCRIPTION
## Problem

On macOS, tray popups (`TrayApp` in ComposeNativeTray, hosted in the standalone transparent `NSPanel`) show a weird shadow/halo around the popup.

## Cause

AppKit computes a transparent window's shadow from its opaque pixels, and never recomputes it for CAMetalLayer-rendered content unless `invalidateShadow` is called after each present — which nothing did. The shadow was captured from stale/mid-fade frames (the first presented frame is the alpha≈0 start of the fade-in), leaving a wrong-shaped halo around the popup. It also stacked on top of whatever shadow the Compose content draws.

## Fix

`hasShadow = NO` on both panel branches (standalone + parented) in `popup_panel.m` — parity with the Windows panel, which has no native shadow either (no `CS_DROPSHADOW`): content owns its shadow.

Alternative considered: exposing a JNI `invalidateShadow` and calling it after every present — more code and per-frame main-queue hops for a shadow the content already draws.

Verified locally: rebuilt the dylibs, republished `decorated-window-tao` to mavenLocal and ran the ComposeNativeTray demo against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)