### PR TITLE
feat(graalvm): type-safe march with per-platform default

### DIFF
--- a/examples/benchmark-demo/AGENTS.md
+++ b/examples/benchmark-demo/AGENTS.md
@@ -56,7 +56,7 @@ process is what gets measured. `run-all.sh` reads `JDK_C2_HOME` and `GRAALVM_HOM
 - PGO flow: build `-Ppgo=instrument` → run the binary with cwd = `pgo/` → close the window at
   "Done" → `default.iprof` is written on process exit → rebuild (the profile is auto-detected).
   Train in **GUI** (not headless) to cover the render paths.
-- `march = "native"` in the graalvm DSL: ISA parity with what Swift/Rust ship on macOS ARM.
+- `march = NativeImageMarch.NATIVE` in the graalvm DSL: ISA parity with what Swift/Rust ship on macOS ARM.
   `compatibility` = bare ARMv8.0, ~-15% composite.
 
 ## Measurement protocol

--- a/examples/benchmark-demo/BENCHMARK-SPEC.md
+++ b/examples/benchmark-demo/BENCHMARK-SPEC.md
@@ -27,7 +27,7 @@ JIT/interpreter. Kernel correctness is verifiable on the VM with `dart run bin/c
 Every runtime builds what its stack actually ships to macOS users. Swift/Rust target-triple
 baseline = the M1 ISA (AES/SHA/LSE/CRC32 — every ARM Mac has them). GraalVM's default
 `-march=compatibility` targets bare ARMv8.0 (portability no macOS app needs), so the benchmark
-sets `march = "native"` (`graalvm {}` DSL) — the honest equivalent of the Swift/Rust baseline on
+sets `march = NativeImageMarch.NATIVE` (`graalvm {}` DSL) — the honest equivalent of the Swift/Rust baseline on
 this platform. Measured impact of that asymmetry (M-series, -O3 + recorded PGO): composite 238 →
 254, mandelbrot ×2.
 

--- a/examples/benchmark-demo/build.gradle.kts
+++ b/examples/benchmark-demo/build.gradle.kts
@@ -1,4 +1,5 @@
 import dev.nucleusframework.desktop.application.dsl.CompressionLevel
