### PR TITLE
fix(rpm): inject %dir entries into fpm-generated RPMs

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractElectronBuilderPackageTask.kt
@@ -13,6 +13,7 @@ import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import dev.nucleusframework.desktop.application.internal.UpdateYmlChecksums
 import dev.nucleusframework.desktop.application.internal.UpdateYmlPublish
 import dev.nucleusframework.desktop.application.internal.UpdateYmlGenerator
+import dev.nucleusframework.desktop.application.internal.ExternalToolRunner
 import dev.nucleusframework.desktop.application.internal.LinuxSigner
 import dev.nucleusframework.desktop.application.internal.LinuxUpdateHelper
 import dev.nucleusframework.desktop.application.internal.MacDmgLzma
@@ -303,6 +304,10 @@ abstract class AbstractElectronBuilderPackageTask
             // Must run before signLinuxPackage(): rebuilding the .deb archive to recompress its
             // payload would invalidate any embedded/detached signature produced downstream.
             recompressDebWithXz(outputDir, dist)
+
+            // Must run before signLinuxPackage(): rebuilding the .rpm payload to inject %dir
+            // entries would invalidate any embedded/detached signature produced downstream.
+            injectRpmDirectoryEntries(outputDir)
 
             signLinuxPackage(outputDir, dist)
 
