### PR TITLE
fix(tao): apply TitleBarStyle color overrides to caption buttons

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/TitleBar.kt
@@ -371,6 +371,7 @@ public fun DecoratedWindowScope.BasicTitleBar(
                                 win = taoWindow,
                                 state = titleBarState,
                                 isResizable = taoWindow.isResizable,
+                                style = style,
                                 layout = linuxLayout,
                                 isFullscreen = titleBarState.isFullscreen,
                                 onExitFullscreen = { taoWindow.setFullscreen(false) },
@@ -380,6 +381,7 @@ public fun DecoratedWindowScope.BasicTitleBar(
                         WindowControlsWindows(
                             win = taoWindow,
                             state = titleBarState,
+                            style = style,
                             modifier = Modifier.align(Alignment.End),
                             isFullscreen = titleBarState.isFullscreen,
                             onExitFullscreen = { taoWindow.setFullscreen(false) },

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/WindowControlsLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/WindowControlsLinux.kt
@@ -15,6 +15,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
@@ -23,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import dev.nucleusframework.core.runtime.LinuxDesktopEnvironment
 import dev.nucleusframework.window.DecoratedWindowState
 import dev.nucleusframework.window.TitleBarScope
+import dev.nucleusframework.window.styling.TitleBarStyle
 import dev.nucleusframework.window.tao.TaoWindow
 import dev.nucleusframework.window.utils.linux.LinuxButtonLayout
 import dev.nucleusframework.window.utils.linux.LinuxTitleBarButton
@@ -52,6 +55,7 @@ internal fun TitleBarScope.WindowControlsLinux(
     win: TaoWindow,
     state: DecoratedWindowState,
     isResizable: Boolean,
+    style: TitleBarStyle,
     layout: LinuxButtonLayout = rememberLinuxButtonLayout(),
     isFullscreen: Boolean = false,
     onExitFullscreen: (() -> Unit)? = null,
@@ -75,6 +79,7 @@ internal fun TitleBarScope.WindowControlsLinux(
                     iconHover = closeHover,
                     iconPressed = closePressed,
                     contentDescription = "Close",
+                    style = style,
                     alignment = buttonAlignment,
                     isCloseButton = true,
                 )
@@ -87,6 +92,7 @@ internal fun TitleBarScope.WindowControlsLinux(
                         iconHover = icons.maximizeHover,
                         iconPressed = icons.maximizePressed,
                         contentDescription = "Exit fullscreen",
+                        style = style,
                         alignment = buttonAlignment,
                     )
                     continue
@@ -99,6 +105,7 @@ internal fun TitleBarScope.WindowControlsLinux(
                         iconHover = icons.restoreHover,
                         iconPressed = icons.restorePressed,
                         contentDescription = "Restore",
+                        style = style,
                         alignment = buttonAlignment,
                     )
                 } else {
@@ -108,6 +115,7 @@ internal fun TitleBarScope.WindowControlsLinux(
                         iconHover = icons.maximizeHover,
                         iconPressed = icons.maximizePressed,
                         contentDescription = "Maximize",
+                        style = style,
                         alignment = buttonAlignment,
                     )
                 }
@@ -119,6 +127,7 @@ internal fun TitleBarScope.WindowControlsLinux(
                     iconHover = icons.minimizeHover,
                     iconPressed = icons.minimizePressed,
                     contentDescription = "Minimize",
+                    style = style,
                     alignment = buttonAlignment,
                 )
             }
@@ -135,8 +144,9 @@ private fun TitleBarScope.LinuxControlButton(
     iconHover: Painter,
     iconPressed: Painter,
     contentDescription: String,
+    style: TitleBarStyle,
     alignment: Alignment.Horizontal,
-    @Suppress("UnusedParameter") isCloseButton: Boolean = false,
+    isCloseButton: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 
@@ -169,9 +179,24 @@ private fun TitleBarScope.LinuxControlButton(
                 else -> icon
             }
 
+        // Apply the custom icon tint when set, but skip the close button while
+        // hovered/pressed — its artwork has baked-in colors. Mirrors
+        // `decorated-window-core/WindowControlArea.kt`.
+        val isCloseInteracted = isCloseButton && (hovered || pressed)
+        val iconTint = style.colors.controlButtonIconColor
+        val iconHoverTint = style.colors.controlButtonIconHoverColor
+        val colorFilter =
+            when {
+                isCloseInteracted -> null
+                (hovered || pressed) && iconHoverTint != Color.Unspecified -> ColorFilter.tint(iconHoverTint)
+                iconTint != Color.Unspecified -> ColorFilter.tint(iconTint)
+                else -> null
+            }
+
         Image(
             painter = currentIcon,
             contentDescription = contentDescription,
+            colorFilter = colorFilter,
             modifier =
                 Modifier
                     .onPointerEvent(PointerEventType.Enter) { hovered = true }

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/WindowControlsWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/deco/WindowControlsWindows.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.pointer.PointerEventType
@@ -50,6 +51,7 @@ import dev.nucleusframework.window.icons.windows.RestoreDark
 import dev.nucleusframework.window.icons.windows.RestoreInactive
 import dev.nucleusframework.window.icons.windows.RestoreInactiveDark
 import dev.nucleusframework.window.icons.windows.WindowsControlButtonIcons
+import dev.nucleusframework.window.styling.TitleBarStyle
 import dev.nucleusframework.window.tao.TaoWindow
 
 // Mirrors `decorated-window-core/WindowsWindowControlArea.kt` so the visual
@@ -93,6 +95,7 @@ private val WindowsCloseButtonPressed = Color(0xFFF1707A)
 internal fun WindowControlsWindows(
     win: TaoWindow,
     state: DecoratedWindowState,
+    style: TitleBarStyle,
     modifier: Modifier = Modifier,
     isFullscreen: Boolean = false,
     onExitFullscreen: (() -> Unit)? = null,
@@ -106,6 +109,7 @@ internal fun WindowControlsWindows(
             WindowsCaptionButton(
                 onClick = { win.minimize() },
                 isDark = isDark,
+                style = style,
                 icon =
                     if (state.isActive) {
                         if (isDark) WindowsControlButtonIcons.MinimizeDark else WindowsControlButtonIcons.Minimize
@@ -125,6 +129,7 @@ internal fun WindowControlsWindows(
                 WindowsCaptionButton(
                     onClick = onExitFullscreen,
                     isDark = isDark,
+                    style = style,
                     icon =
                         if (state.isActive) {
                             if (isDark) {
@@ -149,6 +154,7 @@ internal fun WindowControlsWindows(
                 WindowsCaptionButton(
                     onClick = { win.setMaximized(false) },
                     isDark = isDark,
+                    style = style,
                     icon =
                         if (state.isActive) {
                             if (isDark) WindowsControlButtonIcons.RestoreDark else WindowsControlButtonIcons.Restore
@@ -165,6 +171,7 @@ internal fun WindowControlsWindows(
                 WindowsCaptionButton(
                     onClick = { win.setMaximized(true) },
                     isDark = isDark,
+                    style = style,
                     icon =
                         if (state.isActive) {
                             if (isDark) WindowsControlButtonIcons.MaximizeDark else WindowsControlButtonIcons.Maximize
@@ -185,6 +192,7 @@ internal fun WindowControlsWindows(
             WindowsCaptionButton(
                 onClick = { win.requestUserClose() },
                 isDark = isDark,
+                style = style,
                 icon =
                     if (state.isActive) {
                         if (isDark) WindowsControlButtonIcons.CloseDark else WindowsControlButtonIcons.Close
@@ -209,6 +217,7 @@ internal fun WindowControlsWindows(
 private fun WindowsCaptionButton(
     onClick: () -> Unit,
     isDark: Boolean,
+    style: TitleBarStyle,
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     contentDescription: String,
     iconHover: androidx.compose.ui.graphics.vector.ImageVector? = null,
@@ -218,18 +227,26 @@ private fun WindowsCaptionButton(
     var pressed by remember { mutableStateOf(false) }
 
     val backgroundColor =
-        when {
-            pressed && isCloseButton -> WindowsCloseButtonPressed
-            pressed -> if (isDark) WindowsButtonPressedDark else WindowsButtonPressedLight
-            hovered && isCloseButton -> WindowsCloseButtonHovered
-            hovered -> if (isDark) WindowsButtonHoveredDark else WindowsButtonHoveredLight
-            else -> Color.Transparent
-        }
+        captionButtonBackground(
+            hovered = hovered,
+            pressed = pressed,
+            isCloseButton = isCloseButton,
+            isDark = isDark,
+            style = style,
+        )
 
     val isCloseHovered = (hovered || pressed) && isCloseButton
     val currentIcon: Painter =
         rememberVectorPainter(
             if (isCloseHovered && iconHover != null) iconHover else icon,
+        )
+
+    val colorFilter =
+        captionButtonColorFilter(
+            hovered = hovered,
+            pressed = pressed,
+            isCloseHovered = isCloseHovered,
+            style = style,
         )
 
     Box(
@@ -252,6 +269,51 @@ private fun WindowsCaptionButton(
                 ),
         contentAlignment = Alignment.Center,
     ) {
-        Image(painter = currentIcon, contentDescription = contentDescription)
+        Image(painter = currentIcon, contentDescription = contentDescription, colorFilter = colorFilter)
+    }
+}
+
+// Mirrors `decorated-window-core/WindowsWindowControlArea.kt` so custom
+// [TitleBarStyle] colors apply identically on the Tao backend. Close-button
+// hover/pressed always use the fixed Windows red — matching AWT.
+private fun captionButtonBackground(
+    hovered: Boolean,
+    pressed: Boolean,
+    isCloseButton: Boolean,
+    isDark: Boolean,
+    style: TitleBarStyle,
+): Color {
+    val customHover = style.colors.iconButtonHoveredBackground
+    val customPressed = style.colors.iconButtonPressedBackground
+    val pressedColor =
+        customPressed.takeUnless { it == Color.Transparent }
+            ?: if (isDark) WindowsButtonPressedDark else WindowsButtonPressedLight
+    val hoveredColor =
+        customHover.takeUnless { it == Color.Transparent }
+            ?: if (isDark) WindowsButtonHoveredDark else WindowsButtonHoveredLight
+    return when {
+        pressed && isCloseButton -> WindowsCloseButtonPressed
+        pressed -> pressedColor
+        hovered && isCloseButton -> WindowsCloseButtonHovered
+        hovered -> hoveredColor
+        else -> Color.Transparent
+    }
+}
+
+private fun captionButtonColorFilter(
+    hovered: Boolean,
+    pressed: Boolean,
+    isCloseHovered: Boolean,
+    style: TitleBarStyle,
+): ColorFilter? {
+    val iconTint = style.colors.controlButtonIconColor
+    val iconHoverTint = style.colors.controlButtonIconHoverColor
+    return when {
+        // Close hover swaps to the baked-red close artwork; don't tint it.
+        isCloseHovered -> null
+        (hovered || pressed) && iconHoverTint != Color.Unspecified ->
+            ColorFilter.tint(iconHoverTint)
+        iconTint != Color.Unspecified -> ColorFilter.tint(iconTint)
+        else -> null
     }
 }


### PR DESCRIPTION
## Summary

Fixes #376. `WindowControlsWindows` and `WindowControlsLinux` in `decorated-window-tao` did not accept a `TitleBarStyle`, so `TitleBarColors.iconButtonHoveredBackground`, `iconButtonPressedBackground`, `controlButtonIconColor`, and `controlButtonIconHoverColor` had no effect on the Tao backend — even though the AWT backend honors them. Since Tao is now the default/recommended backend, the documented `TitleBarColors` API silently did nothing for most users.

- Add a `style: TitleBarStyle` parameter to `WindowControlsWindows` and `WindowControlsLinux`, threaded through every caption-button call site.
- Windows: port `captionButtonBackground()` (honors `iconButtonHoveredBackground` / `iconButtonPressedBackground`) and `captionButtonColorFilter()` (honors `controlButtonIconColor` / `controlButtonIconHoverColor`) from `decorated-window-core/WindowsWindowControlArea.kt`. Close button keeps the fixed Windows red on hover/pressed.
- Linux: apply a `ColorFilter` tint from `controlButtonIconColor` / `controlButtonIconHoverColor`, skipping the close button while interacted (baked-in artwork colors). The previously-unused `isCloseButton` parameter is now meaningful.
- `TitleBar.kt`: pass the in-scope `style` into both control composables.

Behavior now mirrors the AWT backend exactly, matching the "mirrors AWT" contract in the Tao control files.

## Test plan

- [x] `:decorated-window-tao:compileKotlin`
- [x] `:decorated-window-tao:detekt`
- [x] `:decorated-window-tao:ktlintCheck`
- [ ] Manual: set custom `controlButtonIconColor` / `iconButtonHoveredBackground` on a `TitleBarStyle` and confirm caption buttons pick them up on the Tao backend (Windows + Linux)