### PR TITLE
feat(graalvm): auto-include the project's own resources in native image

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/GraalvmSettings.kt
@@ -58,6 +58,16 @@ abstract class GraalvmSettings
         // Defaults to `true` to match Oracle GraalVM's out-of-the-box behavior.
         val mlProfileInference: Property<Boolean> = objects.notNullProperty(true)
 
+        // Automatically register the project's own resources (its source-set resource directories
+        // and those of `project(...)` module dependencies) for inclusion in the native image.
+        // native-image only embeds resources it is told about, and dynamic
+        // `getResourceAsStream(path)` calls cannot be resolved statically — so without this, assets
+        // loaded by a computed path (e.g. markdown files listed in an index) are silently dropped
+        // from the binary. This mirrors the JVM distribution, where every resource ships in the uber
+        // JAR. Third-party JAR resources are NOT included (they are covered by the L1/L2 metadata and
+        // static analysis). Defaults to `true`; set to `false` to manage resource globs manually.
+        val autoIncludeResources: Property<Boolean> = objects.notNullProperty(true)
+
         val buildArgs: ListProperty<String> = objects.listProperty(String::class.java)
         val nativeImageConfigBaseDir: DirectoryProperty = objects.directoryProperty()
         val toolchain: GraalvmToolchainSettings = objects.new()

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/GenerateProjectResourceMetadataTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/GenerateProjectResourceMetadataTask.kt
@@ -1,0 +1,65 @@
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.desktop.application.internal.analyzer.ResourcePattern
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Registers the project's own resources for inclusion in the GraalVM native image.
+ *
+ * native-image only embeds resources that are explicitly registered; statically we cannot
+ * resolve dynamic `getResourceAsStream(path)` calls (paths coming from an index file, a
+ * database, user input, …). To match the JVM distribution — where every resource ends up in
+ * the uber JAR — this task walks the project's resource source directories (its own source
+ * sets plus those of `project(...)` module dependencies) and emits one glob per top-level
+ * entry: a directory is registered recursively (e.g. `commands` → all files under it), a file
+ * keeps its own name (e.g. `tips.md`).
+ *
+ * The output is a standard `reachability-metadata.json`, passed to native-image via
+ * `-H:ConfigurationFileDirectories=`.
+ */
+@CacheableTask
+abstract class GenerateProjectResourceMetadataTask : DefaultTask() {
+    /** The project's resource source directories (already resolved at configuration time). */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val resourceDirs: ConfigurableFileCollection
+
+    /** Output directory where reachability-metadata.json is written. */
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @TaskAction
+    fun generate() {
+        val globs = sortedSetOf<String>()
+        for (dir in resourceDirs.files) {
+            if (!dir.isDirectory) continue
+            dir.listFiles()?.forEach { child ->
+                val name = child.name
+                // META-INF is handled by the auto-included native-image.properties globs
+                // (META-INF/services/*) and may carry signatures/manifests we must not embed.
+                if (name.startsWith(".") || name == "META-INF") return@forEach
+                globs += if (child.isDirectory) "$name/**" else name
+            }
+        }
+
+        val patterns = globs.map { ResourcePattern(glob = it) }.toSet()
+
+        val outDir = outputDir.get().asFile
+        outDir.mkdirs()
+        File(outDir, "reachability-metadata.json")
+            .writeText(buildReachabilityMetadataJson(emptySet(), emptySet(), patterns))
+
+        logger.lifecycle(
+            "Project resource metadata: registered ${patterns.size} resource glob(s) for native-image",
+        )
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -25,6 +25,7 @@ import dev.nucleusframework.internal.utils.uppercaseFirstChar
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
@@ -1981,10 +1982,13 @@ private fun JvmApplicationContext.configureGraalvmElectronBuilderPackaging(
  * Third-party JAR resources are intentionally excluded — they are covered by the L1/L2 metadata
  * and static analysis.
  *
- * Resolved eagerly at configuration time so only plain [File] paths are captured downstream
- * (config-cache safe). Sibling projects that are not yet evaluated simply contribute nothing.
+ * Each entry is a [SourceDirectorySet.getSourceDirectories] file collection, which carries the
+ * task dependencies of the directories it contains (e.g. Compose's generated resource dirs are
+ * outputs of `assembleDesktopMainResources` / `generateAppProperties`). Wiring these — rather
+ * than plain [File] paths — lets Gradle infer the producing tasks automatically. Sibling
+ * projects that are not yet evaluated simply contribute nothing.
  */
-private fun JvmApplicationContext.collectProjectResourceDirs(runtimeConfigName: String?): Set<File> {
+private fun JvmApplicationContext.collectProjectResourceDirs(runtimeConfigName: String?): List<FileCollection> {
     val projects = linkedSetOf(project)
     runtimeConfigName?.let { project.configurations.findByName(it) }
         ?.allDependencies
@@ -1992,12 +1996,12 @@ private fun JvmApplicationContext.collectProjectResourceDirs(runtimeConfigName: 
         ?.forEach { dep ->
             runCatching { project.project(dep.path) }.getOrNull()?.let { projects.add(it) }
         }
-    return projects.flatMapTo(linkedSetOf()) { resourceSrcDirsOf(it) }
+    return projects.flatMap { resourceSrcDirsOf(it) }
 }
 
-/** Resource source directories declared by a project, across KMP JVM, Kotlin/JVM and plain Java. */
-private fun resourceSrcDirsOf(p: Project): Set<File> {
-    val dirs = linkedSetOf<File>()
+/** Resource source directory collections declared by a project, across KMP JVM, Kotlin/JVM and plain Java. */
+private fun resourceSrcDirsOf(p: Project): List<FileCollection> {
+    val collections = mutableListOf<FileCollection>()
 
     // Kotlin Multiplatform: resources of every JVM target's main compilation (and its
     // associated/depended-on source sets, e.g. commonMain).
@@ -2007,14 +2011,14 @@ private fun resourceSrcDirsOf(p: Project): Set<File> {
             ?.filter { it.platformType == KotlinPlatformType.jvm }
             ?.forEach { target ->
                 target.compilations.findByName("main")?.allKotlinSourceSets?.forEach { sourceSet ->
-                    dirs.addAll(sourceSet.resources.srcDirs)
+                    collections.add(sourceSet.resources.sourceDirectories)
                 }
             }
     }
 
     // Kotlin/JVM single-target projects.
     runCatching {
-        p.kotlinJvmExtOrNull?.sourceSets?.findByName("main")?.resources?.srcDirs?.let(dirs::addAll)
+        p.kotlinJvmExtOrNull?.sourceSets?.findByName("main")?.resources?.sourceDirectories?.let(collections::add)
     }
 
     // Plain Java projects (or the java plugin applied alongside Kotlin).
@@ -2024,9 +2028,9 @@ private fun resourceSrcDirsOf(p: Project): Set<File> {
             ?.sourceSets
             ?.findByName("main")
             ?.resources
-            ?.srcDirs
-            ?.let(dirs::addAll)
+            ?.sourceDirectories
+            ?.let(collections::add)
     }
 
-    return dirs
+    return collections
 }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureGraalvmApplication.kt
@@ -13,6 +13,8 @@ import dev.nucleusframework.desktop.application.internal.InfoPlistBuilder.InfoPl
 import dev.nucleusframework.desktop.application.tasks.AbstractElectronBuilderPackageTask
 import dev.nucleusframework.desktop.application.tasks.AbstractNotarizationTask
 import dev.nucleusframework.desktop.tasks.AbstractUnpackDefaultApplicationResourcesTask
+import dev.nucleusframework.internal.kotlinJvmExtOrNull
+import dev.nucleusframework.internal.mppExtOrNull
 import dev.nucleusframework.internal.utils.Arch
 import dev.nucleusframework.internal.utils.OS
 import dev.nucleusframework.internal.utils.currentArch
@@ -21,6 +23,9 @@ import dev.nucleusframework.internal.utils.executableName
 import dev.nucleusframework.internal.utils.javaExecutable
 import dev.nucleusframework.internal.utils.uppercaseFirstChar
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
@@ -30,6 +35,7 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import java.io.File
 
 private val graalvmDefaultJvmArgs: List<String> =
@@ -640,6 +646,34 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                 }
             }
 
+    // ── Project resource auto-inclusion ──
+    // The app's own resources live in the uber JAR but native-image only embeds *registered*
+    // resources. Dynamic getResourceAsStream(computedPath) calls cannot be resolved statically,
+    // so resources loaded by a computed path (e.g. markdown listed in an index) are silently
+    // dropped. Register the project's resource roots as globs, mirroring the JVM distribution.
+    // Resource directories are resolved eagerly at configuration time (config-cache safe: only
+    // File paths are captured, not Project references).
+    val projectResourceMetadataDir = appTmpDir.map { it.dir("graalvm/projectResources") }
+    val generateProjectResourceMetadata =
+        if (graalvm.autoIncludeResources.get()) {
+            val resolvedResourceDirs = collectProjectResourceDirs(runtimeCfg?.name)
+            project.tasks
+                .register(
+                    "generateGraalvmProjectResourceMetadata",
+                    GenerateProjectResourceMetadataTask::class.java,
+                ).apply {
+                    configure { task ->
+                        task.description =
+                            "Register the project's own resources for inclusion in the GraalVM native image"
+                        task.group = NUCLEUS_TASK_GROUP
+                        task.resourceDirs.from(resolvedResourceDirs)
+                        task.outputDir.set(projectResourceMetadataDir)
+                    }
+                }
+        } else {
+            null
+        }
+
     // ── Cleanup manual metadata ──
     // Removes entries from the project's reachability-metadata.json that are already
     // covered by L1 (library JARs), L2 (Oracle repo), L3 (platform), or static analysis.
@@ -697,6 +731,7 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             dependsOn(resolveReachabilityMetadata)
             dependsOn(analyzeStaticMetadata)
             dependsOn(filterLibraryMetadata)
+            generateProjectResourceMetadata?.let { dependsOn(it) }
             compileStubs?.let { dependsOn(it) }
             generateWindowsResources?.let { dependsOn(it) }
 
@@ -744,6 +779,8 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
             val resolvedLibraryMetadataDir = libraryMetadataDir.get().asFile
             val resolvedPlatformMetadataDir = platformMetadataDir.get().asFile
             val resolvedStaticMetadataDir = staticMetadataDir.get().asFile
+            val resolvedProjectResourceMetadataDir =
+                if (generateProjectResourceMetadata != null) projectResourceMetadataDir.get().asFile else null
             val resolvedMetadataRepoDirsFile = metadataRepoDirsFile.get().asFile
             val resolvedBuildArgs = graalvm.buildArgs.get()
             // Default: portable baseline everywhere, except macOS on Apple Silicon where the
@@ -899,6 +936,11 @@ internal fun JvmApplicationContext.configureGraalvmApplication() {
                         // detected from bytecode scanning of runtime classpath JARs)
                         if (resolvedStaticMetadataDir.exists()) {
                             add("-H:ConfigurationFileDirectories=$resolvedStaticMetadataDir")
+                        }
+
+                        // Include the project's own resources (globs generated from its resource roots)
+                        if (resolvedProjectResourceMetadataDir != null && resolvedProjectResourceMetadataDir.exists()) {
+                            add("-H:ConfigurationFileDirectories=$resolvedProjectResourceMetadataDir")
                         }
 
                         // Include metadata from Oracle Reachability Metadata Repository
@@ -1927,4 +1969,64 @@ private fun JvmApplicationContext.configureGraalvmElectronBuilderPackaging(
             }
         }
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Project resource discovery
+// ═══════════════════════════════════════════════════════════════════
+
+/**
+ * Resolves the resource source directories that belong to the project itself: its own source
+ * sets plus those of every `project(...)` module dependency on the given runtime configuration.
+ * Third-party JAR resources are intentionally excluded — they are covered by the L1/L2 metadata
+ * and static analysis.
+ *
+ * Resolved eagerly at configuration time so only plain [File] paths are captured downstream
+ * (config-cache safe). Sibling projects that are not yet evaluated simply contribute nothing.
+ */
+private fun JvmApplicationContext.collectProjectResourceDirs(runtimeConfigName: String?): Set<File> {
+    val projects = linkedSetOf(project)
+    runtimeConfigName?.let { project.configurations.findByName(it) }
+        ?.allDependencies
+        ?.withType(ProjectDependency::class.java)
+        ?.forEach { dep ->
+            runCatching { project.project(dep.path) }.getOrNull()?.let { projects.add(it) }
+        }
+    return projects.flatMapTo(linkedSetOf()) { resourceSrcDirsOf(it) }
+}
+
+/** Resource source directories declared by a project, across KMP JVM, Kotlin/JVM and plain Java. */
+private fun resourceSrcDirsOf(p: Project): Set<File> {
+    val dirs = linkedSetOf<File>()
+
+    // Kotlin Multiplatform: resources of every JVM target's main compilation (and its
+    // associated/depended-on source sets, e.g. commonMain).
+    runCatching {
+        p.mppExtOrNull
+            ?.targets
+            ?.filter { it.platformType == KotlinPlatformType.jvm }
+            ?.forEach { target ->
+                target.compilations.findByName("main")?.allKotlinSourceSets?.forEach { sourceSet ->
+                    dirs.addAll(sourceSet.resources.srcDirs)
+                }
+            }
+    }
+
+    // Kotlin/JVM single-target projects.
+    runCatching {
+        p.kotlinJvmExtOrNull?.sourceSets?.findByName("main")?.resources?.srcDirs?.let(dirs::addAll)
+    }
+
+    // Plain Java projects (or the java plugin applied alongside Kotlin).
+    runCatching {
+        p.extensions
+            .findByType(JavaPluginExtension::class.java)
+            ?.sourceSets
+            ?.findByName("main")
+            ?.resources
+            ?.srcDirs
+            ?.let(dirs::addAll)
+    }
+
+    return dirs
 }


### PR DESCRIPTION
## Summary

- native-image only embeds resources it is explicitly registered for. Dynamic `getResourceAsStream(computedPath)` calls (paths from an index file, a database, user input, …) can't be resolved statically, so app assets loaded by a computed path were silently dropped from the binary — even though the JVM distribution ships every resource in the uber JAR.
- Adds `GenerateProjectResourceMetadataTask`: walks the project's resource source directories and emits one glob per top-level entry (a directory recursively, a file by name) into a `reachability-metadata.json` passed to native-image via `-H:ConfigurationFileDirectories`.
- Discovery covers the project's own source sets (KMP JVM / Kotlin-JVM / plain Java) **and** those of `project(...)` module dependencies. Third-party JAR resources stay excluded — they remain covered by the L1/L2 metadata and static analysis.
- Resource directories are resolved eagerly at configuration time (config-cache safe: only `File` paths are captured, no `Project` references leak into task state).
- New opt-out: `graalvm { autoIncludeResources = false }` (defaults to `true`).

## Why

Apps with resources loaded by computed paths (e.g. a library of thousands of markdown files enumerated from an `index.txt`) previously had to hand-list every file in `reachability-metadata.json`, which the tracing agent only records for files actually opened during the trace. This closes the last gap where app-owned resources weren't handled automatically.

## Test plan

- [x] `:plugin:compileKotlin` — builds
- [x] `:plugin:ktlintMainSourceSetCheck` — passes (no new detekt/ktlint findings on the added code)
- [x] End-to-end: published to Maven Local and ran `generateGraalvmProjectResourceMetadata` on a KMP desktop app with `resources.srcDirs("../assets")` → generated the expected globs (`basics/**`, `commands/**`, `tips.md`, …) covering ~8.8k markdown assets
- [ ] Full `packageDistributionForCurrentOS` native build consuming the generated metadata