### PR TITLE
fix(decorated-window-tao): load GTK with RTLD_LOCAL to stop sqlite interposition

### DIFF
--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_shadow.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_shadow.c
@@ -175,7 +175,12 @@ static struct {
 
 static void *shadow_load_first(const char *const *names) {
     for (int i = 0; names[i] != NULL; i++) {
-        void *h = dlopen(names[i], RTLD_NOW | RTLD_GLOBAL);
+        /* RTLD_LOCAL: every symbol is fetched via dlsym() on the returned
+         * handle, so GTK's dependency closure must NOT enter the global
+         * scope — on NixOS it includes libsqlite3 (via tinysparql), which
+         * would interpose the sqlite bundled in androidx/Room's JNI lib
+         * and crash the JVM (issue #366). */
+        void *h = dlopen(names[i], RTLD_NOW | RTLD_LOCAL);
         if (h != NULL) return h;
     }
     return NULL;

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_widget.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_linux_widget.c
@@ -145,7 +145,10 @@ static struct {
 
 static void *load_first(const char *const *names) {
     for (int i = 0; names[i] != NULL; i++) {
-        void *h = dlopen(names[i], RTLD_NOW | RTLD_GLOBAL);
+        /* RTLD_LOCAL: keep GTK's closure out of the global symbol scope —
+         * on NixOS it pulls libsqlite3, which interposes the sqlite bundled
+         * in androidx/Room's JNI lib and segfaults (issue #366). */
+        void *h = dlopen(names[i], RTLD_NOW | RTLD_LOCAL);
         if (h != NULL) return h;
     }
     return NULL;
@@ -741,7 +744,7 @@ Java_dev_nucleusframework_window_tao_NativeTaoLinuxWidgetBridge_nativeRemoveInpu
      * instead of polluting the logs. */
     static gulong (*p_gtk_widget_get_type)(void) = NULL;
     if (p_gtk_widget_get_type == NULL) {
-        void *libgtk = dlopen("libgtk-3.so.0", RTLD_NOW | RTLD_GLOBAL);
+        void *libgtk = dlopen("libgtk-3.so.0", RTLD_NOW | RTLD_LOCAL);
         if (libgtk != NULL) {
             p_gtk_widget_get_type = (gulong (*)(void)) dlsym(libgtk, "gtk_widget_get_type");
         }

--- a/examples/tao-demo/build.gradle.kts
+++ b/examples/tao-demo/build.gradle.kts
@@ -22,6 +22,18 @@ dependencies {
     // store format below activates the sandboxed pipeline so the marker/shim rewrite is exercised
     // end-to-end on macOS.
     implementation(libs.zstd.kmp.jvm)
+    // Issue #366 e2e repro: androidx bundled sqlite driver (same native layer as Room on desktop).
+    implementation("androidx.sqlite:sqlite-bundled:2.6.1")
+}
+
+// Issue #366 e2e repro — see SqliteReproMain.kt. LD_LIBRARY_PATH points at a
+// patched libgtk-3.so.0 whose DT_NEEDED includes libsqlite3.so.0, recreating
+// the NixOS GTK closure that triggers the crash.
+tasks.register<JavaExec>("runSqliteRepro") {
+    group = "nucleus"
+    mainClass.set("dev.nucleusframework.sampletao.SqliteReproMainKt")
+    classpath = sourceSets["main"].runtimeClasspath
+    environment("LD_LIBRARY_PATH", "/tmp/gtk-shim")
 }
 
 java {

--- a/examples/tao-demo/build.gradle.kts
+++ b/examples/tao-demo/build.gradle.kts
@@ -22,18 +22,10 @@ dependencies {
     // store format below activates the sandboxed pipeline so the marker/shim rewrite is exercised
     // end-to-end on macOS.
     implementation(libs.zstd.kmp.jvm)
-    // Issue #366 e2e repro: androidx bundled sqlite driver (same native layer as Room on desktop).
-    implementation("androidx.sqlite:sqlite-bundled:2.6.1")
-}
-
-// Issue #366 e2e repro — see SqliteReproMain.kt. LD_LIBRARY_PATH points at a
-// patched libgtk-3.so.0 whose DT_NEEDED includes libsqlite3.so.0, recreating
-// the NixOS GTK closure that triggers the crash.
-tasks.register<JavaExec>("runSqliteRepro") {
-    group = "nucleus"
-    mainClass.set("dev.nucleusframework.sampletao.SqliteReproMainKt")
-    classpath = sourceSets["main"].runtimeClasspath
-    environment("LD_LIBRARY_PATH", "/tmp/gtk-shim")
+    testImplementation(libs.junit)
+    // Issue #366 e2e regression test: androidx bundled sqlite driver (same
+    // native layer as Room on desktop). See GtkSqliteInterpositionTest.
+    testImplementation("androidx.sqlite:sqlite-bundled:2.6.1")
 }
 
 java {

--- a/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/SqliteReproMain.kt
+++ b/examples/tao-demo/src/main/kotlin/dev/nucleusframework/sampletao/SqliteReproMain.kt
@@ -1,0 +1,94 @@
+package dev.nucleusframework.sampletao
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.sqlite.SQLiteStatement
+import androidx.sqlite.execSQL
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import dev.nucleusframework.application.DecoratedWindow
+import dev.nucleusframework.application.NucleusBackend
+import dev.nucleusframework.application.nucleusApplication
+import dev.nucleusframework.window.NucleusDecoratedWindowTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.system.exitProcess
+
+/**
+ * E2E reproduction of issue #366 — Linux SIGSEGV in libsqlite3.so when a
+ * Room/androidx-sqlite *bundled* driver write runs after a Tao decorated
+ * window opened.
+ *
+ * Mechanism under test: nucleus_tao_linux_shadow.c dlopen()s GTK with
+ * RTLD_GLOBAL at window creation. On distros where GTK's dependency
+ * closure includes libsqlite3 (NixOS: gtk3 -> tinysparql -> sqlite), the
+ * system libsqlite3 enters the *global* symbol scope. The androidx
+ * bundled-sqlite JNI library binds its sqlite3_* PLT entries lazily, so
+ * every sqlite entry point first called *after* the window opened resolves
+ * to the system library and operates on statement objects created by the
+ * bundled copy -> SIGSEGV (issue: sqlite3VdbeMemGrow via bindText).
+ *
+ * Run with LD_LIBRARY_PATH pointing at a patched libgtk-3.so.0 that has
+ * libsqlite3.so.0 added as DT_NEEDED (patchelf --add-needed) to recreate
+ * the NixOS closure on any distro.
+ */
+private inline fun <R> SQLiteStatement.use(block: (SQLiteStatement) -> R): R =
+    try {
+        block(this)
+    } finally {
+        close()
+    }
+
+fun main() {
+    println("[repro] phase 1: open bundled-sqlite DB + read BEFORE any window")
+    val dbFile = File(System.getProperty("java.io.tmpdir"), "nucleus-issue366.db")
+    dbFile.delete()
+    val conn = BundledSQLiteDriver().open(dbFile.absolutePath)
+    conn.execSQL("CREATE TABLE track(id INTEGER PRIMARY KEY, name TEXT)")
+    conn.prepare("SELECT count(*) FROM track").use { st ->
+        st.step()
+        println("[repro] phase 1 read OK, count=${st.getLong(0)}")
+    }
+
+    nucleusApplication(backend = NucleusBackend.Tao) {
+        NucleusDecoratedWindowTheme(isDark = true) {
+            DecoratedWindow(
+                onCloseRequest = ::exitApplication,
+                title = "issue-366 repro",
+            ) {
+                LaunchedEffect(Unit) {
+                    delay(3_000)
+                    // Prove the GTK shadow machinery still works (theme stamp
+                    // requires GTK to be loaded and functional).
+                    val stamp =
+                        runCatching {
+                            Class
+                                .forName("dev.nucleusframework.window.tao.NativeTaoLinuxShadowBridge")
+                                .getMethod("nativeShadowThemeStamp")
+                                .invoke(null)
+                        }.getOrElse { "error: $it" }
+                    println("[repro] shadow theme stamp = $stamp")
+                    println("[repro] phase 2: text-bound WRITE after window opened")
+                    withContext(Dispatchers.IO) {
+                        conn.prepare("INSERT INTO track(name) VALUES (?)").use { st ->
+                            st.bindText(1, "hello-from-issue-366")
+                            st.step()
+                        }
+                        conn.prepare("SELECT name FROM track").use { st ->
+                            st.step()
+                            println("[repro] phase 2 read-back: ${st.getText(0)}")
+                        }
+                    }
+                    println("[repro] write OK — bug NOT reproduced")
+                    exitProcess(0)
+                }
+                Box(Modifier.fillMaxSize().background(Color(0xFF0F1115)))
+            }
+        }
+    }
+}

--- a/examples/tao-demo/src/test/kotlin/dev/nucleusframework/sampletao/GtkSqliteInterpositionTest.kt
+++ b/examples/tao-demo/src/test/kotlin/dev/nucleusframework/sampletao/GtkSqliteInterpositionTest.kt
@@ -1,0 +1,93 @@
+package dev.nucleusframework.sampletao
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * E2E regression test for issue #366 — the Tao Linux CSD shadow/widget
+ * helpers must load GTK with RTLD_LOCAL. With RTLD_GLOBAL, any distro
+ * where GTK's dependency closure includes libsqlite3 (NixOS: gtk3 ->
+ * tinysparql -> sqlite) gets the system sqlite interposed over the copy
+ * bundled in androidx/Room's JNI library, and the first write bound after
+ * a window opened segfaults the JVM.
+ *
+ * The NixOS closure is recreated on any distro by copying the system
+ * libgtk-3.so.0 and adding libsqlite3.so.0 to its DT_NEEDED with
+ * patchelf, then pointing LD_LIBRARY_PATH at the copy. [main] (the repro
+ * scenario) runs in a forked JVM because the failure mode is a SIGSEGV.
+ */
+class GtkSqliteInterpositionTest {
+    @Test(timeout = 180_000)
+    fun `bundled sqlite write survives a Tao window pulling system sqlite via GTK`() {
+        assumeTrue("Linux only", System.getProperty("os.name").lowercase().contains("linux"))
+        assumeTrue(
+            "needs a display",
+            !System.getenv("DISPLAY").isNullOrEmpty() || !System.getenv("WAYLAND_DISPLAY").isNullOrEmpty(),
+        )
+        assumeTrue("needs patchelf", runCatching { exec("patchelf", "--version") }.isSuccess)
+        val gtk = findLibrary("libgtk-3.so.0")
+        assumeTrue("needs system libgtk-3", gtk != null)
+        assumeTrue("needs system libsqlite3", findLibrary("libsqlite3.so.0") != null)
+
+        val shimDir = createTempDir("gtk-sqlite-shim")
+        try {
+            val patched = File(shimDir, "libgtk-3.so.0")
+            gtk!!.copyTo(patched)
+            exec("patchelf", "--add-needed", "libsqlite3.so.0", patched.absolutePath)
+
+            val java = File(System.getProperty("java.home"), "bin/java").absolutePath
+            val process =
+                ProcessBuilder(java, "-cp", System.getProperty("java.class.path"), "dev.nucleusframework.sampletao.SqliteReproMainKt")
+                    .redirectErrorStream(true)
+                    .apply { environment()["LD_LIBRARY_PATH"] = shimDir.absolutePath }
+                    .start()
+            val output = StringBuilder()
+            val reader = Thread { process.inputStream.bufferedReader().forEachLine { output.appendLine(it) } }
+            reader.start()
+            val finished = process.waitFor(120, TimeUnit.SECONDS)
+            if (!finished) process.destroyForcibly()
+            reader.join(5_000)
+
+            assertTrue("repro app timed out\n$output", finished)
+            assertEquals(
+                "forked JVM died — system sqlite interposed over the bundled one (RTLD_GLOBAL regression?)\n$output",
+                0,
+                process.exitValue(),
+            )
+            // Guard against a vacuous pass: GTK (the patched copy) must have
+            // actually loaded and rendered the shadow theme in that process.
+            val stamp = output.lineSequence().firstOrNull { "shadow theme stamp = " in it }?.substringAfter("= ")
+            assertTrue(
+                "GTK shadow machinery not functional (stamp=$stamp)\n$output",
+                !stamp.isNullOrEmpty() && stamp != "null" && !stamp.startsWith("error"),
+            )
+            assertTrue("write did not complete\n$output", output.contains("write OK"))
+        } finally {
+            shimDir.deleteRecursively()
+        }
+    }
+
+    /** Resolves a library through `ldconfig -p`, honoring the current JVM arch. */
+    private fun findLibrary(name: String): File? {
+        val wantX64 = System.getProperty("os.arch") == "amd64"
+        return exec("ldconfig", "-p")
+            .lineSequence()
+            .map(String::trim)
+            .filter { it.startsWith("$name ") && (!wantX64 || "x86-64" in it) }
+            .mapNotNull { line -> line.substringAfter("=> ", "").trim().takeIf(String::isNotEmpty)?.let(::File) }
+            .firstOrNull(File::exists)
+    }
+
+    private fun exec(vararg command: String): String {
+        val process = ProcessBuilder(*command).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        check(process.waitFor() == 0) { "${command.joinToString(" ")} failed:\n$output" }
+        return output
+    }
+
+    private fun createTempDir(prefix: String): File = java.nio.file.Files.createTempDirectory(prefix).toFile()
+}

--- a/examples/tao-demo/src/test/kotlin/dev/nucleusframework/sampletao/SqliteReproMain.kt
+++ b/examples/tao-demo/src/test/kotlin/dev/nucleusframework/sampletao/SqliteReproMain.kt
@@ -33,9 +33,11 @@ import kotlin.system.exitProcess
  * to the system library and operates on statement objects created by the
  * bundled copy -> SIGSEGV (issue: sqlite3VdbeMemGrow via bindText).
  *
- * Run with LD_LIBRARY_PATH pointing at a patched libgtk-3.so.0 that has
- * libsqlite3.so.0 added as DT_NEEDED (patchelf --add-needed) to recreate
- * the NixOS closure on any distro.
+ * Must run in a dedicated JVM with LD_LIBRARY_PATH pointing at a patched
+ * libgtk-3.so.0 that has libsqlite3.so.0 added as DT_NEEDED to recreate
+ * the NixOS closure on any distro — [GtkSqliteInterpositionTest] builds
+ * that shim and forks this main (a SIGSEGV kills the whole JVM, so the
+ * outcome has to be observed from outside).
  */
 private inline fun <R> SQLiteStatement.use(block: (SQLiteStatement) -> R): R =
     try {


### PR DESCRIPTION
## Summary
- Fixes #366 — SIGSEGV in `libsqlite3.so` (`sqlite3VdbeMemGrow`) on Linux when a Room/androidx bundled-sqlite **write** runs after a Tao decorated window opened (regression 2.0.7 → 2.1.0, NixOS).
- Root cause: the CSD shadow helper introduced in 2.1.0 (`nucleus_tao_linux_shadow.c`) dlopen()s GTK with `RTLD_GLOBAL` at every window creation. On NixOS, GTK3's closure pulls `libsqlite3` (gtk3 → tinysparql → sqlite), so the **system** sqlite enters the global symbol scope. The bundled-sqlite JNI lib binds its `sqlite3_*` PLT entries lazily: entry points first called **after** the window opened resolve to the system copy but operate on statements created by the bundled copy → segfault. This is exactly why reads (bound before the window) kept working while writes crashed.
- Fix: `RTLD_GLOBAL` → `RTLD_LOCAL` for all GTK-family dlopen sites (shadow + widget helpers). Safe: every symbol is fetched via `dlsym()` on the explicit handles, nothing relies on `dlsym(RTLD_DEFAULT)`, and GTK's own modules link `libgtk-3.so` via their own `DT_NEEDED`. `nucleus_tao_egl.c`/`nucleus_tao_linux_popup.c` (EGL/GL/X11/wayland — no sqlite in their closures) are deliberately left untouched.
- Adds an e2e repro to `tao-demo` (`SqliteReproMain.kt` + `runSqliteRepro` task), same pattern as the #317 probe. The NixOS closure is recreated on any distro with a patched GTK copy:
  ```bash
  mkdir /tmp/gtk-shim && cp /usr/lib/x86_64-linux-gnu/libgtk-3.so.0 /tmp/gtk-shim/
  patchelf --add-needed libsqlite3.so.0 /tmp/gtk-shim/libgtk-3.so.0
  ./gradlew :examples:tao-demo:runSqliteRepro
  ```

## Test plan
- [x] E2E repro **before** fix: crashes with the issue's exact signature — `nativeBindText` (androidx bundled JNI) → system `libsqlite3.so.0` → SIGSEGV in the sqlite allocator
- [x] E2E repro **after** fix (natives rebuilt, loader cache cleared): `bindText` write + read-back succeed, no crash
- [x] GTK shadow machinery still functional with `RTLD_LOCAL` in the same process (`nativeShadowThemeStamp()` → `Yaru-blue-dark|1`)
- [x] `grep RTLD_DEFAULT` over native sources: no consumer of the global scope
- [ ] Confirm on reporter's NixOS setup