### PR TITLE
feat(tao): pause the render loop while the window is minimized

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -729,6 +729,10 @@ public class TaoWindow internal constructor(
             TaoEventCode.MINIMIZED -> {
                 val minimized = a != 0
                 isMinimized = minimized
+                // On restore, re-kick the render loop. While minimized the scene
+                // host gates frames out before the frame clock ticks, so Compose
+                // animations are parked and nothing re-arms a redraw on its own.
+                if (!minimized) requestRedraw()
                 minimizedListeners.forEach { it.invoke(minimized) }
             }
             TaoEventCode.CURSOR_MOVED -> pointerMoveListener?.invoke(a, b)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -1221,6 +1221,13 @@ internal class TaoComposeSceneHost(
         val ctx = directContext ?: return
         if (attachmentHandle == 0L || widthPx <= 0 || heightPx <= 0) return
 
+        // Minimized: nothing is visible. Drop the frame before recording +
+        // advancing the frame clock — that parks Compose animations (no
+        // withFrameNanos tick → no re-invalidation), so the FrameDispatcher
+        // quiesces instead of rendering into a hidden surface. Restored via
+        // TaoWindow's requestRedraw on the MINIMIZED-off event.
+        if (window.isMinimized) return
+
         // ── interop transaction snapshot (main) ──
         val tx = retrieveTransaction()
         val needsTransaction =

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -1164,6 +1164,14 @@ internal class TaoComposeSceneHostLinux(
         // be able to schedule another redraw — i.e. the app would freeze.
         redrawPending.set(false)
 
+        // Minimized: skip before the frame-clock tick so animations park and
+        // the loop goes idle. Belt-and-suspenders here — the swap-in-flight
+        // back-pressure below already throttles an occluded/minimised window —
+        // but this also covers the app-synthesised minimize (Wayland reports no
+        // iconified state). redrawPending is already cleared above, so restore's
+        // requestRedraw re-arms cleanly.
+        if (window.isMinimized) return
+
         // Wait for the previous frame's `eglSwapBuffers` to complete on the
         // swap thread before issuing the next render. This is what gives us
         // hardware vsync without melting CPU: the swap thread parks in

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -942,6 +942,14 @@ internal class TaoComposeSceneHostWindows(
 
         if (widthPx <= 0 || heightPx <= 0) return
 
+        // Minimized: skip before the frame-clock tick below. Unlike
+        // Linux/Wayland there's no vsync back-pressure while minimized (ANGLE's
+        // flip-model swapchain never reports occlusion), so without this the
+        // loop would spin recording + presenting into a hidden surface whenever
+        // an animation keeps invalidating. Parks animations; restored via
+        // TaoWindow.requestRedraw on the MINIMIZED-off event.
+        if (window.isMinimized) return
+
         // Push a pending size into the ComposeScene + GL surface before the
         // frame-clock drain, so the size-change-driven recomposition (and any
         // coroutine keyed on the new size) is scheduled and drained this frame.


### PR DESCRIPTION
## What

Stop driving the render loop while a tao window is minimized, instead of continuing to record + present frames into a surface the user cannot see.

Each platform scene host gets a `if (window.isMinimized) return` guard at the top of its frame body, placed **before the frame-clock tick**:

- `TaoComposeSceneHost.kt` (macOS) — `renderFrameSuspending`
- `TaoComposeSceneHostWindows.kt` — `onRedrawRequested`
- `TaoComposeSceneHostLinux.kt` — `onRedrawRequested`

`TaoWindow` re-kicks the loop with `requestRedraw()` on the `MINIMIZED`-off (restore) event.

## Why

The loop is `invalidate`-driven, so a *static* minimized window already renders nothing. The gap is *animated* content: Compose animations keep invalidating and the loop keeps doing full record + GPU work into a hidden surface.

- **Windows is the real case**: ANGLE uses a flip-model swapchain, which never returns `DXGI_STATUS_OCCLUDED`, so there is no vsync back-pressure while minimized — the loop can spin at full rate.
- **Linux** already throttles via swap-in-flight back-pressure (Wayland withholds frame callbacks when occluded); the guard is belt-and-suspenders there and additionally covers the app-synthesised minimize (Wayland reports no iconified state).
- **macOS** has no such back-pressure on the Metal present path.

## Mechanism

Gating **before** `sendFrame` means the frame clock never advances while minimized, so `withFrameNanos`-driven animations re-suspend without emitting new invalidations. The `FrameDispatcher` then parks on its own — only the frame(s) already in flight at minimize time hit the early return. Restore's `requestRedraw` advances the clock again and resumes normal rendering.

This mirrors the standard practice of Flutter (`AppLifecycleState.hidden` stops `onBeginFrame`/`onDrawFrame`), Qt (`isExposed()` → stop rendering), Electron (`backgroundThrottling`) and browser rAF throttling — a pure render-pause, no forced GC.

## Test

`./gradlew :decorated-window-tao:compileKotlin` passes. Behavioural check: run a demo with a running animation, minimize, confirm CPU/GPU drops to idle and rendering resumes cleanly on restore.