### PR TITLE
fix(tao): clear pending JNI exceptions after a11y/deep-link upcalls

### DIFF
--- a/decorated-window-tao/src/main/native/src/platform/linux/a11y.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/a11y.rs
@@ -800,6 +800,10 @@ fn forward_action_to_jvm(
                     JValue::Object(&jstr.into()),
                 ],
             );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
         }
         Action::SetValue => {
             // Slider / progress value setter. AT-SPI's
@@ -820,6 +824,10 @@ fn forward_action_to_jvm(
                     JValue::Double(value),
                 ],
             );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
         }
         Action::SetScrollOffset | Action::ScrollToPoint => {
             // Both carry a target point; forward as an absolute scroll
@@ -841,6 +849,10 @@ fn forward_action_to_jvm(
                     JValue::Float(dy),
                 ],
             );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
         }
         Action::SetTextSelection => {
             let sel = match request.data {
@@ -858,6 +870,10 @@ fn forward_action_to_jvm(
                     JValue::Int(sel.focus.character_index as i32),
                 ],
             );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
         }
         Action::CustomAction => {
             let idx = match request.data {
@@ -877,6 +893,10 @@ fn forward_action_to_jvm(
                     JValue::Int(idx),
                 ],
             );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
         }
         _ => {
             if action_bit == 0 {
@@ -892,6 +912,10 @@ fn forward_action_to_jvm(
                     JValue::Int(action_bit),
                 ],
             );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
         }
     }
 }

--- a/decorated-window-tao/src/main/native/src/platform/macos/a11y.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/a11y.rs
@@ -196,6 +196,10 @@ pub extern "C" fn nucleus_tao_a11y_set_text(
                 JValue::Object(&jstr.into()),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 
@@ -224,6 +228,10 @@ pub extern "C" fn nucleus_tao_a11y_invoke_custom_action(
                 JValue::Int(action_index),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 
@@ -254,6 +262,10 @@ pub extern "C" fn nucleus_tao_a11y_scroll_by(
                 JValue::Float(dy),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 
@@ -284,6 +296,10 @@ pub extern "C" fn nucleus_tao_a11y_set_selection(
                 JValue::Int(end),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 
@@ -314,5 +330,9 @@ pub extern "C" fn nucleus_tao_a11y_invoke_action(
                 JValue::Int(action as i32),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }

--- a/decorated-window-tao/src/main/native/src/platform/macos/apple_events.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/apple_events.rs
@@ -32,5 +32,9 @@ pub(crate) fn dispatch_deep_link(url: &str) {
             "(Ljava/lang/String;)V",
             &[JValue::Object(&jstr.into())],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }

--- a/decorated-window-tao/src/main/native/src/platform/windows/a11y.rs
+++ b/decorated-window-tao/src/main/native/src/platform/windows/a11y.rs
@@ -181,6 +181,10 @@ extern "system" fn invoke_action_trampoline(hwnd: i64, node_id: u64, action: u16
                 JValue::Int(action as i32),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 
@@ -209,6 +213,10 @@ extern "system" fn set_text_trampoline(
                 JValue::Object(&jstr.into()),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 
@@ -234,6 +242,10 @@ extern "system" fn set_selection_trampoline(
                 JValue::Int(end),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 
@@ -259,6 +271,10 @@ extern "system" fn scroll_by_trampoline(
                 JValue::Float(dy),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 
@@ -283,6 +299,10 @@ extern "system" fn set_value_trampoline(
                 JValue::Double(value),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 
@@ -307,6 +327,10 @@ extern "system" fn custom_action_trampoline(
                 JValue::Int(index),
             ],
         );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

The accessibility and deep-link **native → JVM** callbacks in the tao backend call into `NativeTaoBridge.dispatch*` via `call_static_method` but **never** `exception_check` / `exception_clear` afterwards — unlike the pointer / key / touch / DnD dispatch paths (`events.rs`, `dnd.rs`, `touch.rs`), which all consistently do:

```rust
if env.exception_check().unwrap_or(false) {
    let _ = env.exception_describe();
    let _ = env.exception_clear();
}
```

If a Kotlin `dispatchA11y*` / `dispatchDeepLink` handler throws, the exception stays **pending on the callback thread** — a long-lived thread (AT-SPI/zbus on Linux, UIA on Windows, AppKit on macOS) that keeps issuing further `find_class` + `call_static_method` calls. A JNI call made with a pending exception is **undefined behaviour**, and since the crate ships with `panic = "abort"` (`Cargo.toml`), it escalates to a **process abort** whose crash site looks unrelated to the actual bug.

This is the one place a *routine* JVM-side exception (not a Rust logic bug) can take down the whole app.

## Fix

Apply the same guard already proven in `events.rs`/`dnd.rs`/`touch.rs` to all **18** previously-unguarded upcall sites:

| file | sites |
|---|---|
| `platform/macos/apple_events.rs` | 1 (`dispatchDeepLink`) |
| `platform/macos/a11y.rs` | 5 |
| `platform/windows/a11y.rs` | 6 |
| `platform/linux/a11y.rs` | 6 |

Pattern is inlined verbatim (matching the existing style in the dispatch modules) rather than abstracted, so the diff reads as "same guard, applied to the sites that were missing it." A helper-based refactor of all ~25 sites is a reasonable follow-up but intentionally out of scope here.

## Verification

- **macOS side** (`apple_events.rs` + `macos/a11y.rs` + all shared code): `cargo check` passes clean (only pre-existing `dead_code` warnings from vendored `tao`).
- **Windows / Linux a11y** are `cfg`-gated and can't be cross-compiled on the dev machine; validated by `rustfmt` parse-check (no syntax errors) and by copying the proven pattern verbatim.
- No behavioural change on the happy path — the guard only fires when a handler actually threw, exactly as the existing dispatch paths already behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)