@@ -1137,6 +1142,352 @@ abstract class AbstractElectronBuilderPackageTask
             }
             for (deb in debs) {
                 recompressSingleDeb(deb, dpkgDeb)
+            }
+        }
+
+        /**
+         * Rebuilds the .rpm produced by electron-builder/fpm to inject `%dir` entries for all
+         * directories in the payload.
+         *
+         * The jpackage C launcher (`libapplauncher.so`) queries the owning RPM package via
+         * `rpm -ql <package>` and scans the output for lines ending in `/app` and `/runtime` to
+         * discover the app directory and JVM runtime path. fpm-based RPMs only list files, not
+         * directories, so the launcher cannot locate its `.cfg` file and fails with:
+         * `Error opening "<app>.cfg" file: No such file or directory`.
+         *
+         * This function extracts the RPM payload, builds a spec file that includes `%dir`
+         * entries (mirroring JDK's `template.spec` logic), and re-packages via `rpmbuild`,
+         * preserving the original metadata and scriptlets.
+         */
+        private fun injectRpmDirectoryEntries(outputDir: File) {
+            if (currentOS != OS.Linux) return
+            if (targetFormat != TargetFormat.Rpm) return
+
+            val rpmbuild = findExecutableInPath("rpmbuild") ?: run {
+                logger.warn("rpmbuild not found in PATH; skipping RPM directory entry injection")
+                return
+            }
+            val rpm2cpio = findExecutableInPath("rpm2cpio") ?: run {
+                logger.warn("rpm2cpio not found in PATH; skipping RPM directory entry injection")
+                return
+            }
+            val cpio = findExecutableInPath("cpio") ?: run {
+                logger.warn("cpio not found in PATH; skipping RPM directory entry injection")
+                return
+            }
+            val rpm = findExecutableInPath("rpm") ?: run {
+                logger.warn("rpm not found in PATH; skipping RPM directory entry injection")
+                return
+            }
+
+            val rpms =
+                outputDir
+                    .listFiles { f -> f.isFile && f.extension.equals("rpm", ignoreCase = true) }
+                    ?.toList()
+                    .orEmpty()
+            if (rpms.isEmpty()) {
+                logger.info("No .rpm artifact found to inject directory entries in ${outputDir.absolutePath}")
+                return
+            }
+            for (rpmFile in rpms) {
+                injectRpmDirectoryEntriesSingle(rpmFile, rpmbuild, rpm2cpio, cpio, rpm)
+            }
+        }
+
+        private fun injectRpmDirectoryEntriesSingle(
+            rpmFile: File,
+            rpmbuild: File,
+            rpm2cpio: File,
+            cpio: File,
+            rpm: File,
+        ) {
+            // Check if the RPM already has directory entries for /app and /runtime.
+            // If it does, no injection is needed (e.g. native jpackage RPM or already fixed).
+            val allLines = captureRpmOutput(rpm, listOf("-qlp", rpmFile.absolutePath)).lines().filter { it.isNotBlank() }
+
+            val hasAppDir = allLines.any { it.endsWith("/app") }
+            val hasRuntimeDir = allLines.any { it.endsWith("/runtime") }
+            if (hasAppDir && hasRuntimeDir) {
+                logger.info("RPM ${rpmFile.name} already has directory entries; skipping injection")
+                return
+            }
+
+            logger.lifecycle("Injecting %dir entries into ${rpmFile.name}…")
+
+            val workDir = File(rpmFile.parentFile, "${rpmFile.nameWithoutExtension}.dir-inject")
+            val buildroot = File(workDir, "BUILDROOT")
+            val topDir = File(workDir, "rpmbuild")
+            val buildDir = File(workDir, "BUILD")
+            buildroot.deleteRecursively()
+            topDir.deleteRecursively()
+            buildDir.deleteRecursively()
+            buildroot.mkdirs()
+            listOf("BUILD", "RPMS", "SOURCES", "SPECS", "SRPMS").forEach {
+                File(topDir, it).mkdirs()
+            }
+            buildDir.mkdirs()
+
+            // Extract RPM payload into buildroot
+            runExternalTool(
+                rpm2cpio,
+                listOf(rpmFile.absolutePath),
+                logToConsole = ExternalToolRunner.LogToConsole.Never,
+                checkExitCodeIsNormal = true,
+            ).assertNormalExitValue()
+            // Extract RPM payload into buildroot via rpm2cpio | cpio
+            execOperations.exec { spec ->
+                spec.executable = "sh"
+                spec.args = listOf(
+                    "-c",
+                    "${rpm2cpio.absolutePath} '${rpmFile.absolutePath}' | ${cpio.absolutePath} -idmu --quiet",
+                )
+                spec.workingDir = buildroot
+                spec.isIgnoreExitValue = false
+            }
+
+            // Build the file list for %files
+            // Collect all directories (excluding filesystem package directories)
+            val appDirs =
+                buildroot.walkTopDown()
+                    .filter { d -> d.isDirectory && d != buildroot }
+                    .map { d ->
+                        val p = buildroot.toPath().relativize(d.toPath()).toString()
+                        if (p.startsWith(".")) p.substring(1) else "/$p"
+                    }
+                    .filter { it.isNotBlank() && it != "/" }
+                    .sorted()
+                    .toList()
+
+            // Default filesystem directories to exclude (mirrors JDK template.spec)
+            val defaultFilesystem =
+                setOf(
+                    "/",
+                    "/opt",
+                    "/usr",
+                    "/usr/bin",
+                    "/usr/lib",
+                    "/usr/local",
+                    "/usr/local/bin",
+                    "/usr/local/lib",
+                )
+
+            // Get filesystem package directories if available
+            val fsDirs =
+                try {
+                    captureRpmOutput(rpm, listOf("-ql", "filesystem"))
+                        .lines()
+                        .filter { it.isNotBlank() }
+                        .toSet()
+                } catch (e: Exception) {
+                    emptySet()
+                }
+
+            val excludeDirs = defaultFilesystem + fsDirs
+            val pkgDirs = appDirs.filter { it !in excludeDirs }
+
+            // Collect all files (including symlinks)
+            val pkgFiles =
+                buildroot.walkTopDown()
+                    .filter { it.isFile || java.nio.file.Files.isSymbolicLink(it.toPath()) }
+                    .map { f ->
+                        val p = buildroot.toPath().relativize(f.toPath()).toString()
+                        if (p.startsWith(".")) p.substring(1) else "/$p"
+                    }
+                    .filter { it.isNotBlank() && it != "/" }
+                    .sorted()
+                    .toList()
+
+            // Build filelist for %files
+            val filelistFile = File(workDir, "filelist.txt")
+            filelistFile.bufferedWriter().use { writer ->
+                for (dir in pkgDirs) {
+                    writer.write("%dir \"$dir\"")
+                    writer.newLine()
+                }
+                for (file in pkgFiles) {
+                    writer.write("\"$file\"")
+                    writer.newLine()
+                }
+            }
+
+            // Extract RPM metadata for the spec
+            val name = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{NAME}", rpmFile.absolutePath)).trim()
+            val version = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{VERSION}", rpmFile.absolutePath)).trim()
+            val release = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{RELEASE}", rpmFile.absolutePath)).trim()
+            val arch = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{ARCH}", rpmFile.absolutePath)).trim()
+            val summary = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{SUMMARY}", rpmFile.absolutePath)).trim()
+            val license = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{LICENSE}", rpmFile.absolutePath)).trim()
+            val vendor = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{VENDOR}", rpmFile.absolutePath)).trim()
+            val url = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{URL}", rpmFile.absolutePath)).trim()
+            val description = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{DESCRIPTION}", rpmFile.absolutePath)).trim()
+            val group = captureRpmOutput(rpm, listOf("-qp", "--qf", "%{GROUP}", rpmFile.absolutePath)).trim()
+
+            // Extract scriptlets
+            val postScript = captureRpmScripts(rpm, rpmFile, "post")
+            val preScript = captureRpmScripts(rpm, rpmFile, "pre")
+            val postunScript = captureRpmScripts(rpm, rpmFile, "postun")
+            val preunScript = captureRpmScripts(rpm, rpmFile, "preun")
+
+            // Build spec file
+            val specFile = File(topDir, "SPECS/$name.spec")
+            specFile.bufferedWriter().use { writer ->
+                writer.write("Summary: $summary")
+                writer.newLine()
+                writer.write("Name: $name")
+                writer.newLine()
+                writer.write("Version: $version")
+                writer.newLine()
+                writer.write("Release: $release")
+                writer.newLine()
+                writer.write("License: $license")
+                writer.newLine()
+                if (vendor.isNotBlank()) {
+                    writer.write("Vendor: $vendor")
+                    writer.newLine()
+                }
+                if (url.isNotBlank() && url != "(none)") {
+                    writer.write("URL: $url")
+                    writer.newLine()
+                }
+                writer.write("BuildArch: $arch")
+                writer.newLine()
+                writer.write("Autoprov: 0")
+                writer.newLine()
+                writer.write("Autoreq: 0")
+                writer.newLine()
+                writer.write("%define __jar_repack %{nil}")
+                writer.newLine()
+                writer.write("%define _build_id_links none")
+                writer.newLine()
+                writer.newLine()
+                writer.write("%description")
+                writer.newLine()
+                writer.write(description)
+                writer.newLine()
+                writer.newLine()
+                writer.write("%prep")
+                writer.newLine()
+                writer.newLine()
+                writer.write("%build")
+                writer.newLine()
+                writer.newLine()
+                writer.write("%install")
+                writer.newLine()
+                writer.write("rm -rf %{buildroot}")
+                writer.newLine()
+                writer.write("mkdir -p %{buildroot}")
+                writer.newLine()
+                writer.write("cp -a %{_sourcedir}/* %{buildroot}/")
+                writer.newLine()
+                writer.newLine()
+                if (preScript.isNotBlank()) {
+                    writer.write("%pre")
+                    writer.newLine()
+                    writer.write(preScript)
+                    writer.newLine()
+                    writer.newLine()
+                }
+                if (postScript.isNotBlank()) {
+                    writer.write("%post")
+                    writer.newLine()
+                    writer.write(postScript)
+                    writer.newLine()
+                    writer.newLine()
+                }
+                if (preunScript.isNotBlank()) {
+                    writer.write("%preun")
+                    writer.newLine()
+                    writer.write(preunScript)
+                    writer.newLine()
+                    writer.newLine()
+                }
+                if (postunScript.isNotBlank()) {
+                    writer.write("%postun")
+                    writer.newLine()
+                    writer.write(postunScript)
+                    writer.newLine()
+                    writer.newLine()
+                }
+                writer.write("%files -f ${filelistFile.absolutePath}")
+                writer.newLine()
+            }
+
+            // Copy buildroot contents to SOURCES (for cp in %install)
+            val sourcesDir = File(topDir, "SOURCES")
+            buildroot.listFiles()?.forEach { child ->
+                child.copyRecursively(File(sourcesDir, child.name), overwrite = true)
+            }
+
+            // Run rpmbuild
+            runExternalTool(
+                rpmbuild,
+                listOf(
+                    "-bb",
+                    specFile.absolutePath,
+                    "--define",
+                    "_topdir ${topDir.absolutePath}",
+                    "--define",
+                    "_rpmdir ${workDir.absolutePath}",
+                    "--define",
+                    "_sourcedir ${sourcesDir.absolutePath}",
+                    "--define",
+                    "_builddir ${buildDir.absolutePath}",
+                    "--define",
+                    "buildroot ${buildroot.absolutePath}",
+                    "--define",
+                    "_rpmfilename ${name}-${version}-${release}.${arch}.rpm",
+                ),
+                logToConsole = ExternalToolRunner.LogToConsole.Always,
+                checkExitCodeIsNormal = true,
+            ).assertNormalExitValue()
+
+            val rebuiltRpm = File(workDir, "$name-$version-$release.$arch.rpm")
+            if (!rebuiltRpm.isFile) {
+                throw GradleException("RPM directory entry injection produced no output: ${rebuiltRpm.absolutePath}")
+            }
+
+            // Replace the original RPM
+            if (!rpmFile.delete()) {
+                throw GradleException("Could not replace original rpm: ${rpmFile.absolutePath}")
+            }
+            rebuiltRpm.copyTo(rpmFile, overwrite = true)
+            rebuiltRpm.delete()
+
+            // Cleanup
+            workDir.deleteRecursively()
+
+            logger.lifecycle("Injected %dir entries into ${rpmFile.name}")
+        }
+
+        private fun captureRpmOutput(
+            rpm: File,
+            args: List<String>,
+        ): String {
+            val tempFile = File.createTempFile("rpm-capture", ".txt")
+            tempFile.deleteOnExit()
+            runExternalTool(
+                rpm,
+                args,
+                logToConsole = ExternalToolRunner.LogToConsole.Never,
+                checkExitCodeIsNormal = false,
+                processStdout = { content ->
+                    tempFile.writeText(content)
+                },
+            )
+            return tempFile.readText().also { tempFile.delete() }
+        }
+
+        private fun captureRpmScripts(
+            rpm: File,
+            rpmFile: File,
+            scriptlet: String,
+        ): String {
+            return try {
+                captureRpmOutput(rpm, listOf("-qp", "--qf", "%{$scriptlet}", rpmFile.absolutePath)).let {
+                    if (it.trim() == "(none)" || it.isBlank()) "" else it
+                }
+            } catch (e: Exception) {
+                ""
             }
         }
 


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

