### PR TITLE
feat(decorated-window-tao): replicate GTK CSD drop shadow on Linux

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
@@ -215,19 +215,19 @@ fun DecoratedWindowScope.BasicTitleBar(
     // own slide by the tween duration.
     val menuBarOffset = if (isFullscreenWithNewControls) menuBarOffsetPt.dp else 0.dp
 
-    // Push the resolved title-bar background into the Skia clear color
-    // (re-applied every frame in `TaoComposeSceneHost`) so any Compose
-    // region without an explicit background — most visibly the gap above
-    // the offset title bar during the macOS fullscreen menu-bar slide-in —
-    // matches the chrome color rather than flashing white. This is the
-    // tao equivalent of the AWT NSWindow background jbr/jni get for free
-    // from the user's theme.
+    // Push the resolved title-bar background into the Skia clear color,
+    // re-applied every frame by every Tao host (macOS / Windows / Linux), so
+    // any Compose region without an explicit background matches the chrome
+    // color rather than flashing a hardcoded white or — on Linux — showing
+    // the desktop through the transparent CSD clear. This is the Tao
+    // equivalent of the AWT NSWindow background that jbr/jni get for free from
+    // the user's theme (see `DecoratedWindowBody`'s `Modifier.background`).
+    // On Linux the host still carves the CSD shadow margins / rounded corners
+    // back to transparent after rendering, so the drop shadow is unaffected.
     val titleBarBackground by style.colors.backgroundFor(currentState)
-    if (isMacOS) {
-        val clearColorState = LocalRequestedClearColor.current
-        SideEffect {
-            clearColorState?.value = titleBarBackground.toArgb()
-        }
+    val clearColorState = LocalRequestedClearColor.current
+    SideEffect {
+        clearColorState?.value = titleBarBackground.toArgb()
     }
 
     // Push the animated offset back to native so the AppKit traffic-light

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -56,10 +56,15 @@ private val hiddenFromDockLogger: java.util.logging.Logger =
 
 /**
  * Holds the ARGB clear color the Skia render loop applies to each frame,
- * pushed in by the themed window and by `TitleBar` from the resolved chrome
- * background. macOS-only: Linux/Windows hosts ignore it (they have native
- * window chrome with proper backgrounds). Defaults to opaque white via
- * [TaoComposeSceneHost.clearColorArgbState] until the first composition.
+ * pushed in by the themed window (`DecoratedWindowComposable`, from the window
+ * background) and by `TitleBar` from the resolved chrome background — the
+ * latter composes deeper, so it wins when both are present. Honored by all
+ * three Tao hosts (macOS / Windows / Linux) so a Compose region without an
+ * explicit background matches the chrome color on every platform — mirroring
+ * the AWT backends' `Modifier.background(titleBarBackground)` in
+ * `DecoratedWindowBody`. On Linux the host still carves the CSD shadow margins
+ * and rounded corners back to transparent after rendering, so the drop shadow
+ * is unaffected. Defaults to opaque white until the first composition.
  */
 internal val LocalRequestedClearColor =
     staticCompositionLocalOf<androidx.compose.runtime.MutableState<Int>?> { null }
@@ -501,6 +506,7 @@ private fun ApplicationScope.openDecoratedWindowLinux(
                 LocalTitleBarInfo provides TitleBarInfo(title, icon),
                 LocalTaoWindow provides window,
                 LocalRequestedTitleBarHeight provides titleBarHeightState,
+                LocalRequestedClearColor provides host.clearColorArgbState,
                 LocalFullscreenTitleBarHolder provides fullscreenHolder,
                 LocalTaoNativeViewHost provides host.nativeViewHost(),
                 LocalTaoCompositionLocalContextBridge provides host::setSceneCompositionLocalContext,
@@ -876,6 +882,7 @@ private fun ApplicationScope.openDecoratedWindowWindows(
                 LocalTitleBarInfo provides TitleBarInfo(title, icon),
                 LocalTaoWindow provides window,
                 LocalRequestedTitleBarHeight provides titleBarHeightState,
+                LocalRequestedClearColor provides host.clearColorArgbState,
                 LocalFullscreenTitleBarHolder provides fullscreenHolder,
                 LocalTaoNativeViewHost provides host.nativeViewHost(),
                 LocalTaoCompositionLocalContextBridge provides host::setSceneCompositionLocalContext,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.absolutePadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
@@ -24,6 +26,7 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.core.runtime.Platform
 import dev.nucleusframework.window.DecoratedWindowState
@@ -48,7 +51,8 @@ internal val LocalRequestedTitleBarHeight =
     }
 
 private val hiddenFromDockLogger: java.util.logging.Logger =
-    java.util.logging.Logger.getLogger("dev.nucleusframework.window.tao.hiddenFromDock")
+    java.util.logging.Logger
+        .getLogger("dev.nucleusframework.window.tao.hiddenFromDock")
 
 /**
  * Holds the ARGB clear color the Skia render loop applies to each frame,
@@ -208,6 +212,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             alwaysOnTop,
             maximized,
             isDialog,
+            undecorated,
             icon,
             minimumSize,
             onCloseRequest,
@@ -431,6 +436,7 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     alwaysOnTop: Boolean,
     maximized: Boolean,
     isDialog: Boolean,
+    undecorated: Boolean,
     icon: Painter?,
     minimumSize: DpSize?,
     onCloseRequest: () -> Unit,
@@ -445,6 +451,9 @@ private fun ApplicationScope.openDecoratedWindowLinux(
     host.previewKeyHandler = onPreviewKeyEvent
     host.keyHandler = onKeyEvent
     host.setSceneCompositionLocalContext(initialCompositionLocalContext)
+    // GTK-style CSD drop shadow around the visible frame (skipped for
+    // borderless ghost windows; popups are filtered in the host itself).
+    host.decorationShadowEnabled = !undecorated
 
     // ── Linux accessibility (AT-SPI2 via AccessKit) ────────────────────────
     // Same SemanticsObserver pipeline as macOS / Windows. The controller
@@ -514,10 +523,23 @@ private fun ApplicationScope.openDecoratedWindowLinux(
                     remember {
                         mutableStateOf(0)
                     }
+                // Inset the whole UI by the CSD shadow margins — the shadow
+                // itself is painted natively-themed by the host's render
+                // loop in the ring this padding frees up. Zero when the
+                // shadow is inactive or the window is maximized/fullscreen.
+                val shadowInsets by host.windowShadow.insetsState
                 CompositionLocalProvider(
                     dev.nucleusframework.window.LocalModalDialogCount provides modalCount,
                 ) {
-                    Box(modifier = Modifier.fillMaxSize()) {
+                    Box(
+                        modifier =
+                            Modifier.fillMaxSize().absolutePadding(
+                                left = shadowInsets.left.dp,
+                                top = shadowInsets.top.dp,
+                                right = shadowInsets.right.dp,
+                                bottom = shadowInsets.bottom.dp,
+                            ),
+                    ) {
                         FullscreenOverlayHost(
                             holder = fullscreenHolder,
                             isFullscreen = stateHolder.value.isFullscreen,
@@ -556,7 +578,47 @@ private fun ApplicationScope.openDecoratedWindowLinux(
             }
         }
         val (initialW, initialH) = initialLinuxSize(window, w, h, maximized)
-        host.onResized(initialW, initialH)
+        var surfaceW = initialW
+        var surfaceH = initialH
+        val shadow = host.windowShadow
+        if (shadow.isActive) {
+            // Grow the surface by the shadow margins so the *visible* frame
+            // keeps the requested size — the same bookkeeping GTK does in
+            // gtk_window_update_csd_size. Declaring the extents before the
+            // first map lets the WM position/tile with the visible frame
+            // from the very first frame.
+            val s = window.scaleFactor
+            val marginW = shadow.marginLeft + shadow.marginRight
+            val marginH = shadow.marginTop + shadow.marginBottom
+            val grownWLog = (initialW / s).roundToInt() + marginW
+            val grownHLog = (initialH / s).roundToInt() + marginH
+            // X11: `_GTK_FRAME_EXTENTS` is only a declaration — grow the X
+            // window ourselves (while maximized this lands in the WM's
+            // saved "normal" geometry, used on restore). On Wayland GDK's
+            // set_shadow_width reconfigures the surface itself to keep the
+            // window geometry stable.
+            if (host.isX11) {
+                window.setInnerSize(grownWLog.toDouble(), grownHLog.toDouble())
+            }
+            shadow.reconcile(
+                suspended = maximized,
+                surfaceWLogical = grownWLog,
+                surfaceHLogical = grownHLog,
+            )
+            if (!maximized) {
+                surfaceW = (grownWLog * s).roundToInt()
+                surfaceH = (grownHLog * s).roundToInt()
+            }
+            // Margins participate in the size hints on both backends (GDK
+            // Wayland subtracts them again when emitting the xdg min size).
+            minimumSize?.let {
+                window.setMinimumSize(
+                    it.width.value.toDouble() + marginW,
+                    it.height.value.toDouble() + marginH,
+                )
+            }
+        }
+        host.onResized(surfaceW, surfaceH)
         // First paint must happen *after* the surface is shown:
         //  - X11: a pre-show synchronous render leaves the GLX backbuffer
         //    invalidated by the subsequent map, so the dialog stayed black

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoLinuxShadowBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/NativeTaoLinuxShadowBridge.kt
@@ -1,0 +1,103 @@
+package dev.nucleusframework.window.tao
+
+import dev.nucleusframework.core.runtime.NativeLibraryLoader
+
+// The shadow helper is compiled into the widget helper library (see
+// linux/build.sh) — one .so, two JNI bridge classes.
+private const val LIBRARY_NAME = "nucleus_tao_linux_widget"
+
+/**
+ * JNI bridge to `linux/nucleus_tao_linux_shadow.c` — GTK client-side
+ * decoration shadows for the Tao backend's undecorated Linux windows.
+ *
+ * Replicates GTK's own CSD shadow mechanism: the live theme's
+ * `window.csd > decoration` node is rendered off-screen (normal +
+ * `:backdrop` states) and the invisible margin is declared to the WM via
+ * `gdk_window_set_shadow_width()` (`_GTK_FRAME_EXTENTS` on X11,
+ * xdg_surface window-geometry margins on Wayland). See
+ * [dev.nucleusframework.window.tao.render.TaoWindowShadowLinux] for the
+ * drawing/animation half.
+ *
+ * Threading: every entry point must run on the GTK main thread (= Tao
+ * event-loop thread = Compose dispatcher thread).
+ */
+internal object NativeTaoLinuxShadowBridge {
+    val isLoaded: Boolean =
+        NativeLibraryLoader.load(
+            LIBRARY_NAME,
+            NativeTaoLinuxShadowBridge::class.java,
+        )
+
+    /**
+     * True when client-side shadows can work here — mirrors GTK3's
+     * `gtk_window_supports_client_shadow`: compositor running, RGBA visual
+     * available, and on X11 ([kind] = 1) a WM advertising
+     * `_GTK_FRAME_EXTENTS` in `_NET_SUPPORTED`. [kind] = 2 for Wayland.
+     */
+    @JvmStatic
+    external fun nativeShadowSupported(kind: Int): Boolean
+
+    /**
+     * Renders the themed decoration node into an off-screen ARGB surface:
+     * shadow + 1px outline around a `visibleW`×`visibleH` logical frame
+     * with the given logical margins, at [scale]. Corner radii (logical
+     * px) are forced so the shadow hugs the same rounded shape as the
+     * content carve.
+     *
+     * Returns `[widthPx, heightPx, pixels…]` — row-major premultiplied
+     * ARGB32 (= Skia BGRA_8888 PREMUL on little-endian) — or null.
+     */
+    @JvmStatic
+    @Suppress("LongParameterList")
+    external fun nativeShadowRender(
+        backdrop: Boolean,
+        tiled: Boolean,
+        visibleW: Int,
+        visibleH: Int,
+        marginL: Int,
+        marginT: Int,
+        marginR: Int,
+        marginB: Int,
+        scale: Float,
+        radiusTopLeft: Float,
+        radiusTopRight: Float,
+        radiusBottomRight: Float,
+        radiusBottomLeft: Float,
+    ): IntArray?
+
+    /**
+     * Declares the invisible shadow margin (logical px) to the WM —
+     * GTK's own `gdk_window_set_shadow_width()`: `_GTK_FRAME_EXTENTS` on
+     * X11, window-geometry margins on Wayland (where GDK also grows the
+     * surface to keep the visible geometry stable). Zeros clear it.
+     */
+    @JvmStatic
+    external fun nativeShadowApply(
+        gtkWindowPtr: Long,
+        marginL: Int,
+        marginT: Int,
+        marginR: Int,
+        marginB: Int,
+    )
+
+    /**
+     * Restricts the window input region to the given logical rect (visible
+     * frame + 12 px resize ring, GTK4's `RESIZE_HANDLE_SIZE`) so clicks in
+     * the outer shadow fall through. `width < 0` resets to full surface.
+     */
+    @JvmStatic
+    external fun nativeShadowSetInputShape(
+        gtkWindowPtr: Long,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    )
+
+    /**
+     * Cache key for rendered shadow images: `"<gtk-theme-name>|<dark>"`.
+     * Changes when the user switches theme or toggles dark preference.
+     */
+    @JvmStatic
+    external fun nativeShadowThemeStamp(): String?
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -72,8 +72,7 @@ class TaoWindow internal constructor(
     @Volatile
     private var closeRequestedListener: (() -> Unit)? = null
 
-    @Volatile
-    private var destroyedListener: (() -> Unit)? = null
+    private val destroyedListeners = CopyOnWriteArrayList<() -> Unit>()
 
     @Volatile
     private var redrawListener: (() -> Unit)? = null
@@ -550,8 +549,9 @@ class TaoWindow internal constructor(
         closeRequestedListener = block
     }
 
+    /** Multi-cast: every call adds a listener; all of them fire when the window is destroyed. */
     fun onDestroyed(block: () -> Unit) {
-        destroyedListener = block
+        destroyedListeners += block
     }
 
     fun onRedrawRequested(block: () -> Unit) {
@@ -692,7 +692,7 @@ class TaoWindow internal constructor(
             TaoEventCode.SCALE_FACTOR_CHANGED -> scaleFactorListener?.invoke(a / 1000f)
             TaoEventCode.CLOSE_REQUESTED -> closeRequestedListener?.invoke()
             TaoEventCode.DESTROYED -> {
-                destroyedListener?.invoke()
+                destroyedListeners.forEach { it.invoke() }
                 TaoApplication.remove(handle)
             }
             TaoEventCode.REDRAW_REQUESTED -> {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ResizeFrameDecoration.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/ResizeFrameDecoration.kt
@@ -57,21 +57,28 @@ internal class ResizeFrameDecoration(
     private var inBand: Boolean = false
 
     /**
-     * Returns the resize direction if [x], [y] (logical px, window-local) sits
-     * in the edge band of a window sized [widthLogical] × [heightLogical].
+     * Returns the resize direction if [x], [y] (logical px, frame-local) sits
+     * in the edge band of a frame sized [widthLogical] × [heightLogical].
      * Returns `null` if outside the band — caller forwards the event normally.
+     *
+     * [outerBandLogical] extends the hit zone *outside* the frame — used when
+     * the window carries an invisible CSD shadow margin, whose area doubles as
+     * the resize grip exactly like native GTK client-side decorations (the
+     * window input shape clips it to GTK's 12 px resize ring).
      *
      * Corner zones win over edge zones (a click at (4, 4) on a 200×200 window
      * is `NorthWest`, not `North`). This matches the JBR + Tao precedence.
      */
+    @Suppress("LongParameterList")
     fun hitTest(
         x: Float,
         y: Float,
         widthLogical: Int,
         heightLogical: Int,
         forTouch: Boolean = false,
+        outerBandLogical: Int = 0,
     ): Direction? {
-        if (!isInsideFrame(x, y, widthLogical, heightLogical)) return null
+        if (!isInsideFrame(x, y, widthLogical, heightLogical, outerBandLogical)) return null
         val edge = if (forTouch) touchEdgeThicknessLogical else edgeThicknessLogical
         val nearLeft = x < edge
         val nearRight = x >= widthLogical - edge
@@ -104,13 +111,14 @@ internal class ResizeFrameDecoration(
         y: Float,
         widthLogical: Int,
         heightLogical: Int,
+        outerBandLogical: Int = 0,
     ): Boolean =
         widthLogical > 0 &&
             heightLogical > 0 &&
-            x >= 0f &&
-            y >= 0f &&
-            x < widthLogical &&
-            y < heightLogical
+            x >= -outerBandLogical &&
+            y >= -outerBandLogical &&
+            x < widthLogical + outerBandLogical &&
+            y < heightLogical + outerBandLogical
 
     /**
      * Pointer-move hook. If [direction] is non-null the cursor is updated to

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
@@ -95,6 +95,18 @@ internal class TaoComposeSceneHostLinux(
     val titleBarHeightDpState: androidx.compose.runtime.MutableState<Float> =
         androidx.compose.runtime.mutableStateOf(0f)
 
+    /**
+     * ARGB color the render loop clears the surface to each frame, pushed in
+     * via [LocalRequestedClearColor] by the themed window (window background)
+     * and by `TitleBar` (resolved title-bar background). Defaults to opaque
+     * white until the first composition. The
+     * post-render carve ([applyFrameDecoration]) re-clears the CSD shadow
+     * margins and rounded corners to transparent, so the drop shadow still
+     * composites over clean transparency regardless of this clear color.
+     */
+    val clearColorArgbState: androidx.compose.runtime.MutableState<Int> =
+        androidx.compose.runtime.mutableStateOf(0xFFFFFFFF.toInt())
+
     /** App-level pre-dispatch hook. See [TaoComposeSceneHost.previewKeyHandler]. */
     var previewKeyHandler: ((KeyEvent) -> Boolean)? = null
 
@@ -1275,7 +1287,14 @@ internal class TaoComposeSceneHostLinux(
             cachedSurface = surface
         }
 
-        surface.canvas.clear(0x00000000)
+        // Clear to the resolved title-bar background (pushed by `TitleBar` via
+        // [LocalRequestedClearColor]) so any Compose region without an explicit
+        // background matches the chrome color — aligned with the macOS / Windows
+        // Tao hosts and the AWT backends, instead of showing the desktop through
+        // a transparent clear. The CSD shadow margins + rounded corners are carved
+        // back to transparent by [applyFrameDecoration] below, so the drop shadow
+        // still composites over clean transparency.
+        surface.canvas.clear(clearColorArgbState.value)
         sc.render(surface.canvas.asComposeCanvas(), now)
         applyFrameDecoration(surface.canvas, now)
         surface.flushAndSubmit(syncCpu = false)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostLinux.kt
@@ -283,11 +283,56 @@ internal class TaoComposeSceneHostLinux(
     /** Backend kind of the current EGL attachment: 1 = X11, 2 = Wayland. */
     private var attachedKind: Int = 0
 
+    /** True once attached on the X11/XWayland backend (vs native Wayland). */
+    val isX11: Boolean get() = attachedKind == 1
+
+    /**
+     * Opt-in for the GTK-style CSD drop shadow around the visible frame.
+     * Set by [dev.nucleusframework.window.tao.openDecoratedWindow] before
+     * [attach] for regular decorated windows/dialogs (not popups, not
+     * fully-undecorated ghost windows).
+     */
+    var decorationShadowEnabled: Boolean = false
+
+    /**
+     * GTK-theme drop shadow drawn in the invisible margin around the
+     * visible frame; also owns the `_GTK_FRAME_EXTENTS` / xdg-geometry
+     * declaration and the focus-driven backdrop cross-fade. Inactive until
+     * [attach] arms it (and never armed when unsupported — no compositor,
+     * no ARGB visual, WM without `_GTK_FRAME_EXTENTS`).
+     */
+    val windowShadow = TaoWindowShadowLinux(::requestRedrawCoalesced)
+
+    /**
+     * True while a compositor-driven interactive resize/move drag is in
+     * flight. The compositor's grab makes GTK report a focus-out for the
+     * whole drag, but a native GTK window keeps its focused shadow while
+     * being resized or moved — so focus loss is masked for the shadow while
+     * this is set. Cleared when focus comes back (the grab ended) or on the
+     * next real button press (events only reach us once the grab is over).
+     */
+    private var compositorDragActive = false
+
     /** True while the EGL attachment is torn down because the window is hidden. */
     private var gpuSuspended: Boolean = false
 
     fun attach() {
         attachGpu()
+
+        if (decorationShadowEnabled && !window.isPopup) {
+            val gtkWindow = NativeTaoBridge.nativeLinuxGtkWindow(window.handle)
+            // The shadow hugs the same rounded shape as the content carve
+            // (uniform radius on all four corners, per-DE).
+            val radius = cornerRadiusPx.toFloat()
+            windowShadow.initialize(
+                gtkWindowPtr = gtkWindow,
+                kind = attachedKind,
+                radiusTopLeft = radius,
+                radiusTopRight = radius,
+                radiusBottomRight = radius,
+                radiusBottomLeft = radius,
+            )
+        }
 
         @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
         val dndManager =
@@ -774,7 +819,10 @@ internal class TaoComposeSceneHostLinux(
                         ysFixed[0] / TOUCH_POSITION_SCALE,
                         forTouch = true,
                     )
-                if (resizeDecoration.onLeftPress(direction)) return
+                if (resizeDecoration.onLeftPress(direction)) {
+                    compositorDragActive = true
+                    return
+                }
             }
 
             val pointers = ArrayList<ComposeScenePointer>(count)
@@ -1126,7 +1174,13 @@ internal class TaoComposeSceneHostLinux(
     }
 
     fun onFocusChanged(focused: Boolean) {
+        if (focused) compositorDragActive = false
         windowInfo.isWindowFocused = focused
+        // Kick the 200ms normal <-> backdrop shadow cross-fade (no-op when
+        // the shadow is inactive). Focus loss during a compositor drag is
+        // the grab talking, not the user switching windows — keep the
+        // focused shadow, like native GTK CSD windows do during a resize.
+        windowShadow.onFocusChanged(focused || compositorDragActive)
     }
 
     private fun updateWindowInfoSize() {
@@ -1223,17 +1277,7 @@ internal class TaoComposeSceneHostLinux(
 
         surface.canvas.clear(0x00000000)
         sc.render(surface.canvas.asComposeCanvas(), now)
-        // Also drop the rounding when tiled/snapped (Aero Snap): a half/quarter
-        // screen window sits flush against the screen edge, so rounded corners
-        // there look wrong — native CSD windows square off when tiled too.
-        if (cornerRadiusPx > 0 && !window.isMaximized && !window.isFullscreen && !window.isTiled) {
-            // widthPx/heightPx are physical pixels and the canvas has no scale
-            // transform, so the logical radius must be scaled up to physical to
-            // keep the corner curvature constant in logical terms across DPI
-            // (the AWT path gets this for free via Graphics2D's scale transform).
-            val radiusPhysical = (cornerRadiusPx * scale).roundToInt().coerceAtLeast(1)
-            carveRoundedCorners(surface.canvas, widthPx, heightPx, radiusPhysical)
-        }
+        applyFrameDecoration(surface.canvas, now)
         surface.flushAndSubmit(syncCpu = false)
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
         swapThread?.requestSwap()
@@ -1251,28 +1295,99 @@ internal class TaoComposeSceneHostLinux(
     }
 
     /**
-     * Alpha-blended rounded-corner clip. Paints the four corner cut-outs with
-     * `BlendMode.CLEAR` (destination alpha → 0) so the compositor blends the
-     * content behind those pixels — works uniformly on X11 and Wayland (no
-     * XShape needed).
+     * Post-render frame decoration: corner carve + CSD shadow.
      *
-     * The path is `full_rect XOR rounded_rect` via `EVEN_ODD` fill, which
-     * yields exactly the four corner pieces; AA at the rounded edge stays in
-     * the destination, only the strictly-outside pixels are zeroed.
+     * Mirrors the CSD shadow margins for the current window state (the WM
+     * declaration itself is zeroed/restored synchronously by the native
+     * window-state-event handler; this drives Compose padding, the carve and
+     * the shadow drawing — margins drop for maximized, fullscreen AND tiled
+     * windows), then clears everything outside the visible rounded frame and
+     * paints the themed shadow into the freed margins.
      */
-    private fun carveRoundedCorners(
+    private fun applyFrameDecoration(
         canvas: Canvas,
-        w: Int,
-        h: Int,
+        now: Long,
+    ) {
+        val isMaximized = window.isMaximized
+        val isFullscreen = window.isFullscreen
+        val isTiled = window.isTiled
+        val s = if (scale > 0f) scale else 1f
+        windowShadow.reconcile(
+            suspended = isMaximized || isFullscreen || isTiled,
+            surfaceWLogical = (widthPx / s).roundToInt(),
+            surfaceHLogical = (heightPx / s).roundToInt(),
+        )
+        val shadowInsets = windowShadow.effectiveInsets
+
+        // Drop the rounding when tiled/snapped (Aero Snap): a half/quarter
+        // screen window sits flush against the screen edge, so rounded corners
+        // there look wrong — native CSD windows square off when tiled too.
+        val roundCorners = cornerRadiusPx > 0 && !isMaximized && !isFullscreen && !isTiled
+        if (roundCorners || !shadowInsets.isZero) {
+            // widthPx/heightPx are physical pixels and the canvas has no scale
+            // transform, so the logical radius must be scaled up to physical to
+            // keep the corner curvature constant in logical terms across DPI
+            // (the AWT path gets this for free via Graphics2D's scale transform).
+            val radiusPhysical =
+                if (roundCorners) (cornerRadiusPx * scale).roundToInt().coerceAtLeast(1) else 0
+            // With shadow margins the visible frame is inset — the carve then
+            // also clears any content that leaked into the margin area, so the
+            // shadow below composites over clean transparency.
+            carveOutsideFrame(
+                canvas,
+                left = (shadowInsets.left * s).roundToInt(),
+                top = (shadowInsets.top * s).roundToInt(),
+                right = widthPx - (shadowInsets.right * s).roundToInt(),
+                bottom = heightPx - (shadowInsets.bottom * s).roundToInt(),
+                surfaceW = widthPx,
+                surfaceH = heightPx,
+                radius = radiusPhysical,
+            )
+        }
+        // Shadow after the carve: its geometry never overlaps the visible
+        // frame interior (GTK paints outset shadows around the border box),
+        // so plain src-over into the just-cleared margins is correct.
+        windowShadow.draw(canvas, widthPx, heightPx, s, now)
+    }
+
+    /**
+     * Alpha-blended clip of everything outside the visible rounded frame.
+     * Paints the cut-outs with `BlendMode.CLEAR` (destination alpha → 0) so
+     * the compositor blends the content behind those pixels — works
+     * uniformly on X11 and Wayland (no XShape needed).
+     *
+     * Without shadow margins the frame equals the surface and this clears
+     * exactly the four corner pieces (the historical behavior); with margins
+     * it additionally clears the whole margin band, so the GTK shadow drawn
+     * afterwards composites over clean transparency.
+     *
+     * The path is `surface_rect XOR rounded_frame_rect` via `EVEN_ODD` fill;
+     * AA at the rounded edge stays in the destination, only the strictly
+     * outside pixels are zeroed. All coordinates are physical pixels.
+     */
+    @Suppress("LongParameterList")
+    private fun carveOutsideFrame(
+        canvas: Canvas,
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+        surfaceW: Int,
+        surfaceH: Int,
         radius: Int,
     ) {
-        val wf = w.toFloat()
-        val hf = h.toFloat()
-        val rf = radius.toFloat()
+        if (right <= left || bottom <= top) return
         PathBuilder(PathFillMode.EVEN_ODD)
-            .addRect(Rect.makeXYWH(0f, 0f, wf, hf))
-            .addRRect(RRect.makeXYWH(0f, 0f, wf, hf, rf))
-            .detach()
+            .addRect(Rect.makeXYWH(0f, 0f, surfaceW.toFloat(), surfaceH.toFloat()))
+            .addRRect(
+                RRect.makeLTRB(
+                    left.toFloat(),
+                    top.toFloat(),
+                    right.toFloat(),
+                    bottom.toFloat(),
+                    radius.toFloat(),
+                ),
+            ).detach()
             .use { frame ->
                 Paint().use { paint ->
                     paint.blendMode = BlendMode.CLEAR
@@ -1325,6 +1440,9 @@ internal class TaoComposeSceneHostLinux(
      * reentrantly from inside the very Move dispatch that started the drag.
      */
     fun onNativeWindowDragStarted() {
+        // The move grab also steals the focus notify — keep the focused
+        // shadow for the whole drag (see [compositorDragActive]).
+        compositorDragActive = true
         // The compositor's interactive-move grab swallows the button release, so
         // neither the Compose scene nor the title-bar drag gesture ever see it:
         // the pointer stays "pressed" and the window ignores hover/clicks until a
@@ -1373,8 +1491,13 @@ internal class TaoComposeSceneHostLinux(
         // would never show again after the first edge drag.
         if (pressed && buttonCode == dev.nucleusframework.window.tao.TaoMouseButton.LEFT) {
             val direction = currentResizeDirection(lastPointerX, lastPointerY)
-            if (resizeDecoration.onLeftPress(direction)) return
+            if (resizeDecoration.onLeftPress(direction)) {
+                compositorDragActive = true
+                return
+            }
         }
+        // Any other real press means no compositor grab is in flight.
+        if (pressed) compositorDragActive = false
         if (pressed) pressedButtons.add(buttonCode) else pressedButtons.remove(buttonCode)
 
         // A press reaching the parent scene is outside every popup layer (the
@@ -1419,9 +1542,21 @@ internal class TaoComposeSceneHostLinux(
         if (window.isFullscreen) return null
         if (window.isMaximized) return null
         val s = if (scale > 0f) scale else 1f
-        val widthLogical = (widthPx / s).toInt()
-        val heightLogical = (heightPx / s).toInt()
-        return resizeDecoration.hitTest(xPx / s, yPx / s, widthLogical, heightLogical, forTouch)
+        // With CSD shadow margins the resize band is measured against the
+        // *visible* frame, and extends into the invisible margin like GTK's
+        // resize ring (the input shape already clips it to 12 px outside).
+        val insets = windowShadow.effectiveInsets
+        val widthLogical = (widthPx / s).toInt() - insets.left - insets.right
+        val heightLogical = (heightPx / s).toInt() - insets.top - insets.bottom
+        val outerBand = if (insets.isZero) 0 else maxOf(insets.left, insets.top, insets.right, insets.bottom)
+        return resizeDecoration.hitTest(
+            xPx / s - insets.left,
+            yPx / s - insets.top,
+            widthLogical,
+            heightLogical,
+            forTouch,
+            outerBandLogical = outerBand,
+        )
     }
 
     fun onPointerScroll(event: TaoPointerScrollEvent) {
@@ -1821,6 +1956,7 @@ internal class TaoComposeSceneHostLinux(
         // Clear any input region we may have set while the window was
         // alive; harmless even if the EGL surface is about to go away.
         overlayController.dispose()
+        windowShadow.dispose()
         if (attachmentHandle != 0L) {
             NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
             NativeTaoEglBridge.nativeDetach(attachmentHandle)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -76,6 +76,18 @@ internal class TaoComposeSceneHostWindows(
     val titleBarHeightDpState: androidx.compose.runtime.MutableState<Float> =
         androidx.compose.runtime.mutableStateOf(0f)
 
+    /**
+     * ARGB color the render loop clears the surface to each frame, pushed in
+     * via [LocalRequestedClearColor] by the themed window (window background)
+     * and by `TitleBar` (resolved title-bar background). Defaults to opaque
+     * white until the first composition. Aligns
+     * the Windows host with macOS / Linux (and the AWT backends) so a Compose
+     * region without an explicit background matches the chrome color instead
+     * of a hardcoded white.
+     */
+    val clearColorArgbState: androidx.compose.runtime.MutableState<Int> =
+        androidx.compose.runtime.mutableStateOf(0xFFFFFFFF.toInt())
+
     /** App-level pre-dispatch hook. See [TaoComposeSceneHost.previewKeyHandler]. */
     var previewKeyHandler: ((KeyEvent) -> Boolean)? = null
 
@@ -988,7 +1000,11 @@ internal class TaoComposeSceneHostWindows(
             }
 
         try {
-            surface.canvas.clear(0xFFFFFFFF.toInt())
+            // Clear to the resolved title-bar background (pushed by `TitleBar`
+            // via [LocalRequestedClearColor]) so a Compose region without an
+            // explicit background matches the chrome color — aligned with the
+            // macOS / Linux Tao hosts and the AWT backends.
+            surface.canvas.clear(clearColorArgbState.value)
             sc.render(surface.canvas.asComposeCanvas(), now)
             // `flushAndSubmit` issues the glFlush that commits the frame to
             // the back buffer; the present happens below, after the overlay/

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWindowShadowLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoWindowShadowLinux.kt
@@ -1,0 +1,490 @@
+@file:Suppress("MagicNumber")
+
+package dev.nucleusframework.window.tao.render
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import dev.nucleusframework.window.tao.NativeTaoLinuxShadowBridge
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.FilterMode
+import org.jetbrains.skia.IRect
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+import org.jetbrains.skia.Paint
+import org.jetbrains.skia.Rect
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * GTK-style client-side drop shadow for the Tao backend's undecorated Linux
+ * windows — the drawing/animation half of the mechanism GTK uses for its own
+ * CSD windows (the WM half — `_GTK_FRAME_EXTENTS` / xdg window geometry — is
+ * [NativeTaoLinuxShadowBridge.nativeShadowApply]).
+ *
+ * The shadow pixels come from the *live* GTK theme: the `window.csd >
+ * decoration` CSS node is rendered off-screen by GTK itself (so Adwaita,
+ * Yaru, Breeze-gtk… all look native, including the 1px window outline), then
+ * nine-sliced into the window margins each frame. GTK's blurred shadow is
+ * constant along each edge, so the nine-slice stretch is exact — the same
+ * trick as GTK's own cached corner masks + repeated side strips
+ * (gtkcssshadowvalue.c `_gtk_css_shadow_value_paint_box`).
+ *
+ * Focus loss cross-fades to the theme's `decoration:backdrop` rendering over
+ * 200 ms ease-out, mirroring Adwaita's `transition: $backdrop_transition`.
+ * Shadow margins are identical in both states (themes keep a transparent
+ * placeholder shadow for exactly this reason), so the window never jumps.
+ *
+ * States, mirroring GTK's `get_shadow_width`:
+ *  - floating: full margins, normal/backdrop shadow;
+ *  - tiled/snapped: margins kept (they are the resize grip area — GTK themes
+ *    render only the 1px outline plus a transparent ring, see GNOME/gtk#3670);
+ *  - maximized/fullscreen: margins dropped to zero, no shadow.
+ *
+ * Threading: everything runs on the GTK main thread (= render thread).
+ */
+internal class TaoWindowShadowLinux(
+    private val requestRedraw: () -> Unit,
+) {
+    /** Logical margins measured from the theme, min 12 px (GTK4's RESIZE_HANDLE_SIZE). */
+    var marginLeft = 0
+        private set
+    var marginTop = 0
+        private set
+    var marginRight = 0
+        private set
+    var marginBottom = 0
+        private set
+
+    /**
+     * Margins the WM currently knows about (zeroed while maximized /
+     * fullscreen). Exposed to Compose as content padding — logical px = dp.
+     * Written only from the GTK main thread.
+     */
+    val insetsState: MutableState<ShadowInsets> = mutableStateOf(ShadowInsets.ZERO)
+
+    data class ShadowInsets(
+        val left: Int,
+        val top: Int,
+        val right: Int,
+        val bottom: Int,
+    ) {
+        val isZero: Boolean get() = left == 0 && top == 0 && right == 0 && bottom == 0
+
+        companion object {
+            val ZERO = ShadowInsets(0, 0, 0, 0)
+        }
+    }
+
+    private var gtkWindowPtr: Long = 0
+    private var active = false
+
+    /** Corner radii (logical px, TL/TR/BR/BL) the content carve uses — the shadow hugs the same shape. */
+    private var radiusTopLeft = 0f
+    private var radiusTopRight = 0f
+    private var radiusBottomRight = 0f
+    private var radiusBottomLeft = 0f
+
+    private var appliedInsets = ShadowInsets.ZERO
+    private var appliedInputW = -1
+    private var appliedInputH = -1
+
+    /** True once the desired margins were handed to the native side. */
+    private var nativeArmed = false
+
+    /** 0 = fully normal, 1 = fully backdrop. */
+    private var backdropFraction = 0f
+    private var animStartNanos = 0L
+    private var animFrom = 0f
+    private var animTarget = 0f
+
+    private var themeStamp: String? = null
+
+    private class CachedImage(
+        val image: Image,
+        val centerSlice: IRect,
+        val scale: Float,
+    )
+
+    /** Keyed by backdrop(1)/tiled(2) bits; invalidated on scale/theme change. */
+    private val images = HashMap<Int, CachedImage>()
+
+    /**
+     * Measures the theme's shadow extents and arms the controller. Must be
+     * called on the GTK main thread once the window is realized. Returns
+     * false when CSD shadows can't work here (no compositor / no ARGB
+     * visual / WM without `_GTK_FRAME_EXTENTS` — GTK falls back to its
+     * "solid-csd" look in the same situation).
+     *
+     * [kind] is the EGL attachment kind: 1 = X11, 2 = Wayland.
+     */
+    fun initialize(
+        gtkWindowPtr: Long,
+        kind: Int,
+        radiusTopLeft: Float,
+        radiusTopRight: Float,
+        radiusBottomRight: Float,
+        radiusBottomLeft: Float,
+    ): Boolean {
+        if (active) return true
+        if (gtkWindowPtr == 0L) return false
+        if (!NativeTaoLinuxShadowBridge.isLoaded) return false
+        if (!NativeTaoLinuxShadowBridge.nativeShadowSupported(kind)) return false
+
+        this.gtkWindowPtr = gtkWindowPtr
+        this.radiusTopLeft = radiusTopLeft
+        this.radiusTopRight = radiusTopRight
+        this.radiusBottomRight = radiusBottomRight
+        this.radiusBottomLeft = radiusBottomLeft
+
+        val measured = measureExtents() ?: return false
+        // GTK4 clamps every side to RESIZE_HANDLE_SIZE so the invisible
+        // margin always fits a resize grip, even for themes with tiny shadows.
+        marginLeft = max(measured[0], RESIZE_HANDLE_SIZE)
+        marginTop = max(measured[1], RESIZE_HANDLE_SIZE)
+        marginRight = max(measured[2], RESIZE_HANDLE_SIZE)
+        marginBottom = max(measured[3], RESIZE_HANDLE_SIZE)
+        themeStamp = NativeTaoLinuxShadowBridge.nativeShadowThemeStamp()
+        active = true
+        return true
+    }
+
+    val isActive: Boolean get() = active
+
+    /** Margins currently declared to the WM (zero while maximized/fullscreen). */
+    val effectiveInsets: ShadowInsets get() = appliedInsets
+
+    /**
+     * Renders both shadow states at scale 1 with a generous probe margin and
+     * takes the per-side alpha bounding box. Extents ignore shadow *color* in
+     * GTK (transparent placeholder shadows keep both states the same size),
+     * so the max over the two scans is taken — a backdrop-only larger shadow
+     * would otherwise be clipped.
+     */
+    private fun measureExtents(): IntArray? {
+        var l = 0
+        var t = 0
+        var r = 0
+        var b = 0
+        for (backdrop in booleanArrayOf(false, true)) {
+            val data =
+                NativeTaoLinuxShadowBridge.nativeShadowRender(
+                    backdrop = backdrop,
+                    tiled = false,
+                    visibleW = PROBE_CORE,
+                    visibleH = PROBE_CORE,
+                    marginL = PROBE_MARGIN,
+                    marginT = PROBE_MARGIN,
+                    marginR = PROBE_MARGIN,
+                    marginB = PROBE_MARGIN,
+                    scale = 1f,
+                    radiusTopLeft = radiusTopLeft,
+                    radiusTopRight = radiusTopRight,
+                    radiusBottomRight = radiusBottomRight,
+                    radiusBottomLeft = radiusBottomLeft,
+                ) ?: return null
+            val bounds = alphaBounds(data) ?: return null
+            // Fully transparent decoration (shadow-less theme) → keep zeros.
+            if (bounds[2] < 0) continue
+            l = max(l, PROBE_MARGIN - bounds[0])
+            t = max(t, PROBE_MARGIN - bounds[1])
+            r = max(r, bounds[2] - (PROBE_MARGIN + PROBE_CORE - 1))
+            b = max(b, bounds[3] - (PROBE_MARGIN + PROBE_CORE - 1))
+        }
+        return intArrayOf(max(l, 0), max(t, 0), max(r, 0), max(b, 0))
+    }
+
+    /**
+     * Bounding box of non-zero alpha in a `[w, h, pixels…]` payload as
+     * `[minX, minY, maxX, maxY]` (`maxX = -1` when fully transparent), or
+     * null when the payload is malformed.
+     */
+    private fun alphaBounds(data: IntArray): IntArray? {
+        val w = data[0]
+        val h = data[1]
+        if (w <= 0 || h <= 0 || data.size < 2 + w * h) return null
+        var minX = w
+        var minY = h
+        var maxX = -1
+        var maxY = -1
+        for (y in 0 until h) {
+            val rowBase = 2 + y * w
+            for (x in 0 until w) {
+                if (data[rowBase + x] ushr 24 != 0) {
+                    if (x < minX) minX = x
+                    if (x > maxX) maxX = x
+                    if (y < minY) minY = y
+                    if (y > maxY) maxY = y
+                }
+            }
+        }
+        return intArrayOf(minX, minY, maxX, maxY)
+    }
+
+    /**
+     * Reconciles the WM-declared margins and input shape with the current
+     * window state. Cheap when nothing changed — called once per rendered
+     * frame, exactly like GTK re-evaluating `get_shadow_width` on state
+     * transitions.
+     *
+     * [surfaceWLogical]/[surfaceHLogical] are the full surface logical size
+     * (margins included); the visible frame for the input-shape rect is
+     * derived by subtracting the margins.
+     */
+    fun reconcile(
+        suspended: Boolean,
+        surfaceWLogical: Int,
+        surfaceHLogical: Int,
+    ) {
+        if (!active) return
+        val target =
+            if (suspended) {
+                ShadowInsets.ZERO
+            } else {
+                ShadowInsets(marginLeft, marginTop, marginRight, marginBottom)
+            }
+        val visibleWLogical = surfaceWLogical - target.left - target.right
+        val visibleHLogical = surfaceHLogical - target.top - target.bottom
+        val insetsChanged = target != appliedInsets
+        if (insetsChanged) {
+            // The native side owns the WM declaration: the desired margins
+            // are handed over once, and a window-state-event handler zeroes/
+            // restores them *synchronously* on maximize/fullscreen/tile
+            // transitions — GTK's exact timing (a frame-later update from
+            // here makes mutter fight the window during a snap). This state
+            // only mirrors the effective value for Compose padding, the
+            // carve and the shadow drawing.
+            if (!nativeArmed) {
+                NativeTaoLinuxShadowBridge.nativeShadowApply(
+                    gtkWindowPtr,
+                    marginLeft,
+                    marginTop,
+                    marginRight,
+                    marginBottom,
+                )
+                nativeArmed = true
+            }
+            appliedInsets = target
+            insetsState.value = target
+        }
+        // Input region = visible frame + 12 px resize ring (GTK4's
+        // RESIZE_HANDLE_SIZE) so clicks in the outer shadow fall through —
+        // mirrors gtkwindow.c `update_realized_window_properties`.
+        if (target.isZero) {
+            if (appliedInputW != -1 || insetsChanged) {
+                NativeTaoLinuxShadowBridge.nativeShadowSetInputShape(gtkWindowPtr, 0, 0, -1, -1)
+                appliedInputW = -1
+                appliedInputH = -1
+            }
+        } else if (insetsChanged || visibleWLogical != appliedInputW || visibleHLogical != appliedInputH) {
+            NativeTaoLinuxShadowBridge.nativeShadowSetInputShape(
+                gtkWindowPtr,
+                target.left - RESIZE_HANDLE_SIZE,
+                target.top - RESIZE_HANDLE_SIZE,
+                visibleWLogical + 2 * RESIZE_HANDLE_SIZE,
+                visibleHLogical + 2 * RESIZE_HANDLE_SIZE,
+            )
+            appliedInputW = visibleWLogical
+            appliedInputH = visibleHLogical
+        }
+    }
+
+    /**
+     * Retargets the focus cross-fade. Mirrors the theme's
+     * `decoration:backdrop { transition: 200ms ease-out; }`.
+     */
+    fun onFocusChanged(focused: Boolean) {
+        if (!active) return
+        val target = if (focused) 0f else 1f
+        if (target == animTarget && animStartNanos != 0L) return
+        if (target == backdropFraction) {
+            animTarget = target
+            return
+        }
+        animFrom = backdropFraction
+        animTarget = target
+        animStartNanos = System.nanoTime()
+        // A theme/dark-mode switch is invisible while unfocused-idle; the
+        // focus edge is a natural, cheap moment to revalidate the cache.
+        val stamp = NativeTaoLinuxShadowBridge.nativeShadowThemeStamp()
+        if (stamp != themeStamp) {
+            themeStamp = stamp
+            clearImages()
+        }
+        requestRedraw()
+    }
+
+    /** True while the backdrop cross-fade needs more frames. */
+    val isAnimating: Boolean get() = active && backdropFraction != animTarget
+
+    /**
+     * Draws the shadow into the margin area of the frame surface. Call after
+     * the content carve — the carve cleared everything outside the visible
+     * rounded frame, and the shadow's own geometry never overlaps the frame
+     * interior (GTK paints outset shadows with an even-odd path around the
+     * border box), so plain src-over layering is correct.
+     */
+    fun draw(
+        canvas: Canvas,
+        surfaceWPx: Int,
+        surfaceHPx: Int,
+        scale: Float,
+        nowNanos: Long,
+    ) {
+        if (!active || appliedInsets.isZero) return
+        stepAnimation(nowNanos)
+
+        val fraction = backdropFraction
+        when {
+            fraction <= 0f -> drawState(canvas, surfaceWPx, surfaceHPx, scale, backdrop = false, alpha = 1f)
+            fraction >= 1f -> drawState(canvas, surfaceWPx, surfaceHPx, scale, backdrop = true, alpha = 1f)
+            else -> {
+                drawState(canvas, surfaceWPx, surfaceHPx, scale, backdrop = false, alpha = 1f - fraction)
+                drawState(canvas, surfaceWPx, surfaceHPx, scale, backdrop = true, alpha = fraction)
+            }
+        }
+        if (isAnimating) requestRedraw()
+    }
+
+    private fun stepAnimation(nowNanos: Long) {
+        if (backdropFraction == animTarget) return
+        val elapsed = (nowNanos - animStartNanos) / 1_000_000f
+        val progress = (elapsed / BACKDROP_TRANSITION_MS).coerceIn(0f, 1f)
+        backdropFraction =
+            if (progress >= 1f) {
+                animTarget
+            } else {
+                animFrom + (animTarget - animFrom) * easeOut(progress)
+            }
+    }
+
+    /** CSS `ease-out` = cubic-bezier(0, 0, 0.58, 1); a close even-power approximation. */
+    private fun easeOut(t: Float): Float {
+        val inv = 1f - t
+        return 1f - inv * inv
+    }
+
+    private fun drawState(
+        canvas: Canvas,
+        surfaceWPx: Int,
+        surfaceHPx: Int,
+        scale: Float,
+        backdrop: Boolean,
+        alpha: Float,
+    ) {
+        val cached = imageFor(backdrop, scale) ?: return
+        // Nine-slice needs the destination to fit both un-stretched corner
+        // blocks; skip the shadow for windows smaller than that (the WM
+        // margin is still honoured, there's just nothing worth drawing).
+        if (surfaceWPx <= cached.centerSlice.left + (cached.image.width - cached.centerSlice.right) ||
+            surfaceHPx <= cached.centerSlice.top + (cached.image.height - cached.centerSlice.bottom)
+        ) {
+            return
+        }
+        Paint().use { paint ->
+            paint.setAlphaf(alpha.coerceIn(0f, 1f))
+            canvas.drawImageNine(
+                cached.image,
+                cached.centerSlice,
+                Rect.makeWH(surfaceWPx.toFloat(), surfaceHPx.toFloat()),
+                // NEAREST: the stretched regions of a GTK shadow are constant
+                // strips; linear filtering would only soften the crisp 1px
+                // theme outline.
+                FilterMode.NEAREST,
+                paint,
+            )
+        }
+    }
+
+    private fun imageFor(
+        backdrop: Boolean,
+        scale: Float,
+    ): CachedImage? {
+        val key = if (backdrop) 1 else 0
+        val cached = images[key]
+        if (cached != null && cached.scale == scale) return cached
+        images.remove(key)?.image?.close()
+
+        // Canonical render: big enough that the four corner blocks (margin +
+        // corner radius + 1px safety) never overlap, leaving a genuine
+        // centre strip to stretch.
+        val maxRadius =
+            ceil(
+                maxOf(radiusTopLeft, radiusTopRight, radiusBottomRight, radiusBottomLeft).toDouble(),
+            ).toInt()
+        val core = 2 * (maxRadius + SLICE_SAFETY) + CENTER_STRIP
+        val data =
+            NativeTaoLinuxShadowBridge.nativeShadowRender(
+                backdrop = backdrop,
+                tiled = false,
+                visibleW = core,
+                visibleH = core,
+                marginL = marginLeft,
+                marginT = marginTop,
+                marginR = marginRight,
+                marginB = marginBottom,
+                scale = scale,
+                radiusTopLeft = radiusTopLeft,
+                radiusTopRight = radiusTopRight,
+                radiusBottomRight = radiusBottomRight,
+                radiusBottomLeft = radiusBottomLeft,
+            ) ?: return null
+        val w = data[0]
+        val h = data[1]
+        if (w <= 0 || h <= 0 || data.size < 2 + w * h) return null
+
+        val bytes = ByteArray(w * h * 4)
+        var src = 2
+        var dst = 0
+        while (dst < bytes.size) {
+            val px = data[src++]
+            // Cairo ARGB32 is native-endian packed ARGB; emit little-endian
+            // BGRA bytes to match ColorType.BGRA_8888.
+            bytes[dst++] = (px and 0xFF).toByte()
+            bytes[dst++] = ((px ushr 8) and 0xFF).toByte()
+            bytes[dst++] = ((px ushr 16) and 0xFF).toByte()
+            bytes[dst++] = ((px ushr 24) and 0xFF).toByte()
+        }
+        val image =
+            Image.makeRaster(
+                ImageInfo(w, h, ColorType.BGRA_8888, ColorAlphaType.PREMUL),
+                bytes,
+                rowBytes = w * 4,
+            )
+        val sliceL = ((marginLeft + maxRadius + SLICE_SAFETY) * scale).roundToInt()
+        val sliceT = ((marginTop + maxRadius + SLICE_SAFETY) * scale).roundToInt()
+        val sliceR = w - ((marginRight + maxRadius + SLICE_SAFETY) * scale).roundToInt()
+        val sliceB = h - ((marginBottom + maxRadius + SLICE_SAFETY) * scale).roundToInt()
+        val result = CachedImage(image, IRect.makeLTRB(sliceL, sliceT, sliceR, sliceB), scale)
+        images[key] = result
+        return result
+    }
+
+    private fun clearImages() {
+        for (cached in images.values) cached.image.close()
+        images.clear()
+    }
+
+    fun dispose() {
+        clearImages()
+        active = false
+    }
+
+    private companion object {
+        /** GTK4 gtkwindow.c: `#define RESIZE_HANDLE_SIZE 12`. */
+        const val RESIZE_HANDLE_SIZE = 12
+
+        /** Adwaita `$backdrop_transition: 200ms ease-out`. */
+        const val BACKDROP_TRANSITION_MS = 200f
+
+        /** Extents probe: visible core size and per-side room, logical px. */
+        const val PROBE_CORE = 40
+        const val PROBE_MARGIN = 100
+
+        /** Corner-block padding and stretchable centre strip, logical px. */
+        const val SLICE_SAFETY = 2
+        const val CENTER_STRIP = 4
+    }
+}

--- a/decorated-window-tao/src/main/native/linux/build.sh
+++ b/decorated-window-tao/src/main/native/linux/build.sh
@@ -107,7 +107,8 @@ build_widget() {
     local OUT="$OUT_DIR/libnucleus_tao_linux_widget.so"
     "$CC" -shared -fPIC -O2 -fvisibility=hidden \
         -I"$JNI_INCLUDE" -I"$JNI_INCLUDE_LINUX" \
-        "$SCRIPT_DIR/nucleus_tao_linux_widget.c" -ldl \
+        "$SCRIPT_DIR/nucleus_tao_linux_widget.c" \
+        "$SCRIPT_DIR/nucleus_tao_linux_shadow.c" -ldl -lm \
         -o "$OUT"
     strip --strip-unneeded "$OUT" || true
 }

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_shadow.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_shadow.c
@@ -1,0 +1,544 @@
+/**
+ * JNI bridge: GTK client-side-decoration drop shadow, rendered from the
+ * live GTK 3 theme for the Tao backend's undecorated windows.
+ *
+ * Replicates the mechanism GTK uses for its own CSD windows
+ * (gtk/gtkwindow.c `get_shadow_width` + gtkcssshadowvalue.c painting):
+ *
+ *   1. The theme's `decoration` CSS node (`window.csd > decoration`) is
+ *      rendered off-screen with gtk_render_background/_frame into a cairo
+ *      ARGB32 surface, for both the NORMAL and BACKDROP states — so the
+ *      shadow matches whatever theme the user runs (Adwaita, Yaru, ...)
+ *      including the `:backdrop` fade GTK animates on focus loss.
+ *   2. The invisible margin around the visible frame is declared to the
+ *      window manager through gdk_window_set_shadow_width(), which is the
+ *      exact call GTK makes internally: `_GTK_FRAME_EXTENTS` on X11,
+ *      xdg_surface.set_window_geometry margins on Wayland. Tiling,
+ *      snapping and maximization then use the visible frame only.
+ *   3. The input shape is shrunk to the visible frame plus a 12 px resize
+ *      ring (GTK4's RESIZE_HANDLE_SIZE), so clicks in the outer shadow
+ *      fall through to the window below.
+ *
+ * The Kotlin side (TaoWindowShadowLinux) uploads the rendered pixels as
+ * Skia images, nine-slices them into the window margins each frame and
+ * cross-fades normal <-> backdrop over 200 ms on focus change, mirroring
+ * Adwaita's `transition: 200ms ease-out`.
+ *
+ * Compiled into libnucleus_tao_linux_widget.so (see build.sh). Same
+ * dlopen-only linkage policy as nucleus_tao_linux_widget.c: no link-time
+ * GTK dependency.
+ *
+ * Threading: every entry point must run on the GTK main thread (= Tao
+ * event-loop thread = Compose dispatcher thread).
+ */
+
+#include <jni.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+typedef int      gint;
+typedef int      gboolean;
+typedef char     gchar;
+typedef unsigned long gulong;
+typedef void     GtkWidget;
+typedef void     GtkWindow;
+typedef void     GdkWindow;
+typedef void     GdkScreen;
+typedef void     GdkVisual;
+typedef void     GtkWidgetPath;
+typedef void     GtkStyleContext;
+typedef void     GtkCssProvider;
+typedef void     GtkSettings;
+typedef void     GError;
+typedef void    *GdkAtom;
+typedef gulong   GType;
+typedef unsigned int GtkStateFlags;
+typedef void     cairo_surface_t;
+typedef void     cairo_t;
+typedef void     cairo_region_t;
+
+typedef struct {
+    int x;
+    int y;
+    int width;
+    int height;
+} cairo_rectangle_int_t;
+
+/* GTypeInstance fundamental constant: G_TYPE_NONE == (1 << 2). Appending it
+ * to a widget path creates the anonymous element GTK names via
+ * set_object_name — how GTK models the `decoration` CSS node. */
+#define G_TYPE_NONE_CONST ((GType) (1 << 2))
+#define GTK_STATE_FLAG_BACKDROP (1 << 6)
+#define GTK_STYLE_PROVIDER_PRIORITY_USER 800
+#define CAIRO_FORMAT_ARGB32 0
+
+typedef GdkWindow       *(*PFN_gtk_widget_get_window)(GtkWidget *w);
+typedef GType            (*PFN_gtk_window_get_type)(void);
+typedef GtkWidgetPath   *(*PFN_gtk_widget_path_new)(void);
+typedef gint             (*PFN_gtk_widget_path_append_type)(GtkWidgetPath *p, GType type);
+typedef void             (*PFN_gtk_widget_path_iter_set_object_name)(GtkWidgetPath *p, gint pos, const char *name);
+typedef void             (*PFN_gtk_widget_path_iter_add_class)(GtkWidgetPath *p, gint pos, const char *name);
+typedef void             (*PFN_gtk_widget_path_iter_set_state)(GtkWidgetPath *p, gint pos, GtkStateFlags state);
+typedef void             (*PFN_gtk_widget_path_free)(GtkWidgetPath *p);
+typedef GtkStyleContext *(*PFN_gtk_style_context_new)(void);
+typedef void             (*PFN_gtk_style_context_set_screen)(GtkStyleContext *c, GdkScreen *s);
+typedef void             (*PFN_gtk_style_context_set_path)(GtkStyleContext *c, GtkWidgetPath *p);
+typedef void             (*PFN_gtk_style_context_set_state)(GtkStyleContext *c, GtkStateFlags state);
+typedef void             (*PFN_gtk_style_context_add_provider)(GtkStyleContext *c, void *provider, unsigned int priority);
+typedef GtkCssProvider  *(*PFN_gtk_css_provider_new)(void);
+typedef gboolean         (*PFN_gtk_css_provider_load_from_data)(GtkCssProvider *p, const gchar *data, long length, GError **error);
+typedef void             (*PFN_gtk_render_background)(GtkStyleContext *c, cairo_t *cr, double x, double y, double w, double h);
+typedef void             (*PFN_gtk_render_frame)(GtkStyleContext *c, cairo_t *cr, double x, double y, double w, double h);
+typedef GtkSettings     *(*PFN_gtk_settings_get_default)(void);
+
+typedef GdkScreen       *(*PFN_gdk_screen_get_default)(void);
+typedef gboolean         (*PFN_gdk_screen_is_composited)(GdkScreen *s);
+typedef GdkVisual       *(*PFN_gdk_screen_get_rgba_visual)(GdkScreen *s);
+typedef void             (*PFN_gdk_window_set_shadow_width)(GdkWindow *w, int left, int right, int top, int bottom);
+typedef void             (*PFN_gdk_window_input_shape_combine_region)(GdkWindow *w, const cairo_region_t *region, gint ox, gint oy);
+typedef GdkAtom          (*PFN_gdk_atom_intern_static_string)(const gchar *name);
+typedef gboolean         (*PFN_gdk_x11_screen_supports_net_wm_hint)(GdkScreen *s, GdkAtom property);
+
+typedef cairo_surface_t *(*PFN_cairo_image_surface_create)(int format, int width, int height);
+typedef void             (*PFN_cairo_surface_set_device_scale)(cairo_surface_t *s, double sx, double sy);
+typedef cairo_t         *(*PFN_cairo_create)(cairo_surface_t *s);
+typedef void             (*PFN_cairo_destroy)(cairo_t *cr);
+typedef void             (*PFN_cairo_surface_flush)(cairo_surface_t *s);
+typedef unsigned char   *(*PFN_cairo_image_surface_get_data)(cairo_surface_t *s);
+typedef int              (*PFN_cairo_image_surface_get_stride)(cairo_surface_t *s);
+typedef void             (*PFN_cairo_surface_destroy)(cairo_surface_t *s);
+typedef cairo_region_t  *(*PFN_cairo_region_create_rectangle)(const cairo_rectangle_int_t *rect);
+typedef void             (*PFN_cairo_region_destroy)(cairo_region_t *r);
+
+typedef unsigned int     (*PFN_gdk_window_get_state)(GdkWindow *w);
+
+typedef void             (*PFN_g_object_get)(void *obj, const char *first_prop, ...);
+typedef void             (*PFN_g_object_unref)(void *obj);
+typedef void             (*PFN_g_free)(void *mem);
+typedef void            *(*PFN_g_object_get_data)(void *obj, const char *key);
+typedef void             (*PFN_g_object_set_data_full)(
+    void *obj, const char *key, void *data, void (*destroy)(void *));
+typedef gulong           (*PFN_g_signal_connect_data)(
+    void *instance, const char *signal, void (*handler)(void), void *data,
+    void (*destroy)(void *, void *), int connect_flags);
+
+static struct {
+    int initialized;
+    PFN_gtk_widget_get_window                 gtk_widget_get_window;
+    PFN_gtk_window_get_type                   gtk_window_get_type;
+    PFN_gtk_widget_path_new                   gtk_widget_path_new;
+    PFN_gtk_widget_path_append_type           gtk_widget_path_append_type;
+    PFN_gtk_widget_path_iter_set_object_name  gtk_widget_path_iter_set_object_name;
+    PFN_gtk_widget_path_iter_add_class        gtk_widget_path_iter_add_class;
+    PFN_gtk_widget_path_iter_set_state        gtk_widget_path_iter_set_state;
+    PFN_gtk_widget_path_free                  gtk_widget_path_free;
+    PFN_gtk_style_context_new                 gtk_style_context_new;
+    PFN_gtk_style_context_set_screen          gtk_style_context_set_screen;
+    PFN_gtk_style_context_set_path            gtk_style_context_set_path;
+    PFN_gtk_style_context_set_state           gtk_style_context_set_state;
+    PFN_gtk_style_context_add_provider        gtk_style_context_add_provider;
+    PFN_gtk_css_provider_new                  gtk_css_provider_new;
+    PFN_gtk_css_provider_load_from_data       gtk_css_provider_load_from_data;
+    PFN_gtk_render_background                 gtk_render_background;
+    PFN_gtk_render_frame                      gtk_render_frame;
+    PFN_gtk_settings_get_default              gtk_settings_get_default;
+    PFN_gdk_screen_get_default                gdk_screen_get_default;
+    PFN_gdk_screen_is_composited              gdk_screen_is_composited;
+    PFN_gdk_screen_get_rgba_visual            gdk_screen_get_rgba_visual;
+    PFN_gdk_window_set_shadow_width           gdk_window_set_shadow_width;
+    PFN_gdk_window_input_shape_combine_region gdk_window_input_shape_combine_region;
+    PFN_gdk_atom_intern_static_string         gdk_atom_intern_static_string;
+    PFN_gdk_x11_screen_supports_net_wm_hint   gdk_x11_screen_supports_net_wm_hint; /* optional */
+    PFN_cairo_image_surface_create            cairo_image_surface_create;
+    PFN_cairo_surface_set_device_scale        cairo_surface_set_device_scale;
+    PFN_cairo_create                          cairo_create;
+    PFN_cairo_destroy                         cairo_destroy;
+    PFN_cairo_surface_flush                   cairo_surface_flush;
+    PFN_cairo_image_surface_get_data          cairo_image_surface_get_data;
+    PFN_cairo_image_surface_get_stride        cairo_image_surface_get_stride;
+    PFN_cairo_surface_destroy                 cairo_surface_destroy;
+    PFN_cairo_region_create_rectangle         cairo_region_create_rectangle;
+    PFN_cairo_region_destroy                  cairo_region_destroy;
+    PFN_gdk_window_get_state                  gdk_window_get_state;
+    PFN_g_object_get                          g_object_get;
+    PFN_g_object_unref                        g_object_unref;
+    PFN_g_free                                g_free;
+    PFN_g_object_get_data                     g_object_get_data;
+    PFN_g_object_set_data_full                g_object_set_data_full;
+    PFN_g_signal_connect_data                 g_signal_connect_data;
+} s;
+
+static void *shadow_load_first(const char *const *names) {
+    for (int i = 0; names[i] != NULL; i++) {
+        void *h = dlopen(names[i], RTLD_NOW | RTLD_GLOBAL);
+        if (h != NULL) return h;
+    }
+    return NULL;
+}
+
+static int shadow_ensure_loaded(void) {
+    if (s.initialized) return 1;
+    const char *gtk_libs[]   = { "libgtk-3.so.0", "libgtk-3.so", NULL };
+    const char *gdk_libs[]   = { "libgdk-3.so.0", "libgdk-3.so", NULL };
+    const char *gobj_libs[]  = { "libgobject-2.0.so.0", "libgobject-2.0.so", NULL };
+    const char *glib_libs[]  = { "libglib-2.0.so.0", "libglib-2.0.so", NULL };
+    const char *cairo_libs[] = { "libcairo.so.2", "libcairo.so", NULL };
+    void *libgtk   = shadow_load_first(gtk_libs);
+    void *libgdk   = shadow_load_first(gdk_libs);
+    void *libgobj  = shadow_load_first(gobj_libs);
+    void *libglib  = shadow_load_first(glib_libs);
+    void *libcairo = shadow_load_first(cairo_libs);
+    if (!libgtk || !libgdk || !libgobj || !libglib || !libcairo) return 0;
+
+    s.gtk_widget_get_window                = (PFN_gtk_widget_get_window)                dlsym(libgtk, "gtk_widget_get_window");
+    s.gtk_window_get_type                  = (PFN_gtk_window_get_type)                  dlsym(libgtk, "gtk_window_get_type");
+    s.gtk_widget_path_new                  = (PFN_gtk_widget_path_new)                  dlsym(libgtk, "gtk_widget_path_new");
+    s.gtk_widget_path_append_type          = (PFN_gtk_widget_path_append_type)          dlsym(libgtk, "gtk_widget_path_append_type");
+    s.gtk_widget_path_iter_set_object_name = (PFN_gtk_widget_path_iter_set_object_name) dlsym(libgtk, "gtk_widget_path_iter_set_object_name");
+    s.gtk_widget_path_iter_add_class       = (PFN_gtk_widget_path_iter_add_class)       dlsym(libgtk, "gtk_widget_path_iter_add_class");
+    s.gtk_widget_path_iter_set_state       = (PFN_gtk_widget_path_iter_set_state)       dlsym(libgtk, "gtk_widget_path_iter_set_state");
+    s.gtk_widget_path_free                 = (PFN_gtk_widget_path_free)                 dlsym(libgtk, "gtk_widget_path_free");
+    s.gtk_style_context_new                = (PFN_gtk_style_context_new)                dlsym(libgtk, "gtk_style_context_new");
+    s.gtk_style_context_set_screen         = (PFN_gtk_style_context_set_screen)         dlsym(libgtk, "gtk_style_context_set_screen");
+    s.gtk_style_context_set_path           = (PFN_gtk_style_context_set_path)           dlsym(libgtk, "gtk_style_context_set_path");
+    s.gtk_style_context_set_state          = (PFN_gtk_style_context_set_state)          dlsym(libgtk, "gtk_style_context_set_state");
+    s.gtk_style_context_add_provider       = (PFN_gtk_style_context_add_provider)       dlsym(libgtk, "gtk_style_context_add_provider");
+    s.gtk_css_provider_new                 = (PFN_gtk_css_provider_new)                 dlsym(libgtk, "gtk_css_provider_new");
+    s.gtk_css_provider_load_from_data      = (PFN_gtk_css_provider_load_from_data)      dlsym(libgtk, "gtk_css_provider_load_from_data");
+    s.gtk_render_background                = (PFN_gtk_render_background)                dlsym(libgtk, "gtk_render_background");
+    s.gtk_render_frame                     = (PFN_gtk_render_frame)                     dlsym(libgtk, "gtk_render_frame");
+    s.gtk_settings_get_default             = (PFN_gtk_settings_get_default)             dlsym(libgtk, "gtk_settings_get_default");
+
+    s.gdk_screen_get_default                = (PFN_gdk_screen_get_default)                dlsym(libgdk, "gdk_screen_get_default");
+    s.gdk_screen_is_composited              = (PFN_gdk_screen_is_composited)              dlsym(libgdk, "gdk_screen_is_composited");
+    s.gdk_screen_get_rgba_visual            = (PFN_gdk_screen_get_rgba_visual)            dlsym(libgdk, "gdk_screen_get_rgba_visual");
+    s.gdk_window_set_shadow_width           = (PFN_gdk_window_set_shadow_width)           dlsym(libgdk, "gdk_window_set_shadow_width");
+    s.gdk_window_input_shape_combine_region = (PFN_gdk_window_input_shape_combine_region) dlsym(libgdk, "gdk_window_input_shape_combine_region");
+    s.gdk_atom_intern_static_string         = (PFN_gdk_atom_intern_static_string)         dlsym(libgdk, "gdk_atom_intern_static_string");
+    /* X11-only entry point; absent on X11-less GDK builds. Checked at use. */
+    s.gdk_x11_screen_supports_net_wm_hint   = (PFN_gdk_x11_screen_supports_net_wm_hint)   dlsym(libgdk, "gdk_x11_screen_supports_net_wm_hint");
+
+    s.cairo_image_surface_create     = (PFN_cairo_image_surface_create)     dlsym(libcairo, "cairo_image_surface_create");
+    s.cairo_surface_set_device_scale = (PFN_cairo_surface_set_device_scale) dlsym(libcairo, "cairo_surface_set_device_scale");
+    s.cairo_create                   = (PFN_cairo_create)                   dlsym(libcairo, "cairo_create");
+    s.cairo_destroy                  = (PFN_cairo_destroy)                  dlsym(libcairo, "cairo_destroy");
+    s.cairo_surface_flush            = (PFN_cairo_surface_flush)            dlsym(libcairo, "cairo_surface_flush");
+    s.cairo_image_surface_get_data   = (PFN_cairo_image_surface_get_data)   dlsym(libcairo, "cairo_image_surface_get_data");
+    s.cairo_image_surface_get_stride = (PFN_cairo_image_surface_get_stride) dlsym(libcairo, "cairo_image_surface_get_stride");
+    s.cairo_surface_destroy          = (PFN_cairo_surface_destroy)          dlsym(libcairo, "cairo_surface_destroy");
+    s.cairo_region_create_rectangle  = (PFN_cairo_region_create_rectangle)  dlsym(libcairo, "cairo_region_create_rectangle");
+    s.cairo_region_destroy           = (PFN_cairo_region_destroy)           dlsym(libcairo, "cairo_region_destroy");
+
+    s.gdk_window_get_state = (PFN_gdk_window_get_state) dlsym(libgdk, "gdk_window_get_state");
+
+    s.g_object_get          = (PFN_g_object_get)          dlsym(libgobj, "g_object_get");
+    s.g_object_unref        = (PFN_g_object_unref)        dlsym(libgobj, "g_object_unref");
+    s.g_free                = (PFN_g_free)                dlsym(libglib, "g_free");
+    s.g_object_get_data     = (PFN_g_object_get_data)     dlsym(libgobj, "g_object_get_data");
+    s.g_object_set_data_full = (PFN_g_object_set_data_full) dlsym(libgobj, "g_object_set_data_full");
+    s.g_signal_connect_data = (PFN_g_signal_connect_data) dlsym(libgobj, "g_signal_connect_data");
+
+    if (!s.gtk_widget_get_window || !s.gtk_window_get_type ||
+        !s.gtk_widget_path_new || !s.gtk_widget_path_append_type ||
+        !s.gtk_widget_path_iter_set_object_name ||
+        !s.gtk_widget_path_iter_add_class || !s.gtk_widget_path_iter_set_state ||
+        !s.gtk_widget_path_free || !s.gtk_style_context_new ||
+        !s.gtk_style_context_set_screen || !s.gtk_style_context_set_path ||
+        !s.gtk_style_context_set_state || !s.gtk_style_context_add_provider ||
+        !s.gtk_css_provider_new || !s.gtk_css_provider_load_from_data ||
+        !s.gtk_render_background || !s.gtk_render_frame ||
+        !s.gtk_settings_get_default || !s.gdk_screen_get_default ||
+        !s.gdk_screen_is_composited || !s.gdk_screen_get_rgba_visual ||
+        !s.gdk_window_set_shadow_width ||
+        !s.gdk_window_input_shape_combine_region ||
+        !s.gdk_atom_intern_static_string ||
+        !s.cairo_image_surface_create || !s.cairo_surface_set_device_scale ||
+        !s.cairo_create || !s.cairo_destroy || !s.cairo_surface_flush ||
+        !s.cairo_image_surface_get_data || !s.cairo_image_surface_get_stride ||
+        !s.cairo_surface_destroy || !s.cairo_region_create_rectangle ||
+        !s.cairo_region_destroy || !s.gdk_window_get_state ||
+        !s.g_object_get || !s.g_object_unref || !s.g_free ||
+        !s.g_object_get_data || !s.g_object_set_data_full ||
+        !s.g_signal_connect_data) {
+        return 0;
+    }
+    s.initialized = 1;
+    return 1;
+}
+
+/**
+ * Builds the style context GTK itself would use for a CSD window's
+ * decoration node: path `window.background.csd > decoration`, with
+ * GTK_STATE_FLAG_BACKDROP applied on both nodes for the unfocused variant
+ * and the `tiled` class on the window node for the snapped variant (themes
+ * select `.tiled decoration { ... }`).
+ *
+ * The caller owns the returned context (g_object_unref).
+ */
+static GtkStyleContext *shadow_make_decoration_context(int backdrop, int tiled) {
+    GtkWidgetPath *path = s.gtk_widget_path_new();
+    gint pos = s.gtk_widget_path_append_type(path, s.gtk_window_get_type());
+    s.gtk_widget_path_iter_set_object_name(path, pos, "window");
+    s.gtk_widget_path_iter_add_class(path, pos, "background");
+    s.gtk_widget_path_iter_add_class(path, pos, "csd");
+    if (tiled) s.gtk_widget_path_iter_add_class(path, pos, "tiled");
+    if (backdrop) s.gtk_widget_path_iter_set_state(path, pos, GTK_STATE_FLAG_BACKDROP);
+
+    pos = s.gtk_widget_path_append_type(path, G_TYPE_NONE_CONST);
+    s.gtk_widget_path_iter_set_object_name(path, pos, "decoration");
+    if (backdrop) s.gtk_widget_path_iter_set_state(path, pos, GTK_STATE_FLAG_BACKDROP);
+
+    GtkStyleContext *ctx = s.gtk_style_context_new();
+    s.gtk_style_context_set_screen(ctx, s.gdk_screen_get_default());
+    s.gtk_style_context_set_path(ctx, path);
+    s.gtk_style_context_set_state(ctx, backdrop ? GTK_STATE_FLAG_BACKDROP : 0);
+    s.gtk_widget_path_free(path);
+    return ctx;
+}
+
+/*
+ * Class:     dev_nucleusframework_window_tao_NativeTaoLinuxShadowBridge
+ * Method:    nativeShadowSupported
+ *
+ * Mirrors gtk_window_supports_client_shadow (gtk3 gtkwindow.c): running
+ * compositor + RGBA visual, and on X11 a WM advertising _GTK_FRAME_EXTENTS
+ * in _NET_SUPPORTED. kind: 1 = X11, 2 = Wayland.
+ */
+JNIEXPORT jboolean JNICALL
+Java_dev_nucleusframework_window_tao_NativeTaoLinuxShadowBridge_nativeShadowSupported(
+    JNIEnv *env, jclass clazz, jint kind) {
+    (void) env; (void) clazz;
+    if (!shadow_ensure_loaded()) return JNI_FALSE;
+    GdkScreen *screen = s.gdk_screen_get_default();
+    if (screen == NULL) return JNI_FALSE;
+    if (!s.gdk_screen_is_composited(screen)) return JNI_FALSE;
+    if (s.gdk_screen_get_rgba_visual(screen) == NULL) return JNI_FALSE;
+    if (kind == 1) {
+        if (s.gdk_x11_screen_supports_net_wm_hint == NULL) return JNI_FALSE;
+        GdkAtom atom = s.gdk_atom_intern_static_string("_GTK_FRAME_EXTENTS");
+        if (!s.gdk_x11_screen_supports_net_wm_hint(screen, atom)) return JNI_FALSE;
+    }
+    return JNI_TRUE;
+}
+
+/*
+ * Renders the themed decoration (shadow + 1px outline) around a visibleW x
+ * visibleH frame, with marginL/T/R/B logical pixels of room on each side,
+ * at the given device scale. Corner radii (logical px, TL/TR/BR/BL) are
+ * forced via a per-context USER-priority provider so the shadow hugs the
+ * same rounded shape the Skia carve applies to the content.
+ *
+ * Returns [widthPx, heightPx, pixel0, pixel1, ...] where pixels are
+ * row-major premultiplied ARGB32 (cairo native = Skia BGRA_8888 PREMUL on
+ * little-endian), or NULL on failure.
+ */
+JNIEXPORT jintArray JNICALL
+Java_dev_nucleusframework_window_tao_NativeTaoLinuxShadowBridge_nativeShadowRender(
+    JNIEnv *env, jclass clazz, jboolean backdrop, jboolean tiled,
+    jint visibleW, jint visibleH,
+    jint marginL, jint marginT, jint marginR, jint marginB,
+    jfloat scale, jfloat radTL, jfloat radTR, jfloat radBR, jfloat radBL) {
+    (void) clazz;
+    if (!shadow_ensure_loaded()) return NULL;
+    if (visibleW <= 0 || visibleH <= 0 || scale <= 0.0f) return NULL;
+
+    const int pw = (int) ceil((visibleW + marginL + marginR) * (double) scale);
+    const int ph = (int) ceil((visibleH + marginT + marginB) * (double) scale);
+    if (pw <= 0 || ph <= 0 || pw > 8192 || ph > 8192) return NULL;
+
+    GtkStyleContext *ctx = shadow_make_decoration_context(backdrop, tiled);
+
+    /* Integer formatting only: %f obeys LC_NUMERIC and a comma decimal
+     * separator (e.g. fr_FR) is a CSS parse error. */
+    char css[192];
+    snprintf(css, sizeof(css),
+             "decoration { border-radius: %dpx %dpx %dpx %dpx; }",
+             (int) lround((double) radTL), (int) lround((double) radTR),
+             (int) lround((double) radBR), (int) lround((double) radBL));
+    GtkCssProvider *provider = s.gtk_css_provider_new();
+    if (s.gtk_css_provider_load_from_data(provider, css, -1, NULL)) {
+        s.gtk_style_context_add_provider(ctx, provider, GTK_STYLE_PROVIDER_PRIORITY_USER);
+    }
+
+    cairo_surface_t *surface = s.cairo_image_surface_create(CAIRO_FORMAT_ARGB32, pw, ph);
+    s.cairo_surface_set_device_scale(surface, scale, scale);
+    cairo_t *cr = s.cairo_create(surface);
+    /* Outset box-shadows are painted by the background pass (GTK3
+     * gtkrenderbackground.c paints them outside the border box before the
+     * background itself); the frame pass adds CSS borders if the theme has
+     * any on the decoration node. */
+    s.gtk_render_background(ctx, cr, marginL, marginT, visibleW, visibleH);
+    s.gtk_render_frame(ctx, cr, marginL, marginT, visibleW, visibleH);
+    s.cairo_destroy(cr);
+    s.cairo_surface_flush(surface);
+
+    const unsigned char *data = s.cairo_image_surface_get_data(surface);
+    const int stride = s.cairo_image_surface_get_stride(surface);
+    jintArray out = NULL;
+    if (data != NULL) {
+        out = (*env)->NewIntArray(env, 2 + pw * ph);
+        if (out != NULL) {
+            jint header[2] = { pw, ph };
+            (*env)->SetIntArrayRegion(env, out, 0, 2, header);
+            for (int row = 0; row < ph; row++) {
+                (*env)->SetIntArrayRegion(env, out, 2 + row * pw, pw,
+                                          (const jint *) (data + (size_t) row * stride));
+            }
+        }
+    }
+
+    s.cairo_surface_destroy(surface);
+    s.g_object_unref(provider);
+    s.g_object_unref(ctx);
+    return out;
+}
+
+/* ── WM margin declaration, synchronized with the window state ──────────
+ *
+ * GTK zeroes its shadow width the moment the window turns maximized /
+ * fullscreen / tiled and restores it on the way back, synchronously inside
+ * the window-state-event dispatch — BEFORE the next surface commit. Doing
+ * this a frame later (from the render loop) is too late on Wayland: the
+ * committed xdg geometry disagrees with the compositor's configure during
+ * a maximize/snap transition and mutter visibly fights the window. So the
+ * desired margins are stashed on the GtkWindow and a window-state-event
+ * handler applies the effective value with GTK's exact timing. */
+
+typedef struct {
+    int l;
+    int t;
+    int r;
+    int b;
+    /* Last effective suspend decision: -1 unknown, 0 margins, 1 zeroed.
+     * window-state-event also fires for focus-only changes; re-calling
+     * gdk_window_set_shadow_width with unchanged values must be avoided. */
+    int suspended;
+} ShadowMargins;
+
+static const char *SHADOW_MARGINS_KEY = "nucleus-shadow-margins";
+
+/* GdkWindowState: MAXIMIZED | FULLSCREEN | TILED | TOP/RIGHT/BOTTOM/LEFT_TILED. */
+#define SHADOW_STATE_SUSPEND_MASK \
+    ((1u << 2) | (1u << 4) | (1u << 8) | (1u << 9) | (1u << 11) | (1u << 13) | (1u << 15))
+
+/* Prefix of GdkEventWindowState — enough to reach new_window_state.
+ * Layout on LP64: type @0, window @8, send_event @16, changed_mask @20,
+ * new_window_state @24. */
+typedef struct {
+    int type;
+    void *window;
+    signed char send_event;
+    unsigned int changed_mask;
+    unsigned int new_window_state;
+} ShadowGdkEventWindowState;
+
+static void shadow_apply_effective(GtkWidget *widget, unsigned int state) {
+    ShadowMargins *m = s.g_object_get_data(widget, SHADOW_MARGINS_KEY);
+    GdkWindow *gdk_window = s.gtk_widget_get_window(widget);
+    if (m == NULL || gdk_window == NULL) return;
+    const int suspended = (state & SHADOW_STATE_SUSPEND_MASK) != 0;
+    if (suspended == m->suspended) return;
+    m->suspended = suspended;
+    if (suspended) {
+        s.gdk_window_set_shadow_width(gdk_window, 0, 0, 0, 0);
+    } else {
+        s.gdk_window_set_shadow_width(gdk_window, m->l, m->r, m->t, m->b);
+    }
+}
+
+static gboolean shadow_on_window_state_event(GtkWidget *widget, void *event, void *user_data) {
+    (void) user_data;
+    if (event != NULL) {
+        const ShadowGdkEventWindowState *ev = (const ShadowGdkEventWindowState *) event;
+        shadow_apply_effective(widget, ev->new_window_state);
+    }
+    return 0; /* propagate */
+}
+
+/*
+ * Declares the invisible shadow margin to the window manager — the exact
+ * internal GTK call: _GTK_FRAME_EXTENTS (scaled to device px by GDK) on
+ * X11, per-side margins + xdg_surface.set_window_geometry on Wayland (where
+ * GDK also grows the surface to keep the visible geometry stable). Margins
+ * are logical pixels; they auto-suspend while maximized/fullscreen/tiled
+ * (see shadow_on_window_state_event above).
+ */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_NativeTaoLinuxShadowBridge_nativeShadowApply(
+    JNIEnv *env, jclass clazz, jlong gtkWindowPtr,
+    jint marginL, jint marginT, jint marginR, jint marginB) {
+    (void) env; (void) clazz;
+    if (!shadow_ensure_loaded() || gtkWindowPtr == 0) return;
+    GtkWidget *widget = (GtkWidget *) (intptr_t) gtkWindowPtr;
+    GdkWindow *gdk_window = s.gtk_widget_get_window(widget);
+    if (gdk_window == NULL) return;
+
+    ShadowMargins *margins = (ShadowMargins *) malloc(sizeof(ShadowMargins));
+    if (margins == NULL) return;
+    margins->l = marginL;
+    margins->t = marginT;
+    margins->r = marginR;
+    margins->b = marginB;
+    margins->suspended = -1;
+    const int first = s.g_object_get_data(widget, SHADOW_MARGINS_KEY) == NULL;
+    s.g_object_set_data_full(widget, SHADOW_MARGINS_KEY, margins, free);
+    if (first) {
+        s.g_signal_connect_data(widget, "window-state-event",
+                                (void (*)(void)) shadow_on_window_state_event,
+                                NULL, NULL, 0);
+    }
+    shadow_apply_effective(widget, s.gdk_window_get_state(gdk_window));
+}
+
+/*
+ * Restricts the window's input region to the given logical rect (the
+ * visible frame inflated by the 12 px resize ring — GTK4's
+ * RESIZE_HANDLE_SIZE) so clicks in the outer shadow fall through to
+ * whatever is below. Pass width < 0 to reset to the full surface.
+ */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_NativeTaoLinuxShadowBridge_nativeShadowSetInputShape(
+    JNIEnv *env, jclass clazz, jlong gtkWindowPtr,
+    jint x, jint y, jint width, jint height) {
+    (void) env; (void) clazz;
+    if (!shadow_ensure_loaded() || gtkWindowPtr == 0) return;
+    GdkWindow *gdk_window = s.gtk_widget_get_window((GtkWidget *) (intptr_t) gtkWindowPtr);
+    if (gdk_window == NULL) return;
+    if (width < 0) {
+        s.gdk_window_input_shape_combine_region(gdk_window, NULL, 0, 0);
+        return;
+    }
+    cairo_rectangle_int_t rect = { x, y, width, height };
+    cairo_region_t *region = s.cairo_region_create_rectangle(&rect);
+    s.gdk_window_input_shape_combine_region(gdk_window, region, 0, 0);
+    s.cairo_region_destroy(region);
+}
+
+/*
+ * Cheap change-detection key for the shadow image cache: theme name +
+ * dark preference. A live theme switch (or dark-mode toggle) changes the
+ * stamp; the Kotlin side then re-renders its cached shadow images.
+ */
+JNIEXPORT jstring JNICALL
+Java_dev_nucleusframework_window_tao_NativeTaoLinuxShadowBridge_nativeShadowThemeStamp(
+    JNIEnv *env, jclass clazz) {
+    (void) clazz;
+    if (!shadow_ensure_loaded()) return NULL;
+    GtkSettings *settings = s.gtk_settings_get_default();
+    if (settings == NULL) return NULL;
+    gchar *name = NULL;
+    gboolean dark = 0;
+    s.g_object_get(settings,
+                   "gtk-theme-name", &name,
+                   "gtk-application-prefer-dark-theme", &dark,
+                   NULL);
+    char stamp[256];
+    snprintf(stamp, sizeof(stamp), "%s|%d", name != NULL ? name : "?", dark ? 1 : 0);
+    if (name != NULL) s.g_free(name);
+    return (*env)->NewStringUTF(env, stamp);
+}

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -336,6 +336,10 @@
             "jniAccessible": true
         },
         {
+            "type": "dev.nucleusframework.window.tao.NativeTaoLinuxShadowBridge",
+            "jniAccessible": true
+        },
+        {
             "type": "dev.nucleusframework.window.tao.NativeTaoLinuxWidgetBridge$OverlayInputCallback",
             "jniAccessible": true,
             "methods": [


### PR DESCRIPTION
## Summary

Reproduces GTK's client-side decoration (CSD) drop shadow for the Tao backend's undecorated Linux windows — the same mechanism GTK uses for its own CSD windows, including the shadow that fades to `backdrop` when the window loses focus.

- **Theme-driven rendering**: render the live theme's `window.csd > decoration` CSS node off-screen via GTK itself (native look across Adwaita/Yaru/Breeze, including the 1px window outline), then nine-slice it into the window margins each frame — mirroring `gtkcssshadowvalue.c`'s cached blurred corner masks + repeated side strips (`_gtk_css_shadow_value_paint_box`).
- **WM margin declaration**: declare the invisible shadow margin the way GTK does — `_GTK_FRAME_EXTENTS` on X11 (`gdk_window_set_shadow_width`) and `xdg_surface.set_window_geometry` on Wayland (GDK grows the surface to keep the visible geometry stable). A `window-state-event` handler zeroes/restores the margin **synchronously** on maximize/fullscreen/tile; a frame-later update makes mutter fight the window during a snap.
- **Focus cross-fade**: 200ms ease-out fade to the `decoration:backdrop` rendering (Adwaita's `transition: $backdrop_transition`). Margins are identical in both states (themes keep a transparent placeholder shadow), so the window never jumps.
- **Input shape**: visible frame + 12px resize ring (GTK4 `RESIZE_HANDLE_SIZE`), so clicks in the outer shadow fall through; the resize hit-test extends into the margin.
- **Compositor-grab masking**: focus loss during a compositor resize/move grab is masked so the focused shadow stays for the whole drag — the grab is talking, not the user switching windows.

`dlopen`-only GTK/cairo bindings in a new `nucleus_tao_linux_shadow.c`; GraalVM reachability metadata declares the JNI bridge. AWT backend untouched (out of scope).

## Test plan

- [x] `:decorated-window-tao:compileKotlin` passes
- [x] Shadow files are detekt/ktlint clean (pre-existing violations in unrelated files — `NucleusPlatformViewFactory.kt`, hot-reload WIP — are not touched by this PR)
- [ ] Run `nucleus-demo` on Wayland: shadow renders with the active GTK theme, fades over 200ms on focus loss, restores on focus gain
- [ ] Run `nucleus-demo` on X11 (`NUCLEUS_TAO_LINUX_RENDERER=x11`): shadow renders; `_GTK_FRAME_EXTENTS` honored (maximize lands in workarea, not workarea+extents)
- [ ] Resize drag (mouse + touch): focused shadow stays for the whole drag (focus loss masked)
- [ ] Title-bar move drag: focused shadow stays for the whole drag
- [ ] Snap to screen edge: margins drop cleanly, no window jitter/fighting with mutter
- [ ] Maximize / fullscreen / tile: margins zero, no shadow; restore brings shadow back
- [ ] Corner rounding matches the content carve; bottom corners stay rounded after resize
- [ ] Non-fr_FR locale sanity check (shadow CSS radius formatted with integers, not `%.1f`)