### PR TITLE
feat(plugin): add --enable-native-access=ALL-UNNAMED to default JVM args

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
@@ -57,6 +57,9 @@ import org.gradle.jvm.tasks.Jar
 private val defaultJvmArgs: List<String> =
     buildList {
         add("-D$CONFIGURE_SWING_GLOBALS=true")
+        // Nucleus runtime modules load native libraries via JNI; without this flag
+        // JDK 24+ (JEP 472) emits warnings and future JDKs will refuse access.
+        add("--enable-native-access=ALL-UNNAMED")
         if (currentOS == OS.MacOS) {
             // The decorated-window module uses reflection on java.desktop internals
             // (sun.awt.AWTAccessor) to obtain the native NSWindow pointer.


### PR DESCRIPTION
Nucleus runtime modules load native libraries via JNI. Starting with JDK 24 (JEP 472), unrestricted native access emits runtime warnings, and future JDKs will deny it by default.

This adds `--enable-native-access=ALL-UNNAMED` to `defaultJvmArgs`, which flows to both the jpackage launcher config and the `run` task, so packaged apps and dev runs are covered by a single change. The flag is supported since JDK 17, matching the project's minimum target, so no version guard is needed. GraalVM native-image is unaffected (the flag does not exist there).