### PR TITLE
fix(rpm): own app/runtime dirs so the jpackage launcher finds its .cfg

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderConfigGenerator.kt
@@ -506,7 +506,7 @@ internal class ElectronBuilderConfigGenerator {
         }
     }
 
-    private fun generateLinuxConfig(
+    internal fun generateLinuxConfig(
         yaml: StringBuilder,
         distributions: JvmApplicationDistributions,
         targetFormat: TargetFormat,
@@ -555,6 +555,16 @@ internal class ElectronBuilderConfigGenerator {
                     }
                 }
                 appendIfNotNull(yaml, "  afterInstall", linuxAfterInstallTemplate?.absolutePath)
+                // fpm-generated RPMs list only files, never %dir entries for the app's own
+                // directory tree. The jpackage launcher (libapplauncher.so) discovers the app
+                // and runtime dirs by scanning `rpm -ql <pkg>` for paths ending in /app and
+                // /runtime; without directory entries those scans find nothing, so the launcher
+                // cannot locate its .cfg and dies with `Error opening "<app>.cfg"` on Fedora/RHEL.
+                // --rpm-auto-add-directories makes fpm own every payload directory (while still
+                // excluding the standard filesystem-package dirs), mirroring what jpackage's own
+                // template.spec does via `comm -23` against the filesystem package. See issue #251.
+                yaml.appendLine("  fpm:")
+                yaml.appendLine("    - \"--rpm-auto-add-directories\"")
             }
             TargetFormat.Pacman -> {
                 yaml.appendLine("pacman:")

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderRpmConfigTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/electronbuilder/ElectronBuilderRpmConfigTest.kt
@@ -1,0 +1,66 @@
+package dev.nucleusframework.desktop.application.internal.electronbuilder
+
+import dev.nucleusframework.desktop.application.dsl.JvmApplicationDistributions
+import dev.nucleusframework.desktop.application.dsl.TargetFormat
+import dev.nucleusframework.internal.utils.Arch
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the fix for issue #251: fpm-generated RPMs omit `%dir` entries for the app's own
+ * directory tree, so the jpackage launcher — which discovers the app/runtime dirs by scanning
+ * `rpm -ql` for paths ending in /app and /runtime — cannot find its .cfg and fails on Fedora/RHEL.
+ * The generated RPM config must pass `--rpm-auto-add-directories` to fpm so it owns those dirs.
+ */
+class ElectronBuilderRpmConfigTest {
+    private fun distributions(): JvmApplicationDistributions =
+        ProjectBuilder.builder().build().objects.newInstance(JvmApplicationDistributions::class.java)
+
+    private fun renderLinux(
+        distributions: JvmApplicationDistributions,
+        targetFormat: TargetFormat,
+    ): String {
+        val yaml = StringBuilder()
+        ElectronBuilderConfigGenerator().generateLinuxConfig(
+            yaml = yaml,
+            distributions = distributions,
+            targetFormat = targetFormat,
+            targetArch = Arch.X64,
+            startupWMClass = null,
+            linuxIconOverride = null,
+            linuxAfterInstallTemplate = null,
+            executableName = "nucleusdemo",
+        )
+        return yaml.toString()
+    }
+
+    @Test
+    fun `rpm config passes --rpm-auto-add-directories to fpm`() {
+        val yaml = renderLinux(distributions(), TargetFormat.Rpm)
+
+        assertTrue(yaml, yaml.contains("rpm:"))
+        assertTrue(yaml, yaml.contains("fpm:"))
+        assertTrue(yaml, yaml.contains("--rpm-auto-add-directories"))
+    }
+
+    @Test
+    fun `rpm auto-add coexists with rpm depends`() {
+        val distributions = distributions()
+        distributions.linux.rpmRequires = listOf("libX11")
+
+        val yaml = renderLinux(distributions, TargetFormat.Rpm)
+
+        assertTrue(yaml, yaml.contains("- \"libX11\""))
+        assertTrue(yaml, yaml.contains("--rpm-auto-add-directories"))
+    }
+
+    @Test
+    fun `deb config does not emit the rpm-only fpm flag`() {
+        val yaml = renderLinux(distributions(), TargetFormat.Deb)
+
+        assertTrue(yaml, yaml.contains("deb:"))
+        assertFalse(yaml, yaml.contains("--rpm-auto-add-directories"))
+    }
+}


### PR DESCRIPTION
## Problem

Installing the RPM on Fedora/RHEL and launching the app fails with:

```
Error opening "NucleusDemo.cfg" file: No such file or directory
```

(issue #251)

## Root cause

electron-builder builds RPMs via **fpm**, which lists only files and **never emits `%dir` entries** for the app's own directory tree. The jpackage launcher (`libapplauncher.so`, `Package.cpp::initAppLauncher`) discovers the app and runtime directories by running `rpm -ql <pkg>` and matching lines that `endsWith` `/app` and `/runtime`:

```cpp
// RPM: "rpm -ql '" + name + "'"
if (tstrings::endsWith(line, "/app"))     { appDir = line; }
if (tstrings::endsWith(line, "/runtime")) { runtimeDir = line; }
```

With no directory entries, those scans return nothing → `appDir`/`runtimeDir` stay empty → the launcher can't resolve its `.cfg`. DEB was never affected because `dpkg -L` already lists directories.

## Fix

Pass fpm's `--rpm-auto-add-directories` in the generated electron-builder `rpm:` config so fpm owns every payload directory (while still excluding the standard filesystem-package dirs via its bundled `filesystem_list`), mirroring what jpackage's own `template.spec` does with `comm -23` against the `filesystem` package.

```yaml
rpm:
  fpm:
    - "--rpm-auto-add-directories"
```

This replaces the heavyweight approach in #363 (extract + rebuild the RPM via `rpmbuild`) with a single, correct flag.

## Verified

Reproduced with the exact fpm binary electron-builder caches:

- **Before:** `rpm -qlp` lists only files — no `/app` or `/runtime` directory entries.
- **After:** `rpm -qlp` lists `…/lib/app` and `…/lib/runtime` directory entries → launcher resolves the `.cfg`.
- Filesystem-package dirs (`/opt`, `/usr`, `/usr/bin`, `/usr/share`, `/usr/share/applications`, `/usr/share/icons`) are correctly **excluded** — no conflict with the `filesystem` package.
- Only co-owns `/usr/share/icons/hicolor/*`, which is safe (rpm reference-counts directory ownership; only differing regular files conflict).

Launcher behavior confirmed against OpenJDK `Package.cpp` and the built `libapplauncher.so` (contains `rpm -ql '`, `dpkg -L '`, `tstrings::endsWith`).

## Tests

Adds `ElectronBuilderRpmConfigTest` — the RPM config emits the flag, it coexists with `rpm.depends`, and the DEB config does not emit the rpm-only flag.

## Note

Addresses the launcher `.cfg` error in #251. The separate "installer downloaded the RPM but failed to install" symptom in that issue is unrelated to `%dir` entries (it's a silent-failure bug in the `nucleus-website` install script + missing demo assets on some releases) and is handled separately.