### PR TITLE
feat(decorated-window-tao): integrate Compose Hot Reload

### DIFF
--- a/decorated-window-tao/build.gradle.kts
+++ b/decorated-window-tao/build.gradle.kts
@@ -19,6 +19,16 @@ dependencies {
     api(project(":decorated-window-core"))
     implementation(project(":core-runtime"))
     implementation(libs.compose.desktop.common)
+    // Compose Hot Reload interop (TaoHotReloadBridge). compileOnly: these
+    // artifacts are only referenced when running under the hot-reload agent,
+    // which puts them on the runtime classpath itself (the plugin adds
+    // runtime-jvm — which brings devtools-api — and the agent jar brings the
+    // `agent`/`core`/`orchestration` classes). Used only by `trackWindow`
+    // (WindowsState / orchestration publishing), not by any wrapping.
+    compileOnly(libs.hot.reload.agent)
+    compileOnly(libs.hot.reload.core)
+    compileOnly(libs.hot.reload.orchestration)
+    compileOnly(libs.hot.reload.devtools.api)
     testImplementation(kotlin("test"))
     // Skiko native runtime for the opt-in real-window smoke test
     testImplementation(compose.desktop.currentOs)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/DecoratedWindow.kt
@@ -186,6 +186,21 @@ internal fun ApplicationScope.openDecoratedWindow(
             skipTaskbar = hiddenFromDock,
         )
 
+    // Compose Hot Reload: the agent only auto-wraps AWT `ComposeWindow`/
+    // `ComposeDialog` `setContent` — Tao owns its own windows, so we wrap the
+    // scene content in `DevelopmentEntryPoint` ourselves, and publish this
+    // window's geometry into the orchestration `WindowsState` so the dev-tools
+    // sidecar can follow it. Both no-op when not running under the hot-reload
+    // agent. See [TaoHotReloadIntegration].
+    val hotReloadContent: @Composable TaoDecoratedWindowScope.() -> Unit = {
+        TaoHotReloadIntegration.wrapContent { content() }
+    }
+    // Popups (popupFor != null) are transient overlays; the sidecar tracks
+    // only real windows/dialogs, matching Compose Hot Reload's AWT tracker.
+    if (popupFor == null) {
+        TaoHotReloadIntegration.trackWindow(window, title, alwaysOnTop)
+    }
+
     if (Platform.Current == Platform.Windows) {
         return openDecoratedWindowWindows(
             window,
@@ -203,7 +218,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             onKeyEvent,
             initialCompositionLocalContext,
             nativePopupLayers,
-            content,
+            hotReloadContent,
         )
     }
 
@@ -225,7 +240,7 @@ internal fun ApplicationScope.openDecoratedWindow(
             onKeyEvent,
             initialCompositionLocalContext,
             nativePopupLayers,
-            content,
+            hotReloadContent,
         )
     }
 
@@ -337,7 +352,7 @@ internal fun ApplicationScope.openDecoratedWindow(
                     }
                 }
                 Column(modifier = Modifier.fillMaxSize()) {
-                    scopeFactory().content()
+                    scopeFactory().hotReloadContent()
                 }
             }
         }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoHotReloadBridgeImpl.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoHotReloadBridgeImpl.kt
@@ -25,15 +25,41 @@ import kotlin.math.roundToInt
  * pixels the dev-tools sidecar expects (matching AWT's `window.x/width`, which
  * `startWindowManager` sends verbatim). Fractional HiDPI scales may drift a
  * few pixels; integer scales are exact.
