### PR TITLE
chore(plugin): bump default ProGuard version to 7.9.1

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/ProguardSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/ProguardSettings.kt
@@ -12,7 +12,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import javax.inject.Inject
 
-private const val DEFAULT_PROGUARD_VERSION = "7.7.0"
+private const val DEFAULT_PROGUARD_VERSION = "7.9.1"
 
 abstract class ProguardSettings
     @Inject


### PR DESCRIPTION
## Summary
- Bump the default ProGuard version used by the Gradle plugin from `7.7.0` to `7.9.1` (`ProguardSettings.kt`)

## Test plan
- [ ] `./gradlew packageReleaseDistributionForCurrentOS` builds with ProGuard 7.9.1