> **⚠️ AI-Generated:** This pull request was generated with the assistance of the **GLM-5.2** language model (OpenRouter `z-ai/glm-5.2`). The code, analysis, and documentation were produced through an interactive session and reviewed for correctness, but the reviewer should verify all changes independently.

> **Note to the maintainer:** The human author has no prior experience with Kotlin. The implementation is offered as a working proof-of-concept. Please feel free to refactor, restructure, or replace the code as you see fit — the intent is to demonstrate the fix and unblock #251, not to prescribe a specific implementation.

## 🚀 Description

This PR adds a post-packaging step (`injectRpmDirectoryEntries`) to `AbstractElectronBuilderPackageTask` that rebuilds the `.rpm` produced by electron-builder/fpm to inject `%dir` entries for all directories in the payload.

The function:

1. **Extracts** the RPM payload via `rpm2cpio | cpio` into a BUILDROOT.
2. **Collects directories** from the BUILDROOT, excluding directories provided by the `filesystem` RPM package (or a hardcoded fallback if `filesystem` is not installed, matching JDK's `default_filesystem`).
3. **Collects files** (including symlinks) from the BUILDROOT.
4. **Builds a spec file** that includes:
   - `%dir` entries for all non-filesystem directories.
   - File entries for all files.
   - Original metadata (Name, Version, Release, Summary, License, Vendor, URL, etc.).
   - Original scriptlets (`%pre`, `%post`, `%preun`, `%postun`) extracted via `rpm -qp --qf`.
5. **Re-packages** via `rpmbuild -bb`, replacing the original `.rpm`.
6. **Skips** if the RPM already contains `/app` and `/runtime` directory entries (e.g., native jpackage RPM or already-fixed RPM).

The function is placed in the packaging pipeline **after** electron-builder produces the `.rpm` and **before** `signLinuxPackage()`, so that any signatures are applied to the final payload:

```
recompressDebWithXz(outputDir, dist)     // existing: rebuild .deb
injectRpmDirectoryEntries(outputDir)      // NEW: rebuild .rpm
signLinuxPackage(outputDir, dist)         // existing: sign .deb/.rpm
```

This follows the same pattern as the existing `recompressDebWithXz` function.

## 📄 Motivation and Context

RPM packages produced by Nucleus (via electron-builder/fpm) omit `%dir` entries for the application's directory tree. This causes the jpackage C launcher (`libapplauncher.so`) to fail at runtime on Fedora/RHEL-based systems with:

```
Error opening "NucleusDemo.cfg" file: No such file or directory
```

### Root Cause

When the launcher binary (`bin/NucleusDemo`) starts, the C code in `libapplauncher.so` (`LinuxLauncherLib.cpp` → `launchApp()`) performs the following sequence:

1. `Package::findOwnerOfFile(launcherPath)` runs `rpm -qf` on the launcher path and determines the owning RPM package name (e.g. `nucleusdemo`).
2. Since the package name is non-empty, it takes the RPM branch and calls `Package::initAppLauncher()`, which runs `rpm -ql <package>` and scans each output line for paths ending in `/app` and `/runtime` to discover the app directory and JVM runtime path.
3. **fpm-generated RPMs only list files, not directories** — so `rpm -ql` returns no lines ending in `/app` or `/runtime`.
4. `appDir` and `runtimeDir` remain empty strings → the launcher cannot locate its `.cfg` file → startup fails.

This does **not** affect AppImage, DEB, or non-RPM-installed binaries, because the non-RPM code path in `LinuxLauncherLib.cpp` derives paths directly from `launcherPath` via `dirname()`.

JDK's own `template.spec` (used by `jpackage --type rpm`) avoids this by explicitly generating `%dir` entries via `comm -23` against the `filesystem` package. The electron-builder/fpm pipeline skips this step entirely.

Verified on Nucleus v2.0.7 RPM (built with electron-builder 26.15.5):

```
$ rpm -qlp nucleusdemo-2.0.7-linux-x86_64.rpm | grep -E '/app$|/runtime$'
(no output)
```

Fixes #251.

## 🧪 How Has This Been Tested?

### What was tested

- **Kotlin compilation**: The modified `AbstractElectronBuilderPackageTask.kt` compiles successfully (`./gradlew :plugin-build:plugin:compileKotlin`).
- **Equivalent logic verification**: The identical injection logic was applied as a standalone shell script to the official `nucleusdemo-2.0.7` RPM release. The rebuilt RPM was inspected with `rpm -qlp` and `rpm -qp --scripts` to confirm directory entries were present and scriptlets were preserved.

**Environment:** Fedora 44, x86_64, rpm 4.x, rpmbuild, rpm2cpio, cpio.

#### Before (original RPM from v2.0.7 release)

```
$ rpm -qlp nucleusdemo-2.0.7-linux-x86_64.rpm | grep -E '/app$|/runtime$'
(no output)
Directory entries: 5 (all /usr/lib/.build-id/*)
```

#### After (rebuilt RPM with %dir injection)

```
$ rpm -qlp nucleusdemo-2.0.7-fixed-linux-x86_64.rpm | grep -E '/app$|/runtime$'
/opt/Nucleus Demo/lib/app
/opt/Nucleus Demo/lib/runtime
Directory entries: 48
```

#### Scriptlets preserved

The rebuilt RPM retains all original scriptlets (`%post`, `%postun`):

```
$ rpm -qp --scripts nucleusdemo-2.0.7-fixed-linux-x86_64.rpm
postinstall scriptlet (using /bin/sh):
#!/bin/bash
if type update-alternatives >/dev/null 2>&1; then
    ...
```

#### File integrity

All 268 files from the original RPM are present in the rebuilt RPM. The size increase (~5 MB) is due to rpmbuild using a different default compression level than fpm.

### What was not tested

- **Full example RPM build**: A complete `packageReleaseDistributionForCurrentOS` build was not run locally, as it requires the full Nucleus toolchain (GraalVM, AOT cache, electron-builder/npm, etc.). The Kotlin code compiles, but end-to-end packaging through the Gradle task has not been exercised in this environment.
- **Runtime verification**: The rebuilt RPM was not installed and launched to confirm the launcher resolves the `.cfg` file correctly (the standalone-script verification covers the RPM payload structure, not the launcher execution path).
- **Pre-merge checks**: The repository's CI workflow (Pre Merge Checks) is expected to run automatically on this PR and provide further validation.

### Future improvements

- **Compression parity**: The rebuilt RPM uses rpmbuild's default compression rather than preserving fpm's compression settings. This could be configured via `%define _binary_payload` in the spec file.
- **Build-id handling**: The original RPM includes `/usr/lib/.build-id/*` symlinks generated by fpm. These are preserved in the payload but may not be regenerated by rpmbuild. If build-id links are important, `BuildArch` and debuginfo handling may need adjustment.
- **Unit tests**: A test similar to `LinuxSignerTest` could be added to verify the injection logic against a minimal fpm-generated RPM.
- **Upstream fix**: The ideal long-term fix would be for electron-builder/fpm to include `%dir` entries natively. This PR serves as a workaround until that happens.

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