+ *
+ * Version-skew safety: this class compiles against the catalog's hot-reload
+ * version, but the runtime classes come from whatever agent the user's Compose
+ * plugin launched — and the orchestration API is not binary-stable across
+ * releases (e.g. `WindowsState.WindowState` gained a `title` parameter in
+ * 1.2.0 and dropped the old constructor). Every entry point is guarded: the
+ * first [LinkageError] (or any other failure) permanently disables tracking
+ * for that window, so the sidecar merely stops following it — the app itself
+ * must never be taken down by dev tooling.
  */
 internal class TaoHotReloadBridgeImpl : TaoHotReloadBridge {
 
     override fun trackWindow(window: TaoWindow, title: String?, alwaysOnTop: Boolean) {
+        // [title] is unused: WindowsState.WindowState has no title field in the
+        // hot-reload version bundled by Compose 1.11.x. Kept in the bridge
+        // surface so the call sites don't change when a newer API gains one.
         val windowId = WindowId.create()
         // Conflated channel: coalesce bursts of move/resize events (GTK fires
         // one per pixel of a drag) into a single WindowsState update, exactly
         // like the AWT tracker's `Channel.CONFLATED` + `conflate()`.
         val windowState = Channel<WindowsState.WindowState?>(Channel.CONFLATED)
+
+        // One-shot kill switch: flipped on the first failure inside a Tao
+        // callback (see class KDoc). Closing the channel also ends the pump.
+        var broken = false
+
+        fun guarded(block: () -> Unit) {
+            if (broken) return
+            try {
+                block()
+            } catch (t: Throwable) {
+                broken = true
+                windowState.close()
+            }
+        }
 
         // Pump channel → orchestration WindowsState. Runs on the orchestration
         // task's dispatcher (off the Tao main thread). `null` removes the
@@ -66,10 +92,8 @@ internal class TaoHotReloadBridgeImpl : TaoHotReloadBridge {
                 WindowsState.WindowState(
                     x = x, y = y, width = w, height = h,
                     isAlwaysOnTop = alwaysOnTop,
-                    title = title,
                 ),
             )
-            // Legacy message (deprecated, but older devtools still consume it).
             OrchestrationMessage.ApplicationWindowPositioned(
                 windowId, x, y, w, h, isAlwaysOnTop = alwaysOnTop,
             ).sendAsync()
@@ -84,20 +108,22 @@ internal class TaoHotReloadBridgeImpl : TaoHotReloadBridge {
         // the first meaningful broadcast happens via onResized (fires right
         // after onWindowReady with the mapped size). Still try once in case
         // geometry is already available.
-        broadcastActiveState()
+        guarded { broadcastActiveState() }
 
-        window.onMoved { _, _ -> broadcastActiveState() }
-        window.onResized { _, _ -> broadcastActiveState() }
+        window.onMoved { _, _ -> guarded { broadcastActiveState() } }
+        window.onResized { _, _ -> guarded { broadcastActiveState() } }
         window.onFocusChanged { focused ->
             if (focused) {
-                // Sidecar brings itself toFront() on this.
-                OrchestrationMessage.ApplicationWindowGainedFocus(windowId).sendAsync()
-                broadcastActiveState()
+                guarded {
+                    // Sidecar brings itself toFront() on this.
+                    OrchestrationMessage.ApplicationWindowGainedFocus(windowId).sendAsync()
+                    broadcastActiveState()
+                }
             }
         }
         window.onMinimizedChanged { minimized ->
-            if (minimized) broadcastGone() else broadcastActiveState()
+            guarded { if (minimized) broadcastGone() else broadcastActiveState() }
         }
-        window.onDestroyed { broadcastGone() }
+        window.onDestroyed { guarded { broadcastGone() } }
     }
 }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoHotReloadBridgeImpl.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoHotReloadBridgeImpl.kt
@@ -1,0 +1,103 @@
+package dev.nucleusframework.window.tao
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.consumeAsFlow
+import org.jetbrains.compose.devtools.api.WindowsState
+import org.jetbrains.compose.reload.agent.orchestration
+import org.jetbrains.compose.reload.agent.sendAsync
+import org.jetbrains.compose.reload.core.WindowId
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
+import kotlin.math.roundToInt
+
+/**
+ * Concrete [TaoHotReloadBridge], loaded reflectively by [TaoHotReloadIntegration]
+ * only when Compose Hot Reload is active (`compose.reload.isActive == "true"`),
+ * which is also when the hot-reload artifacts land on the runtime classpath.
+ *
+ * Mirrors `org.jetbrains.compose.reload.jvm.startWindowManager` (the AWT-based
+ * tracker in `hot-reload-runtime-jvm`), but driven by Tao window callbacks
+ * instead of `java.awt.Window` listeners — the Tao backend has no AWT windows
+ * for the agent's auto-instrumentation to attach to.
+ *
+ * Coordinates are converted from Tao's **physical** pixels to the **logical**
+ * pixels the dev-tools sidecar expects (matching AWT's `window.x/width`, which
+ * `startWindowManager` sends verbatim). Fractional HiDPI scales may drift a
+ * few pixels; integer scales are exact.
+ */
+internal class TaoHotReloadBridgeImpl : TaoHotReloadBridge {
+
+    override fun trackWindow(window: TaoWindow, title: String?, alwaysOnTop: Boolean) {
+        val windowId = WindowId.create()
+        // Conflated channel: coalesce bursts of move/resize events (GTK fires
+        // one per pixel of a drag) into a single WindowsState update, exactly
+        // like the AWT tracker's `Channel.CONFLATED` + `conflate()`.
+        val windowState = Channel<WindowsState.WindowState?>(Channel.CONFLATED)
+
+        // Pump channel → orchestration WindowsState. Runs on the orchestration
+        // task's dispatcher (off the Tao main thread). `null` removes the
+        // window (minimize/hide/destroy) — matches AWT's `broadcastGone`.
+        orchestration.subtask {
+            windowState.consumeAsFlow().conflate().collect { state ->
+                orchestration.update(WindowsState) { current ->
+                    val windows = if (state == null) {
+                        current.windows - windowId
+                    } else {
+                        current.windows + (windowId to state)
+                    }
+                    WindowsState(windows)
+                }
+            }
+        }
+
+        fun toLogical(physical: Int): Int = (physical / window.scaleFactor).roundToInt()
+
+        /** Reads the live outer rect and pushes a conflated state update. */
+        fun broadcastActiveState() {
+            val bounds = window.outerBoundsPx() ?: return
+            // [x, y, width, height] physical px → logical.
+            val x = toLogical(bounds[0].toInt())
+            val y = toLogical(bounds[1].toInt())
+            val w = toLogical(bounds[2].toInt())
+            val h = toLogical(bounds[3].toInt())
+            if (w <= 0 || h <= 0) return
+            windowState.trySendBlocking(
+                WindowsState.WindowState(
+                    x = x, y = y, width = w, height = h,
+                    isAlwaysOnTop = alwaysOnTop,
+                    title = title,
+                ),
+            )
+            // Legacy message (deprecated, but older devtools still consume it).
+            OrchestrationMessage.ApplicationWindowPositioned(
+                windowId, x, y, w, h, isAlwaysOnTop = alwaysOnTop,
+            ).sendAsync()
+        }
+
+        fun broadcastGone() {
+            windowState.trySendBlocking(null)
+            OrchestrationMessage.ApplicationWindowGone(windowId).sendAsync()
+        }
+
+        // Initial state: outerBoundsPx is null until the window is mapped, so
+        // the first meaningful broadcast happens via onResized (fires right
+        // after onWindowReady with the mapped size). Still try once in case
+        // geometry is already available.
+        broadcastActiveState()
+
+        window.onMoved { _, _ -> broadcastActiveState() }
+        window.onResized { _, _ -> broadcastActiveState() }
+        window.onFocusChanged { focused ->
+            if (focused) {
+                // Sidecar brings itself toFront() on this.
+                OrchestrationMessage.ApplicationWindowGainedFocus(windowId).sendAsync()
+                broadcastActiveState()
+            }
+        }
+        window.onMinimizedChanged { minimized ->
+            if (minimized) broadcastGone() else broadcastActiveState()
+        }
+        window.onDestroyed { broadcastGone() }
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoHotReloadIntegration.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoHotReloadIntegration.kt
@@ -1,0 +1,74 @@
+package dev.nucleusframework.window.tao
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Bridges the Tao windowing backend to JetBrains Compose Hot Reload.
+ *
+ * Compose Hot Reload's runtime assumes an AWT windowing model: a window manager
+ * (`org.jetbrains.compose.reload.jvm.startWindowManager`) installs
+ * `ComponentListener`s on each `java.awt.Window` to publish its geometry into
+ * the orchestration `WindowsState` — which the separate dev-tools process uses
+ * to position its sidecar window next to the app's. The Tao backend owns its
+ * own windows (Tao/GTK/Win32/AppKit via JNI) and has no `java.awt.Window`, so
+ * nobody publishes geometry and the sidecar never appears.
+ *
+ * [trackWindow] fixes that by feeding Tao window callbacks into the same
+ * `WindowsState` orchestration state, so the dev-tools sidecar follows the Tao
+ * window exactly like it follows an AWT `ComposeWindow`.
+ *
+ * This object stays on the hot path (called from [openDecoratedWindow]) so it
+ * must never reference any hot-reload class directly: those live in artifacts
+ * (`hot-reload-agent`, `-core`, `-orchestration`, `-devtools-api`) that are
+ * only on the runtime classpath under the hot-reload agent. When hot reload is
+ * inactive (`compose.reload.isActive != "true"`, the property the agent sets),
+ * [bridge] is `null` and every method is a no-op / pass-through. When active,
+ * the agent has already placed those artifacts on the classpath, so we load
+ * [TaoHotReloadBridgeImpl] reflectively. Mirrors [LifecycleMainDispatcherPriming].
+ */
+internal object TaoHotReloadIntegration {
+    private val active: Boolean = System.getProperty("compose.reload.isActive") == "true"
+
+    private val bridge: TaoHotReloadBridge? =
+        if (active) {
+            runCatching {
+                Class.forName("dev.nucleusframework.window.tao.TaoHotReloadBridgeImpl")
+                    .getDeclaredConstructor().newInstance() as TaoHotReloadBridge
+            }.getOrNull()
+        } else {
+            null
+        }
+
+    /** True when running under the Compose Hot Reload agent and the bridge loaded. */
+    val isActive: Boolean get() = bridge != null
+
+    /**
+     * Hook for wrapping scene content in a hot-reload entry point. Currently a
+     * pass-through: see the class KDoc for why we don't wrap in
+     * `DevelopmentEntryPoint` here. Kept as an indirection at the
+     * [openDecoratedWindow] call site so a wrapper can be introduced later
+     * without touching every platform path.
+     */
+    @Composable
+    fun wrapContent(content: @Composable () -> Unit): Unit = content()
+
+    /**
+     * Publishes [window]'s geometry into the hot-reload orchestration
+     * `WindowsState` so the dev-tools sidecar can follow it. No-op when hot
+     * reload is inactive. [title] / [alwaysOnTop] are captured from the
+     * `openDecoratedWindow` call site (TaoWindow exposes no getters for them).
+     */
+    fun trackWindow(window: TaoWindow, title: String?, alwaysOnTop: Boolean) {
+        bridge?.trackWindow(window, title, alwaysOnTop)
+    }
+}
+
+/**
+ * Hot-reload bridge surface. Implemented by [TaoHotReloadBridgeImpl], loaded
+ * reflectively only when hot reload is active (and thus the hot-reload
+ * artifacts are on the classpath). Kept free of hot-reload type references so
+ * it can be loaded unconditionally.
+ */
+internal interface TaoHotReloadBridge {
+    fun trackWindow(window: TaoWindow, title: String?, alwaysOnTop: Boolean)
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoHotReloadIntegration.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoHotReloadIntegration.kt
@@ -57,9 +57,14 @@ internal object TaoHotReloadIntegration {
      * `WindowsState` so the dev-tools sidecar can follow it. No-op when hot
      * reload is inactive. [title] / [alwaysOnTop] are captured from the
      * `openDecoratedWindow` call site (TaoWindow exposes no getters for them).
+     *
+     * Failure-proof: the runtime hot-reload classes come from the agent and can
+     * be a different (binary-incompatible) version than the one the bridge was
+     * compiled against — a broken bridge must degrade to "no sidecar tracking",
+     * never crash the app. See [TaoHotReloadBridgeImpl].
      */
     fun trackWindow(window: TaoWindow, title: String?, alwaysOnTop: Boolean) {
-        bridge?.trackWindow(window, title, alwaysOnTop)
+        runCatching { bridge?.trackWindow(window, title, alwaysOnTop) }
     }
 }
 

--- a/examples/tao-demo/build.gradle.kts
+++ b/examples/tao-demo/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     kotlin("jvm")
     alias(libs.plugins.kotlinComposePlugin)
     alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.composeHotReload)
     id("dev.nucleusframework")
 }
 
@@ -44,6 +45,20 @@ kotlin {
 // build. Adding it here only hits the JavaExec tasks.
 tasks.withType<JavaExec>().configureEach {
     jvmArgs("--enable-preview")
+}
+
+// ── Compose Hot Reload ──────────────────────────────────────────────────────
+// The Tao backend publishes its own window geometry into the hot-reload
+// orchestration `WindowsState` (see TaoHotReloadIntegration in decorated-window-tao),
+// so the dev-tools sidecar follows the Tao window exactly like it follows an AWT
+// `ComposeWindow`. `--enable-preview` is already added by the JavaExec block above
+// (ComposeHotRun extends JavaExec); macOS still needs `-XstartOnFirstThread` for
+// the Tao/AppKit main-runloop (the Nucleus plugin only adds it to its own `:run`).
+tasks.withType<org.jetbrains.compose.reload.gradle.ComposeHotRun>().configureEach {
+    mainClass.set("dev.nucleusframework.sampletao.MainKt")
+    if (org.apache.tools.ant.taskdefs.condition.Os.isFamily(org.apache.tools.ant.taskdefs.condition.Os.FAMILY_MAC)) {
+        jvmArgs("-XstartOnFirstThread")
+    }
 }
 
 nucleus.application {

--- a/examples/tao-demo/build.gradle.kts
+++ b/examples/tao-demo/build.gradle.kts
@@ -47,20 +47,6 @@ tasks.withType<JavaExec>().configureEach {
     jvmArgs("--enable-preview")
 }
 
-// ── Compose Hot Reload ──────────────────────────────────────────────────────
-// The Tao backend publishes its own window geometry into the hot-reload
-// orchestration `WindowsState` (see TaoHotReloadIntegration in decorated-window-tao),
-// so the dev-tools sidecar follows the Tao window exactly like it follows an AWT
-// `ComposeWindow`. `--enable-preview` is already added by the JavaExec block above
-// (ComposeHotRun extends JavaExec); macOS still needs `-XstartOnFirstThread` for
-// the Tao/AppKit main-runloop (the Nucleus plugin only adds it to its own `:run`).
-tasks.withType<org.jetbrains.compose.reload.gradle.ComposeHotRun>().configureEach {
-    mainClass.set("dev.nucleusframework.sampletao.MainKt")
-    if (org.apache.tools.ant.taskdefs.condition.Os.isFamily(org.apache.tools.ant.taskdefs.condition.Os.FAMILY_MAC)) {
-        jvmArgs("-XstartOnFirstThread")
-    }
-}
-
 nucleus.application {
     mainClass = "dev.nucleusframework.sampletao.MainKt"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,11 @@ detekt = "2.0.0-alpha.5"
 downloadTask = "5.7.0"
 filekit = "0.14.2"
 graalvmNative = "1.1.3"
-hotReload = "1.2.0-rc01"
+# Must match the hot-reload version bundled by the Compose Gradle plugin (which auto-applies
+# hot-reload to every Compose module): TaoHotReloadBridgeImpl compiles against these artifacts
+# but the runtime ones come from the agent, and the WindowsState API is not binary-stable
+# across releases. Compose 1.11.x bundles 1.1.1 — bump both together.
+hotReload = "1.1.1"
 icons = "261.23567.174"
 jbrApi = "1.10.1"
 jewel = "0.37.0-262.4852.51"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ detekt = "2.0.0-alpha.5"
 downloadTask = "5.7.0"
 filekit = "0.14.2"
 graalvmNative = "1.1.3"
+hotReload = "1.2.0-rc01"
 icons = "261.23567.174"
 jbrApi = "1.10.1"
 jewel = "0.37.0-262.4852.51"
@@ -43,6 +44,7 @@ vanniktechMavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "v
 kotlinComposePlugin = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin"}
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose"}
 graalvmNative = { id = "org.graalvm.buildtools.native", version.ref = "graalvmNative" }
+composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "hotReload" }
 lighthouse = { id = "io.github.dev-vikas-soni.lighthouse", version.ref = "lighthouse" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -50,6 +52,10 @@ kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 
 [libraries]
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilVersion" }
+hot-reload-agent = { module = "org.jetbrains.compose.hot-reload:hot-reload-agent", version.ref = "hotReload" }
+hot-reload-core = { module = "org.jetbrains.compose.hot-reload:hot-reload-core", version.ref = "hotReload" }
+hot-reload-orchestration = { module = "org.jetbrains.compose.hot-reload:hot-reload-orchestration", version.ref = "hotReload" }
+hot-reload-devtools-api = { module = "org.jetbrains.compose.hot-reload:hot-reload-devtools-api", version.ref = "hotReload" }
 intellij-icons = { module = "com.jetbrains.intellij.platform:icons", version.ref = "icons" }
 junit = "junit:junit:4.13.2"
 zstd-kmp-jvm = { module = "com.squareup.zstd:zstd-kmp-jvm", version.ref = "zstdKmp" }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureDesktop.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureDesktop.kt
@@ -33,7 +33,7 @@ internal fun configureDesktop(
             appData.configureGraalvmApplication()
         }
 
-        propagateMainClassToComposeApplication(project, appInternal)
+        propagateMainClassToHotReloadRun(project, appInternal)
         injectStartOnFirstThreadForTaoHotReload(project)
     }
 
@@ -46,43 +46,86 @@ internal fun configureDesktop(
     }
 }
 
+private const val COMPOSE_HOT_RUN_TASK = "org.jetbrains.compose.reload.gradle.ComposeHotRun"
+private const val COMPOSE_HOT_DEV_RUN_TASK = "org.jetbrains.compose.reload.gradle.ComposeHotDevRun"
+
 /**
- * Forwards [dev.nucleusframework.desktop.application.dsl.JvmApplication.mainClass] to
- * `compose.desktop.application.mainClass` so that Compose Hot Reload tasks (e.g. `hotRun`,
- * `hotSnapshotMain`) can resolve the entry point without the user duplicating it via
- * `-PmainClass=...` or a manual `compose.desktop.application { ... }` block.
+ * Makes Compose Hot Reload's run tasks work out of the box on Nucleus projects.
  *
- * This runs in Nucleus's `afterEvaluate`, which fires AFTER the Compose plugin's own
- * `afterEvaluate` (because Nucleus is applied last in user build scripts). By then Compose
- * has already inspected its `_isJvmApplicationInitialized` flag, so initializing the
- * `application` extension here cannot trigger duplicate task registration.
+ * `hotRun`: the hot-reload plugin resolves `mainClass` from a convention chain ending in
+ * `compose.desktop.application.mainClass` — but that extension is only initialized lazily at
+ * execution time, so in Nucleus projects (where `compose.desktop.application { }` must stay
+ * unconfigured, see [checkNoComposeDesktopApplication]) the chain always comes up empty and
+ * `hotRun` fails with "Missing 'mainClass' property". `ComposeHotRun` is a plain [JavaExec],
+ * so [dev.nucleusframework.desktop.application.dsl.JvmApplication.mainClass] is set as the
+ * standard `JavaExec.mainClass` convention instead. The hot-reload plugin's own overrides are
+ * replicated ahead of the Nucleus default, so `-PmainClass=...` / `-DmainClass=...` still win;
+ * `--mainClass=...` sets the property directly and bypasses the convention entirely.
  *
- * Reflection is intentional: a hard dependency on the Compose Gradle plugin classes would
- * couple Nucleus's classpath to a specific Compose version. Reflection lets this become a
- * silent no-op on projects that don't apply the Compose plugin at all.
+ * `hotDev`: `ComposeHotDevRun` renders a single `@Composable` via
+ * `org.jetbrains.compose.reload.jvm.DevApplication --className=... --funName=...`, parameters
+ * the IDE run-gutter injects (`-PclassName` / `-PfunName`) — invoked bare it fails while the
+ * argfile is serialized ("property 'className' has no value"), and no project-level default
+ * `@Composable` exists to point it at. When no `className` is provided the task is redirected
+ * to the application's own main class, i.e. a bare `hotDev` behaves exactly like `hotRun`;
+ * with `-PclassName` the stock dev-composable behavior is untouched.
+ *
+ * Task types are identified by class name to avoid a compile-time dependency on the
+ * hot-reload Gradle plugin (mirrors [injectStartOnFirstThreadForTaoHotReload]).
  */
-private fun propagateMainClassToComposeApplication(
+private fun propagateMainClassToHotReloadRun(
     project: Project,
     appInternal: JvmApplicationInternal,
 ) {
     val mainClass = appInternal.data.mainClass ?: return
-    val desktop = composeDesktopExtension(project) ?: return
-    // Only forward when the Compose Desktop application has ALREADY been initialized
-    // (by an explicit `compose.desktop.application { }` block or the Hot Reload plugin).
-    // `desktop.application` is a lazy getter that initializes the extension as a side effect;
-    // triggering it here would make the Compose plugin register its own packaging tasks, which
-    // collide with Nucleus's identically-named ones. See [isComposeJvmApplicationInitialized].
-    if (!isComposeJvmApplicationInitialized(desktop)) return
-    runCatching {
-        // Accessing via reflection avoids a compile-time dependency on the Compose plugin.
-        val applicationGetter = desktop.javaClass.getMethod("getApplication")
-        val composeApplication = applicationGetter.invoke(desktop) ?: return
-        val mainClassSetter = composeApplication.javaClass.methods
-            .firstOrNull { it.name == "setMainClass" && it.parameterCount == 1 }
-            ?: return
-        mainClassSetter.invoke(composeApplication, mainClass)
+    val mainClassConvention =
+        project.providers
+            .gradleProperty("mainClass")
+            .orElse(project.providers.systemProperty("mainClass"))
+            .orElse(mainClass)
+    val classNameProvided =
+        project.providers
+            .gradleProperty("className")
+            .orElse(project.providers.systemProperty("className"))
+            .isPresent
+    project.tasks.withType(JavaExec::class.java).configureEach { task ->
+        when {
+            task.isSubtypeOf(COMPOSE_HOT_RUN_TASK) -> task.mainClass.convention(mainClassConvention)
+            !classNameProvided && task.isSubtypeOf(COMPOSE_HOT_DEV_RUN_TASK) ->
+                task.redirectBareHotDevToAppMain(mainClass)
+        }
     }
 }
+
+/**
+ * Points a `hotDev` invoked without `-PclassName` at the app's main class instead of
+ * `DevApplication`. `className`/`funName` still need serializable values (the argfile task
+ * queries them, and they were assigned with `.value(<empty provider>)`, which shadows any
+ * convention) — the placeholders end up as `--className`/`--funName` program args that a
+ * regular `main` ignores. Reflection keeps the hot-reload plugin off the compile classpath.
+ */
+private fun JavaExec.redirectBareHotDevToAppMain(appMainClass: String) {
+    runCatching {
+        setHotDevProperty("getClassName\$hot_reload_gradle_plugin", appMainClass)
+        setHotDevProperty("getFunName\$hot_reload_gradle_plugin", "main")
+        mainClass.set(appMainClass)
+    }
+}
+
+private fun JavaExec.setHotDevProperty(
+    getterName: String,
+    value: String,
+) {
+    @Suppress("UNCHECKED_CAST")
+    val property =
+        javaClass.methods.first { it.name == getterName }.invoke(this)
+            as org.gradle.api.provider.Property<String>
+    property.set(value)
+}
+
+private fun JavaExec.isSubtypeOf(taskClassName: String): Boolean =
+    generateSequence<Class<*>>(javaClass) { it.superclass }
+        .any { it.name == taskClassName }
 
 /**
  * Fails with an actionable message when both `nucleus.application { }` and


### PR DESCRIPTION
## Summary

• Add a reflective hot-reload bridge so the Tao backend publishes its window geometry into the Compose Hot Reload orchestration `WindowsState` — the agent's auto-instrumentation only attaches to AWT windows, which Tao does not use, so the dev-tools sidecar otherwise never appears next to a Tao window
• `TaoHotReloadIntegration`: lightweight facade on the `openDecoratedWindow` hot path, free of any hot-reload class reference; no-op pass-through when `compose.reload.isActive != "true"`
• `TaoHotReloadBridgeImpl`: loaded reflectively only under the agent; mirrors `hot-reload-runtime-jvm`'s `startWindowManager`, driven by Tao callbacks (`onMoved`/`onResized`/`onFocusChanged`/`onMinimizedChanged`/`onDestroyed`) instead of AWT listeners; converts physical → logical pixels for the sidecar
• `decorated-window-tao`: `compileOnly` the hot-reload artifacts (agent supplies them at runtime)
• `tao-demo`: apply the `composeHotReload` plugin and configure `ComposeHotRun` (incl. macOS `-XstartOnFirstThread`)
• Version catalog: `hotReload = 1.2.0-rc01` + `agent`/`core`/`orchestration`/`devtools-api` libraries

## Notes

• Draft: needs validation on macOS/Windows (physical→logical pixel conversion, AppKit/Win32 geometry callbacks) and a check that the sidecar actually follows the Tao window across HiDPI scales.
• Fractional HiDPI scales may drift a few pixels; integer scales are exact (documented on `TaoHotReloadBridgeImpl`).

## Type

feat