### PR TITLE
fix(graalvm): use @argfile on Windows to avoid command-line length limit

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -56,6 +56,13 @@ private fun isOracleGraalvm(javaHome: File): Boolean =
                 line.contains("Oracle", ignoreCase = true)
         }
 
+// native-image reads arguments from an @argfile using the JDK argument-file syntax: tokens are
+// separated by whitespace/newlines, double quotes group a token, and backslash is an escape
+// character. Wrap every argument in double quotes and escape backslashes and quotes so Windows
+// absolute paths (C:\Users\...) survive verbatim instead of being mangled by the tokenizer.
+private fun escapeNativeImageArgFileArgument(arg: String): String =
+    "\"" + arg.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 internal fun JvmApplicationContext.configureGraalvmApplication() {
     val graalvm = app.graalvm
@@ -793,7 +800,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
 
                 // Build args at execution time so that outputs from dependent tasks
                 // (static analysis dir, metadata repo dirs file, …) exist on disk.
-                args =
+                val builtArgs =
                     buildList {
                         add("-jar")
                         add(resolvedUberJar)
@@ -907,6 +914,25 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                         }
 
                         addAll(resolvedBuildArgs)
+                    }
+
+                // On Windows, native-image.cmd is a batch script launched through cmd.exe,
+                // which caps the whole command line at 8191 characters ("La ligne de commande
+                // est trop longue"). The many absolute -H:ConfigurationFileDirectories= entries
+                // plus --pgo=<path> and buildArgs blow past that. Route the arguments through a
+                // native-image @argfile (JDK argument-file syntax) so only "@<file>" reaches the
+                // command line. Other platforms pass the arguments directly.
+                args =
+                    if (currentOS == OS.Windows) {
+                        val argFile = File(outputDir, "native-image-args.txt")
+                        argFile.writeText(
+                            builtArgs.joinToString(System.lineSeparator()) {
+                                escapeNativeImageArgFileArgument(it)
+                            },
+                        )
+                        listOf("@${argFile.absolutePath}")
+                    } else {
+                        builtArgs
                     }
             }
         }


### PR DESCRIPTION
## Summary

- `:nativeImageCompile` invokes `native-image.cmd` through `cmd.exe`, which caps the whole command line at **8191 characters**.
- The task passes every argument on the command line: `-jar` + uber-jar path, a long series of absolute `-H:ConfigurationFileDirectories=<path>` entries (project config, library/platform/static metadata, one per Oracle metadata-repo dir), plus `--pgo=<absolute path>` and `buildArgs`.
- With PGO applied the line overflows the limit and the build fails with `La ligne de commande est trop longue` — the Windows shell error, not a native-image error.
- Fix: on Windows, write the arguments to a native-image `@argfile` (JDK argument-file syntax, with backslash/quote escaping so absolute paths survive) and pass only `@<file>` on the command line. macOS/Linux keep passing arguments directly (no length limit, avoids escaping risk on the well-exercised macOS pipeline).

## Test plan

- [ ] `:nativeImageCompile` succeeds on Windows with PGO enabled (previously failed)
- [ ] Generated `native-image-args.txt` contains correctly quoted/escaped absolute paths
- [ ] macOS and Linux native image builds unchanged