+import dev.nucleusframework.desktop.application.dsl.NativeImageMarch
 import dev.nucleusframework.desktop.application.dsl.NativeImageOptimization
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -55,7 +56,7 @@ nucleus.application {
         // ISA parity with what Swift/Rust actually ship on macOS ARM: their target-triple
         // baseline is the M1 ISA (AES/SHA/LSE/CRC32...), so `native` here — GraalVM's default
         // `compatibility` targets bare ARMv8.0, a portability no macOS app needs.
-        march = "native"
+        march = NativeImageMarch.NATIVE
         // PGO (Oracle GraalVM): build instrumented with -Ppgo=instrument, run the binary with
         // --headless to record default.iprof into pgo/, then rebuild — the profile is applied
         // automatically whenever pgo/default.iprof exists. True PGO replaces ML-inferred PGO.

--- a/examples/fs-watcher-smoke/build.gradle.kts
+++ b/examples/fs-watcher-smoke/build.gradle.kts
@@ -1,3 +1,4 @@
+import dev.nucleusframework.desktop.application.dsl.NativeImageMarch
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import org.gradle.api.tasks.Exec
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -32,7 +33,10 @@ nucleus.application {
         javaLanguageVersion = 25
         jvmVendor = JvmVendorSpec.BELLSOFT
         imageName = "fs-watcher-native-smoke"
-        march = providers.gradleProperty("nativeMarch").getOrElse("compatibility")
+        // Leave unset for the per-platform default; -PnativeMarch=native overrides it locally.
+        providers.gradleProperty("nativeMarch").orNull?.let {
+            march = NativeImageMarch.valueOf(it.uppercase())
+        }
         buildArgs.addAll(
             "-H:+AddAllCharsets",
             "-Djava.awt.headless=true",

--- a/examples/tao-demo/build.gradle.kts
+++ b/examples/tao-demo/build.gradle.kts
@@ -1,4 +1,5 @@
 import dev.nucleusframework.desktop.application.dsl.CompressionLevel
+import dev.nucleusframework.desktop.application.dsl.NativeImageMarch
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -59,7 +60,10 @@ nucleus.application {
         javaLanguageVersion = 25
         jvmVendor = JvmVendorSpec.BELLSOFT
         imageName = "sample-tao"
-        march = providers.gradleProperty("nativeMarch").getOrElse("compatibility")
+        // Leave unset for the per-platform default; -PnativeMarch=native overrides it locally.
+        providers.gradleProperty("nativeMarch").orNull?.let {
+            march = NativeImageMarch.valueOf(it.uppercase())
+        }
         buildArgs.addAll(
             "-H:+AddAllCharsets",
             "-Djava.awt.headless=false",

--- a/examples/zstd-demo/build.gradle.kts
+++ b/examples/zstd-demo/build.gradle.kts
@@ -1,4 +1,5 @@
 import dev.nucleusframework.desktop.application.dsl.CompressionLevel
+import dev.nucleusframework.desktop.application.dsl.NativeImageMarch
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -51,7 +52,10 @@ nucleus.application {
         javaLanguageVersion = 25
         jvmVendor = JvmVendorSpec.BELLSOFT
         imageName = "zstd-demo"
-        march = providers.gradleProperty("nativeMarch").getOrElse("compatibility")
+        // Leave unset for the per-platform default; -PnativeMarch=native overrides it locally.
+        providers.gradleProperty("nativeMarch").orNull?.let {
+            march = NativeImageMarch.valueOf(it.uppercase())
+        }
         buildArgs.addAll(
             "-H:+AddAllCharsets",
             "-Djava.awt.headless=false",

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -25,10 +25,12 @@ abstract class GraalvmSettings
         val javaLanguageVersion: Property<Int> = objects.notNullProperty(25)
         val jvmVendor: Property<JvmVendorSpec> = objects.nullableProperty()
         val imageName: Property<String> = objects.nullableProperty()
-        // Portable ISA baseline by default: the produced binary is meant to be distributed, so it
-        // must run on any x86-64 CPU. "native" optimizes for the build machine only and crashes on
-        // older CPUs ("does not support all of the following CPU features"). Override for local perf.
-        val march: Property<String> = objects.notNullProperty("compatibility")
+        // Target CPU instruction set (`-march`). Leave unset for the per-platform default:
+        // [NativeImageMarch.COMPATIBILITY] (portable baseline for distributed binaries) everywhere
+        // except macOS on Apple Silicon, which defaults to [NativeImageMarch.NATIVE] (its armv8-a
+        // baseline is present on every supported Mac, so there is no portability cost). Set to
+        // [NativeImageMarch.NATIVE] to tune for the build machine (crashes on older/different CPUs).
+        val march: Property<NativeImageMarch> = objects.nullableProperty()
 
         // Optimization level for native-image (the `-O*` flag). Leave unset to keep native-image's
         // own default (`-O2`). Use [NativeImageOptimization.SIZE] to shrink Compose images (~20–30%),

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/NativeImageMarch.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/NativeImageMarch.kt
@@ -1,0 +1,27 @@
+package dev.nucleusframework.desktop.application.dsl
+
+/**
+ * Target CPU instruction-set architecture passed to GraalVM `native-image` (the `-march` flag).
+ *
+ * Leave [dev.nucleusframework.desktop.application.dsl.GraalvmSettings.march] unset to use the
+ * per-platform default: [COMPATIBILITY] everywhere except macOS on Apple Silicon, which defaults
+ * to [NATIVE] (its baseline `armv8-a` is already present on every supported Mac, so there is no
+ * portability cost).
+ */
+enum class NativeImageMarch(
+    internal val flag: String,
+) {
+    /**
+     * `-march=native`: optimize for the exact CPU of the build machine. Produces the fastest
+     * binary but it crashes on any older/different CPU ("does not support all of the following
+     * CPU features"). Use only for locally-run builds, never for a distributed x86-64 binary.
+     */
+    NATIVE("native"),
+
+    /**
+     * `-march=compatibility`: the lowest-common-denominator ISA baseline (`x86-64-v1` / `armv8-a`).
+     * The produced binary runs on any CPU of the target architecture — the safe default for
+     * distributed binaries.
+     */
+    COMPATIBILITY("compatibility"),
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -4,6 +4,7 @@ package dev.nucleusframework.desktop.application.internal
 
 import dev.nucleusframework.desktop.application.dsl.FileAssociation
 import dev.nucleusframework.desktop.application.dsl.GraalvmSettings
+import dev.nucleusframework.desktop.application.dsl.NativeImageMarch
 import dev.nucleusframework.desktop.application.dsl.PackagingBackend
 import dev.nucleusframework.desktop.application.dsl.UrlProtocol
 import dev.nucleusframework.desktop.application.internal.InfoPlistBuilder.InfoPlistValue.InfoPlistListValue
@@ -668,7 +669,16 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             val resolvedStaticMetadataDir = staticMetadataDir.get().asFile
             val resolvedMetadataRepoDirsFile = metadataRepoDirsFile.get().asFile
             val resolvedBuildArgs = graalvm.buildArgs.get()
-            val resolvedMarch = graalvm.march.get()
+            // Default: portable baseline everywhere, except macOS on Apple Silicon where the
+            // armv8-a baseline is already universal so "native" is a free perf win.
+            val resolvedMarch =
+                (
+                    graalvm.march.orNull ?: if (currentOS == OS.MacOS && currentArch == Arch.Arm64) {
+                        NativeImageMarch.NATIVE
+                    } else {
+                        NativeImageMarch.COMPATIBILITY
+                    }
+                ).flag
             val resolvedOptimizationFlag = graalvm.optimization.orNull?.flag
             val resolvedAllCharsets = graalvm.allCharsets.get()
             val resolvedMlProfileInference = graalvm.mlProfileInference.get()


### PR DESCRIPTION
## What

Make the GraalVM `march` DSL setting **type-safe** and give it a smart **per-platform default**.

- New `NativeImageMarch` enum (`NATIVE` / `COMPATIBILITY`) replaces the free-form `String` property.
- `march` is now unset by default. When unset, the plugin resolves:
  - **macOS on Apple Silicon → `NATIVE`** — its `armv8-a` baseline is already present on every supported Mac, so `native` is a free perf win with no portability cost.
  - **everywhere else → `COMPATIBILITY`** — portable ISA baseline (`x86-64-v1` / `armv8-a`) so distributed binaries run on any CPU of the target architecture.
- An explicit `march = …` in the `graalvm {}` block always overrides the default.

## Why

`native` optimizes for the build machine and crashes on older/different CPUs, so it's unsafe as a global default for distributed x86-64 binaries — but on Apple Silicon `compatibility` and `native` are effectively equivalent, so defaulting macOS ARM to `native` costs nothing and is faster. A `String` property also gave no compile-time safety against typos.

## Changes

- `NativeImageMarch` enum (new).
- `GraalvmSettings.march`: `Property<String>` → `Property<NativeImageMarch>` (nullable, unset = platform default).
- `configureGraalvmApplication`: resolve the per-platform default when unset.
- Examples migrated to the enum; `-PnativeMarch=…` override mapped through `NativeImageMarch.valueOf(...)`.
- Doc references updated.

Plugin compiles clean; `:plugin:test` passes.