### PR TITLE
refactor(tao): extract shared scene drag-and-drop into TaoSceneDnD

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/dnd/TaoSceneDnD.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/dnd/TaoSceneDnD.kt
@@ -1,0 +1,176 @@
+package dev.nucleusframework.window.tao.dnd
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTransferAction
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.scene.ComposeSceneDragAndDropNode
+import dev.nucleusframework.window.tao.TaoDragAndDropPayload
+import java.awt.Point
+import java.awt.dnd.DnDConstants
+import java.io.File
+
+/**
+ * Platform-agnostic drag-and-drop scene wiring, shared by the macOS, Windows and
+ * Linux [dev.nucleusframework.window.tao.scene] hosts.
+ *
+ * The three hosts previously each carried a byte-identical copy of this logic;
+ * the only per-platform differences are the native bridge object
+ * (`NativeTao{MacOs,Windows,Linux}DndBridge`) and the first callback parameter
+ * name (nsView/hwnd/handle). Everything below is independent of those, so it
+ * lives here once.
+ *
+ * This helper is the **common denominator only** — event construction plus the
+ * Compose-node handoff. Two per-host quirks are deliberately kept in each host's
+ * thin `InboundDnDCallback` override rather than folded in here, because they
+ * are genuine behavioural differences, not duplication:
+ *  - `TaoDnDDiagnostics.log(...)` calls (macOS/Windows log; Linux does not);
+ *  - the `if (!hasFiles) return NONE` short-circuit in `onDragEnter`
+ *    (macOS/Windows guard non-file drags; Linux intentionally does not).
+ * Folding either in here would silently change Linux behaviour.
+ *
+ * Inbound handlers return a plain `Boolean` (accepted?) rather than a
+ * `DROP_EFFECT_*` constant: each host maps `true → its own DROP_EFFECT_COPY` and
+ * `false → its own DROP_EFFECT_NONE`, so nothing here depends on the three
+ * bridges happening to share the same integer values.
+ *
+ * Each host keeps its own named `InboundDnDCallback` implementing that bridge's
+ * `Callback` interface (required for GraalVM JNI reachability — anonymous
+ * classes aren't picked up by `GetMethodID`); the overrides just delegate here.
+ */
+@OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
+internal object TaoSceneDnD {
+    private fun makeDragEvent(
+        xPx: Int,
+        yPx: Int,
+        files: Array<String>?,
+    ): DragAndDropEvent = makeEvent(xPx, yPx, files, drop = false)
+
+    private fun makeDropEvent(
+        xPx: Int,
+        yPx: Int,
+        files: Array<String>?,
+    ): DragAndDropEvent = makeEvent(xPx, yPx, files, drop = true)
+
+    private fun makeEvent(
+        xPx: Int,
+        yPx: Int,
+        files: Array<String>?,
+        drop: Boolean,
+    ): DragAndDropEvent {
+        val payload = TaoDragAndDropPayload(files = files?.toList() ?: emptyList())
+        val transferable = TaoFilesTransferable(files = payload.files.map { File(it) })
+        val cursor = Point(xPx, yPx)
+        val native =
+            if (drop) {
+                TaoSyntheticDropEvent(
+                    cursorLocn = cursor,
+                    dropAction = DnDConstants.ACTION_COPY,
+                    backingTransferable = transferable,
+                    payload = payload,
+                )
+            } else {
+                TaoSyntheticDragEvent(
+                    cursorLocn = cursor,
+                    dropAction = DnDConstants.ACTION_COPY,
+                    backingTransferable = transferable,
+                    payload = payload,
+                )
+            }
+        return DragAndDropEvent(
+            action = DragAndDropTransferAction.Copy,
+            nativeEvent = native,
+            positionInRootImpl = Offset(xPx.toFloat(), yPx.toFloat()),
+        )
+    }
+
+    /**
+     * @return true if the drag was accepted (host maps to DROP_EFFECT_COPY, else
+     *   NONE). Callers that guard non-file drags must do so before calling.
+     */
+    fun onDragEnter(
+        node: ComposeSceneDragAndDropNode?,
+        x: Int,
+        y: Int,
+    ): Boolean {
+        if (node == null) return false
+        val ev = makeDragEvent(x, y, null)
+        val accepted = node.acceptDragAndDropTransfer(ev)
+        if (accepted) {
+            node.onStarted(ev)
+            node.onEntered(ev)
+        }
+        return accepted
+    }
+
+    /** @return true if a drop target is currently eligible. */
+    fun onDragOver(
+        node: ComposeSceneDragAndDropNode?,
+        x: Int,
+        y: Int,
+    ): Boolean {
+        if (node == null) return false
+        val ev = makeDragEvent(x, y, null)
+        node.onMoved(ev)
+        return node.hasEligibleDropTarget
+    }
+
+    fun onDragLeave(node: ComposeSceneDragAndDropNode?) {
+        if (node == null) return
+        val ev = makeDragEvent(-1, -1, null)
+        node.onExited(ev)
+        node.onEnded(ev)
+    }
+
+    /** @return true if the drop was accepted. */
+    fun onDrop(
+        node: ComposeSceneDragAndDropNode?,
+        x: Int,
+        y: Int,
+        files: Array<String>?,
+    ): Boolean {
+        if (node == null) return false
+        val ev = makeDropEvent(x, y, files)
+        val accepted = node.onDrop(ev)
+        node.onEnded(ev)
+        return accepted
+    }
+
+    /**
+     * Shared outbound (Compose source → OS) drag launch. The host supplies its
+     * bridge's `DROP_EFFECT_*` constants and a [startDrag] lambda wrapping the
+     * platform `nativeStartDrag`; the guards (`isLoaded`, valid surface handle)
+     * stay in the host since they read host state.
+     */
+    fun launchOutboundDrag(
+        request: TaoDragAndDropManager.OutboundRequest,
+        dropEffectCopy: Int,
+        dropEffectMove: Int,
+        dropEffectLink: Int,
+        startDrag: (files: Array<String>?, text: String?, allowedEffects: Int) -> Int,
+    ): DragAndDropTransferAction? {
+        val allowed =
+            request.supportedActions
+                .fold(0) { acc, action ->
+                    acc or
+                        when (action) {
+                            DragAndDropTransferAction.Copy -> dropEffectCopy
+                            DragAndDropTransferAction.Move -> dropEffectMove
+                            DragAndDropTransferAction.Link -> dropEffectLink
+                            else -> 0
+                        }
+                }.let { if (it == 0) dropEffectCopy else it }
+        val files =
+            request.files
+                .takeIf { it.isNotEmpty() }
+                ?.map { it.absolutePath }
+                ?.toTypedArray()
+        return when (startDrag(files, request.text, allowed)) {
+            dropEffectCopy -> DragAndDropTransferAction.Copy
+            dropEffectMove -> DragAndDropTransferAction.Move
+            dropEffectLink -> DragAndDropTransferAction.Link
+            else -> null
+        }
+    }
+}

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -378,48 +378,18 @@ internal class TaoComposeSceneHost(
     ): androidx.compose.ui.draganddrop.DragAndDropTransferAction? {
         if (!dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.isLoaded) return null
         if (nsViewHandle == 0L) return null
-
-        val allowed =
-            request.supportedActions
-                .fold(0) { acc, action ->
-                    acc or
-                        when (action) {
-                            androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy ->
-                                dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_COPY
-                            androidx.compose.ui.draganddrop.DragAndDropTransferAction.Move ->
-                                dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_MOVE
-                            androidx.compose.ui.draganddrop.DragAndDropTransferAction.Link ->
-                                dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_LINK
-                            else -> 0
-                        }
-                }.let {
-                    if (it == 0) {
-                        dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_COPY
-                    } else {
-                        it
-                    }
-                }
-
-        val files =
-            request.files
-                .takeIf { it.isNotEmpty() }
-                ?.map { it.absolutePath }
-                ?.toTypedArray()
-        val effect =
+        return dev.nucleusframework.window.tao.dnd.TaoSceneDnD.launchOutboundDrag(
+            request = request,
+            dropEffectCopy = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_COPY,
+            dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_MOVE,
+            dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_LINK,
+        ) { files, text, allowedEffects ->
             dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.nativeStartDrag(
                 nsView = nsViewHandle,
                 files = files,
-                text = request.text,
-                allowedEffects = allowed,
+                text = text,
+                allowedEffects = allowedEffects,
             )
-        return when (effect) {
-            dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_COPY ->
-                androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy
-            dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_MOVE ->
-                androidx.compose.ui.draganddrop.DragAndDropTransferAction.Move
-            dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_LINK ->
-                androidx.compose.ui.draganddrop.DragAndDropTransferAction.Link
-            else -> null
         }
     }
 
@@ -445,65 +415,7 @@ internal class TaoComposeSceneHost(
      */
     @OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
     private inner class InboundDnDCallback : dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.Callback {
-        private fun rootNode() = scene?.rootDragAndDropNode
-
-        private fun makeDragEvent(
-            xPx: Int,
-            yPx: Int,
-            files: Array<String>?,
-        ): androidx.compose.ui.draganddrop.DragAndDropEvent {
-            val payload =
-                dev.nucleusframework.window.tao.TaoDragAndDropPayload(
-                    files = files?.toList() ?: emptyList(),
-                )
-            val transferable =
-                dev.nucleusframework.window.tao.dnd.TaoFilesTransferable(
-                    files = payload.files.map { java.io.File(it) },
-                )
-            val native =
-                dev.nucleusframework.window.tao.dnd.TaoSyntheticDragEvent(
-                    cursorLocn = java.awt.Point(xPx, yPx),
-                    dropAction = java.awt.dnd.DnDConstants.ACTION_COPY,
-                    backingTransferable = transferable,
-                    payload = payload,
-                )
-            return androidx.compose.ui.draganddrop.DragAndDropEvent(
-                action = androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy,
-                nativeEvent = native,
-                positionInRootImpl =
-                    androidx.compose.ui.geometry
-                        .Offset(xPx.toFloat(), yPx.toFloat()),
-            )
-        }
-
-        private fun makeDropEvent(
-            xPx: Int,
-            yPx: Int,
-            files: Array<String>?,
-        ): androidx.compose.ui.draganddrop.DragAndDropEvent {
-            val payload =
-                dev.nucleusframework.window.tao.TaoDragAndDropPayload(
-                    files = files?.toList() ?: emptyList(),
-                )
-            val transferable =
-                dev.nucleusframework.window.tao.dnd.TaoFilesTransferable(
-                    files = payload.files.map { java.io.File(it) },
-                )
-            val native =
-                dev.nucleusframework.window.tao.dnd.TaoSyntheticDropEvent(
-                    cursorLocn = java.awt.Point(xPx, yPx),
-                    dropAction = java.awt.dnd.DnDConstants.ACTION_COPY,
-                    backingTransferable = transferable,
-                    payload = payload,
-                )
-            return androidx.compose.ui.draganddrop.DragAndDropEvent(
-                action = androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy,
-                nativeEvent = native,
-                positionInRootImpl =
-                    androidx.compose.ui.geometry
-                        .Offset(xPx.toFloat(), yPx.toFloat()),
-            )
-        }
+        private fun node() = scene?.rootDragAndDropNode
 
         override fun onDragEnter(
             nsView: Long,
@@ -518,16 +430,9 @@ internal class TaoComposeSceneHost(
             if (!hasFiles) {
                 return dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
             }
-            val node =
-                rootNode()
-                    ?: return dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
-            val ev = makeDragEvent(x, y, null)
-            val accepted = node.acceptDragAndDropTransfer(ev)
-            if (accepted) {
-                node.onStarted(ev)
-                node.onEntered(ev)
-            }
-            return if (accepted) {
+            return if (dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                    .onDragEnter(node(), x, y)
+            ) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_COPY
             } else {
                 dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
@@ -540,26 +445,20 @@ internal class TaoComposeSceneHost(
             y: Int,
             modState: Int,
             hasFiles: Boolean,
-        ): Int {
-            val node =
-                rootNode()
-                    ?: return dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
-            val ev = makeDragEvent(x, y, null)
-            node.onMoved(ev)
-            return if (node.hasEligibleDropTarget) {
+        ): Int =
+            if (dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                    .onDragOver(node(), x, y)
+            ) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_COPY
             } else {
                 dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
             }
-        }
 
         override fun onDragLeave(nsView: Long) {
             dev.nucleusframework.window.tao.TaoDnDDiagnostics
                 .log("onDragLeave")
-            val node = rootNode() ?: return
-            val ev = makeDragEvent(-1, -1, null)
-            node.onExited(ev)
-            node.onEnded(ev)
+            dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                .onDragLeave(node())
         }
 
         override fun onDrop(
@@ -572,13 +471,9 @@ internal class TaoComposeSceneHost(
             dev.nucleusframework.window.tao.TaoDnDDiagnostics.log(
                 "onDrop x=$x y=$y files=${files?.size ?: 0}",
             )
-            val node =
-                rootNode()
-                    ?: return dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_NONE
-            val ev = makeDropEvent(x, y, files)
-            val accepted = node.onDrop(ev)
-            node.onEnded(ev)
-            return if (accepted) {
+            return if (dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                    .onDrop(node(), x, y, files)
+            ) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_COPY
             } else {
                 dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_NONE

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -583,48 +583,18 @@ internal class TaoComposeSceneHostLinux(
     ): androidx.compose.ui.draganddrop.DragAndDropTransferAction? {
         if (!dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.isLoaded) return null
         if (window.handle == 0L) return null
-
-        val allowed =
-            request.supportedActions
-                .fold(0) { acc, action ->
-                    acc or
-                        when (action) {
-                            androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy ->
-                                dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_COPY
-                            androidx.compose.ui.draganddrop.DragAndDropTransferAction.Move ->
-                                dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_MOVE
-                            androidx.compose.ui.draganddrop.DragAndDropTransferAction.Link ->
-                                dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_LINK
-                            else -> 0
-                        }
-                }.let {
-                    if (it == 0) {
-                        dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_COPY
-                    } else {
-                        it
-                    }
-                }
-
-        val files =
-            request.files
-                .takeIf { it.isNotEmpty() }
-                ?.map { it.absolutePath }
-                ?.toTypedArray()
-        val effect =
+        return dev.nucleusframework.window.tao.dnd.TaoSceneDnD.launchOutboundDrag(
+            request = request,
+            dropEffectCopy = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_COPY,
+            dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_MOVE,
+            dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_LINK,
+        ) { files, text, allowedEffects ->
             dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.nativeStartDrag(
                 handle = window.handle,
                 files = files,
-                text = request.text,
-                allowedEffects = allowed,
+                text = text,
+                allowedEffects = allowedEffects,
             )
-        return when (effect) {
-            dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_COPY ->
-                androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy
-            dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_MOVE ->
-                androidx.compose.ui.draganddrop.DragAndDropTransferAction.Move
-            dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_LINK ->
-                androidx.compose.ui.draganddrop.DragAndDropTransferAction.Link
-            else -> null
         }
     }
 
@@ -643,91 +613,26 @@ internal class TaoComposeSceneHostLinux(
      */
     @OptIn(InternalComposeUiApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
     private inner class InboundDnDCallback : dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.Callback {
-        private fun rootNode() = scene?.rootDragAndDropNode
+        private fun node() = scene?.rootDragAndDropNode
 
-        // Coordinates from native are already in physical pixels (post
-        // `gtk_widget_translate_coordinates` × scale_factor on the Rust side),
-        // so we feed them straight into Compose's positionInRoot.
-        private fun makeDragEvent(
-            xPx: Int,
-            yPx: Int,
-            files: Array<String>?,
-        ): androidx.compose.ui.draganddrop.DragAndDropEvent {
-            val payload =
-                dev.nucleusframework.window.tao.TaoDragAndDropPayload(
-                    files = files?.toList() ?: emptyList(),
-                )
-            val transferable =
-                dev.nucleusframework.window.tao.dnd.TaoFilesTransferable(
-                    files = payload.files.map { java.io.File(it) },
-                )
-            val native =
-                dev.nucleusframework.window.tao.dnd.TaoSyntheticDragEvent(
-                    cursorLocn = java.awt.Point(xPx, yPx),
-                    dropAction = java.awt.dnd.DnDConstants.ACTION_COPY,
-                    backingTransferable = transferable,
-                    payload = payload,
-                )
-            return androidx.compose.ui.draganddrop.DragAndDropEvent(
-                action = androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy,
-                nativeEvent = native,
-                positionInRootImpl =
-                    androidx.compose.ui.geometry
-                        .Offset(xPx.toFloat(), yPx.toFloat()),
-            )
-        }
-
-        private fun makeDropEvent(
-            xPx: Int,
-            yPx: Int,
-            files: Array<String>?,
-        ): androidx.compose.ui.draganddrop.DragAndDropEvent {
-            val payload =
-                dev.nucleusframework.window.tao.TaoDragAndDropPayload(
-                    files = files?.toList() ?: emptyList(),
-                )
-            val transferable =
-                dev.nucleusframework.window.tao.dnd.TaoFilesTransferable(
-                    files = payload.files.map { java.io.File(it) },
-                )
-            val native =
-                dev.nucleusframework.window.tao.dnd.TaoSyntheticDropEvent(
-                    cursorLocn = java.awt.Point(xPx, yPx),
-                    dropAction = java.awt.dnd.DnDConstants.ACTION_COPY,
-                    backingTransferable = transferable,
-                    payload = payload,
-                )
-            return androidx.compose.ui.draganddrop.DragAndDropEvent(
-                action = androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy,
-                nativeEvent = native,
-                positionInRootImpl =
-                    androidx.compose.ui.geometry
-                        .Offset(xPx.toFloat(), yPx.toFloat()),
-            )
-        }
-
+        // Linux keeps neither the macOS/Windows diagnostic logging nor their
+        // `if (!hasFiles) return NONE` guard, so its overrides delegate straight
+        // to the shared helper. Folding those in via TaoSceneDnD would change
+        // Linux behaviour (rejecting non-file drags at enter).
         override fun onDragEnter(
             handle: Long,
             x: Int,
             y: Int,
             modState: Int,
             hasFiles: Boolean,
-        ): Int {
-            val node =
-                rootNode()
-                    ?: return dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_NONE
-            val ev = makeDragEvent(x, y, null)
-            val accepted = node.acceptDragAndDropTransfer(ev)
-            if (accepted) {
-                node.onStarted(ev)
-                node.onEntered(ev)
-            }
-            return if (accepted) {
+        ): Int =
+            if (dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                    .onDragEnter(node(), x, y)
+            ) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_COPY
             } else {
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_NONE
             }
-        }
 
         override fun onDragOver(
             handle: Long,
@@ -735,25 +640,18 @@ internal class TaoComposeSceneHostLinux(
             y: Int,
             modState: Int,
             hasFiles: Boolean,
-        ): Int {
-            val node =
-                rootNode()
-                    ?: return dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_NONE
-            val ev = makeDragEvent(x, y, null)
-            node.onMoved(ev)
-            return if (node.hasEligibleDropTarget) {
+        ): Int =
+            if (dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                    .onDragOver(node(), x, y)
+            ) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_COPY
             } else {
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_NONE
             }
-        }
 
-        override fun onDragLeave(handle: Long) {
-            val node = rootNode() ?: return
-            val ev = makeDragEvent(-1, -1, null)
-            node.onExited(ev)
-            node.onEnded(ev)
-        }
+        override fun onDragLeave(handle: Long) =
+            dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                .onDragLeave(node())
 
         override fun onDrop(
             handle: Long,
@@ -761,19 +659,14 @@ internal class TaoComposeSceneHostLinux(
             y: Int,
             modState: Int,
             files: Array<String>?,
-        ): Int {
-            val node =
-                rootNode()
-                    ?: return dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_NONE
-            val ev = makeDropEvent(x, y, files)
-            val accepted = node.onDrop(ev)
-            node.onEnded(ev)
-            return if (accepted) {
+        ): Int =
+            if (dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                    .onDrop(node(), x, y, files)
+            ) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_COPY
             } else {
                 dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_NONE
             }
-        }
     }
 
     // ── Touch & trackpad gestures (Linux) ─────────────────────────────────

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -593,48 +593,18 @@ internal class TaoComposeSceneHostWindows(
     ): androidx.compose.ui.draganddrop.DragAndDropTransferAction? {
         if (!dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.isLoaded) return null
         if (hwnd == 0L) return null
-
-        val allowed =
-            request.supportedActions
-                .fold(0) { acc, action ->
-                    acc or
-                        when (action) {
-                            androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy ->
-                                dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_COPY
-                            androidx.compose.ui.draganddrop.DragAndDropTransferAction.Move ->
-                                dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_MOVE
-                            androidx.compose.ui.draganddrop.DragAndDropTransferAction.Link ->
-                                dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_LINK
-                            else -> 0
-                        }
-                }.let {
-                    if (it == 0) {
-                        dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_COPY
-                    } else {
-                        it
-                    }
-                }
-
-        val files =
-            request.files
-                .takeIf { it.isNotEmpty() }
-                ?.map { it.absolutePath }
-                ?.toTypedArray()
-        val effect =
+        return dev.nucleusframework.window.tao.dnd.TaoSceneDnD.launchOutboundDrag(
+            request = request,
+            dropEffectCopy = dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_COPY,
+            dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_MOVE,
+            dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_LINK,
+        ) { files, text, allowedEffects ->
             dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.nativeStartDrag(
                 hwnd = hwnd,
                 files = files,
-                text = request.text,
-                allowedEffects = allowed,
+                text = text,
+                allowedEffects = allowedEffects,
             )
-        return when (effect) {
-            dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_COPY ->
-                androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy
-            dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_MOVE ->
-                androidx.compose.ui.draganddrop.DragAndDropTransferAction.Move
-            dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_LINK ->
-                androidx.compose.ui.draganddrop.DragAndDropTransferAction.Link
-            else -> null
         }
     }
 
@@ -662,65 +632,7 @@ internal class TaoComposeSceneHostWindows(
     @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
     private inner class InboundDnDCallback :
         dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.Callback {
-        private fun rootNode() = scene?.rootDragAndDropNode
-
-        private fun makeDragEvent(
-            xPx: Int,
-            yPx: Int,
-            files: Array<String>?,
-        ): androidx.compose.ui.draganddrop.DragAndDropEvent {
-            val payload =
-                dev.nucleusframework.window.tao.TaoDragAndDropPayload(
-                    files = files?.toList() ?: emptyList(),
-                )
-            val transferable =
-                dev.nucleusframework.window.tao.dnd.TaoFilesTransferable(
-                    files = payload.files.map { java.io.File(it) },
-                )
-            val native =
-                dev.nucleusframework.window.tao.dnd.TaoSyntheticDragEvent(
-                    cursorLocn = java.awt.Point(xPx, yPx),
-                    dropAction = java.awt.dnd.DnDConstants.ACTION_COPY,
-                    backingTransferable = transferable,
-                    payload = payload,
-                )
-            return androidx.compose.ui.draganddrop.DragAndDropEvent(
-                action = androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy,
-                nativeEvent = native,
-                positionInRootImpl =
-                    androidx.compose.ui.geometry
-                        .Offset(xPx.toFloat(), yPx.toFloat()),
-            )
-        }
-
-        private fun makeDropEvent(
-            xPx: Int,
-            yPx: Int,
-            files: Array<String>?,
-        ): androidx.compose.ui.draganddrop.DragAndDropEvent {
-            val payload =
-                dev.nucleusframework.window.tao.TaoDragAndDropPayload(
-                    files = files?.toList() ?: emptyList(),
-                )
-            val transferable =
-                dev.nucleusframework.window.tao.dnd.TaoFilesTransferable(
-                    files = payload.files.map { java.io.File(it) },
-                )
-            val native =
-                dev.nucleusframework.window.tao.dnd.TaoSyntheticDropEvent(
-                    cursorLocn = java.awt.Point(xPx, yPx),
-                    dropAction = java.awt.dnd.DnDConstants.ACTION_COPY,
-                    backingTransferable = transferable,
-                    payload = payload,
-                )
-            return androidx.compose.ui.draganddrop.DragAndDropEvent(
-                action = androidx.compose.ui.draganddrop.DragAndDropTransferAction.Copy,
-                nativeEvent = native,
-                positionInRootImpl =
-                    androidx.compose.ui.geometry
-                        .Offset(xPx.toFloat(), yPx.toFloat()),
-            )
-        }
+        private fun node() = scene?.rootDragAndDropNode
 
         override fun onDragEnter(
             hwnd: Long,
@@ -735,16 +647,9 @@ internal class TaoComposeSceneHostWindows(
             if (!hasFiles) {
                 return dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
             }
-            val node =
-                rootNode()
-                    ?: return dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
-            val ev = makeDragEvent(x, y, null)
-            val accepted = node.acceptDragAndDropTransfer(ev)
-            if (accepted) {
-                node.onStarted(ev)
-                node.onEntered(ev)
-            }
-            return if (accepted) {
+            return if (dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                    .onDragEnter(node(), x, y)
+            ) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_COPY
             } else {
                 dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
@@ -757,26 +662,20 @@ internal class TaoComposeSceneHostWindows(
             y: Int,
             keyState: Int,
             hasFiles: Boolean,
-        ): Int {
-            val node =
-                rootNode()
-                    ?: return dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
-            val ev = makeDragEvent(x, y, null)
-            node.onMoved(ev)
-            return if (node.hasEligibleDropTarget) {
+        ): Int =
+            if (dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                    .onDragOver(node(), x, y)
+            ) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_COPY
             } else {
                 dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
             }
-        }
 
         override fun onDragLeave(hwnd: Long) {
             dev.nucleusframework.window.tao.TaoDnDDiagnostics
                 .log("onDragLeave")
-            val node = rootNode() ?: return
-            val ev = makeDragEvent(-1, -1, null)
-            node.onExited(ev)
-            node.onEnded(ev)
+            dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                .onDragLeave(node())
         }
 
         override fun onDrop(
@@ -789,13 +688,9 @@ internal class TaoComposeSceneHostWindows(
             dev.nucleusframework.window.tao.TaoDnDDiagnostics.log(
                 "onDrop x=$x y=$y files=${files?.size ?: 0}",
             )
-            val node =
-                rootNode()
-                    ?: return dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_NONE
-            val ev = makeDropEvent(x, y, files)
-            val accepted = node.onDrop(ev)
-            node.onEnded(ev)
-            return if (accepted) {
+            return if (dev.nucleusframework.window.tao.dnd.TaoSceneDnD
+                    .onDrop(node(), x, y, files)
+            ) {
                 dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_COPY
             } else {
                 dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_NONE


### PR DESCRIPTION
## Problem

The three Compose scene hosts each carried a **byte-identical** copy of the drag-and-drop wiring — the inbound `InboundDnDCallback` (`makeDragEvent`/`makeDropEvent` + the `onDragEnter`/`Over`/`Leave`/`Drop` node handoff) and the outbound `launch*OutboundDrag` — ~130 lines per host. The only real differences were the native bridge object (`NativeTao{MacOs,Windows,Linux}DndBridge`) and the first callback parameter name (`nsView`/`hwnd`/`handle`). A DnD fix had to be made in three places and manually kept in sync.

## Change

New `dnd/TaoSceneDnD` holds the platform-agnostic core:

- **`makeDragEvent` / `makeDropEvent`** — moved verbatim; they referenced no bridge, so they were already platform-agnostic.
- **The four inbound node-handoff handlers**, returning a plain `Boolean` (accepted?) rather than a `DROP_EFFECT_*` int. Each host maps `true → its own DROP_EFFECT_COPY`, `false → NONE`, so nothing depends on the three bridges happening to share the same integer values.
- **`launchOutboundDrag`**, parameterised on the bridge's `DROP_EFFECT_*` constants and a `nativeStartDrag` lambda.

Each host **keeps its own named `InboundDnDCallback`** implementing that bridge's `Callback` interface — required for GraalVM JNI reachability (anonymous classes aren't picked up by `GetMethodID`) — but the overrides now just delegate.

## Behaviour is preserved exactly

Two deliberate per-host quirks are **left in the thin overrides**, not folded into the shared helper, because folding them in would silently change Linux:

- macOS/Windows log via `TaoDnDDiagnostics` and guard `if (!hasFiles) return NONE` in `onDragEnter`; **Linux does neither**.
- On Linux, `has_files` is the presence of a `text/uri-list` target (`platform/linux/dnd.rs`), so the guard is **not** a no-op — folding it in would start rejecting non-file drags at enter. Left as a separate decision for whoever owns Linux DnD.

## Verification

Net: **3 hosts −391/+51**, one ~190-line shared file. All three scene hosts compile together on any OS (platform selection is at runtime), so the Windows/Linux delegations are compiler-validated locally, not just macOS:

- `:decorated-window-tao:compileKotlin` ✅
- `:decorated-window-tao:ktlintCheck` ✅
- `:decorated-window-tao:detekt` ✅
- `:decorated-window-tao:test --tests "*.dnd.*"` ✅

(all on macOS / JDK 21)

Follow-ups from the same duplication audit, intentionally out of scope: unify the trackpad-gesture synthesiser (macOS/Linux), the `FlushingMainDispatcher` (Windows/Linux), `mapPointerIcon`/`windowInsets`, and route the two GL hosts through the existing `renderGlFrame` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)