### PR TITLE
chore(graalvm): bump reachability metadata repository to 1.1.4

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -179,7 +179,7 @@ abstract class MetadataRepositorySettings
         val enabled: Property<Boolean> = objects.notNullProperty(true)
 
         /** Version of the metadata repository artifact. */
-        val version: Property<String> = objects.notNullProperty("0.10.6")
+        val version: Property<String> = objects.notNullProperty("1.1.4")
 
         /** Module coordinates (group:artifact) to exclude from repository resolution. */
         val excludedModules: SetProperty<String> =

--- a/plugin-build/plugin/test-analysis-libraries.gradle.kts
+++ b/plugin-build/plugin/test-analysis-libraries.gradle.kts
@@ -109,7 +109,7 @@ val testOracleRepo: Configuration by configurations.creating {
 }
 
 dependencies {
-    testOracleRepo("org.graalvm.buildtools:graalvm-reachability-metadata:0.10.6:repository@zip")
+    testOracleRepo("org.graalvm.buildtools:graalvm-reachability-metadata:1.1.4:repository@zip")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
## Summary
- Update the Oracle GraalVM Reachability Metadata Repository from `0.10.6` to the latest `1.1.4`
- The metadata repository versioning is now aligned with native-build-tools (catalog uses `graalvmNative = 1.1.3`)

## Changes
- `GraalvmSettings.kt` — default `metadataRepository.version` DSL value
- `test-analysis-libraries.gradle.kts` — test ZIP coordinates

## Test plan
- [ ] `./gradlew :plugin:test` resolves the `1.1.4` repository ZIP
- [ ] GraalVM native build resolves metadata for runtime classpath deps