### PR TITLE
fix(decorated-window-tao): release resize-drag native memory on Windows drag end

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/render/TaoComposeSceneHostWindows.kt
@@ -885,6 +885,14 @@ internal class TaoComposeSceneHostWindows(
                 it.resourceCacheLimit = 0
                 it.resourceCacheLimit = RESOURCE_CACHE_LIMIT_BYTES
             }
+            // The purge above only frees Skia's GPU cache. Every remeasure of
+            // the drag also minted Compose layers/pictures whose native Skia
+            // memory is released by the skiko Cleaner only after a GC — and a
+            // static scene allocates nothing after the drag, so no GC ever
+            // comes and the drag's peak footprint stays resident. Nudge one
+            // collection here so the Cleaner can run; bounded to drag end.
+            @Suppress("ExplicitGarbageCollectionCall")
+            System.gc()
         }
     }
 


### PR DESCRIPTION
## Summary
- On Windows, a border-drag resize left the process memory at its peak forever on static scenes (e.g. nucleus-demo gallery), while animated scenes (atom) recovered.
- Cause: each remeasure of the drag mints Compose layers/pictures whose native memory is released by the skiko Cleaner only after a GC. A static scene allocates nothing after the drag, so no GC ever runs and the drag's intermediate-size footprint stays resident — visible as RSS on Windows/ANGLE where GL objects map to committed D3D11 memory. The existing `resourceCacheLimit` purge at WM_EXITSIZEMOVE only covers Skia-owned GPU scratch.
- Fix: nudge one `System.gc()` at drag end (WM_EXITSIZEMOVE) in `TaoComposeSceneHostWindows.onResizeLoopChanged`, right after the existing cache purge. Bounded to drag end, no cost in normal use. macOS/Linux hosts don't need it: their buffers are freed natively (CAMetalLayer pool / cached explicitly-closed EGL surfaces).

## Test plan
- [ ] Windows: run `:examples:nucleus-demo:run`, open the gallery (static scene), do a long border-drag, release — RSS drops back within seconds instead of staying at peak
- [ ] Atom scene still recovers as before
- [ ] macOS/Linux unaffected (change is in the Windows host only)