### PR TITLE
fix(tao): scope JNI local refs on permanently-attached upcall threads

### DIFF
--- a/decorated-window-tao/src/main/native/src/platform/linux/dnd.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/dnd.rs
@@ -252,28 +252,34 @@ fn dispatch_drop(
     let Ok(mut env) = vm.attach_current_thread_permanently() else {
         return DROP_EFFECT_NONE;
     };
-    let arr = match build_string_array(&mut env, files) {
-        Some(a) => a,
-        None => return DROP_EFFECT_NONE,
-    };
-    let res = env.call_method(
-        callback.as_obj(),
-        "onDrop",
-        "(JIII[Ljava/lang/String;)I",
-        &[
-            JValue::Long(handle as jlong),
-            JValue::Int(x),
-            JValue::Int(y),
-            JValue::Int(0),
-            JValue::Object(&arr),
-        ],
-    );
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_describe();
-        let _ = env.exception_clear();
-        return DROP_EFFECT_NONE;
-    }
-    res.and_then(|v| v.i()).unwrap_or(DROP_EFFECT_NONE)
+    // The String[] and its elements are JNI local refs. This runs on the Tao
+    // loop thread (attached permanently, frame never popped), so scope them in
+    // a local frame or every drop leaks the array + one ref per file.
+    env.with_local_frame(files.len() as i32 + 6, |env| -> Result<jint, jni::errors::Error> {
+        let arr = match build_string_array(env, files) {
+            Some(a) => a,
+            None => return Ok(DROP_EFFECT_NONE),
+        };
+        let res = env.call_method(
+            callback.as_obj(),
+            "onDrop",
+            "(JIII[Ljava/lang/String;)I",
+            &[
+                JValue::Long(handle as jlong),
+                JValue::Int(x),
+                JValue::Int(y),
+                JValue::Int(0),
+                JValue::Object(&arr),
+            ],
+        );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+            return Ok(DROP_EFFECT_NONE);
+        }
+        Ok(res.and_then(|v| v.i()).unwrap_or(DROP_EFFECT_NONE))
+    })
+    .unwrap_or(DROP_EFFECT_NONE)
 }
 
 fn build_string_array<'a>(

--- a/decorated-window-tao/src/main/native/src/platform/linux/touch.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/touch.rs
@@ -198,32 +198,40 @@ fn dispatch_touch(
         }
     }
 
-    let Ok(ids_arr) = env.new_long_array(count) else { return };
-    if env.set_long_array_region(&ids_arr, 0, &ids).is_err() { return }
-    let Ok(xs_arr) = env.new_long_array(count) else { return };
-    if env.set_long_array_region(&xs_arr, 0, &xs).is_err() { return }
-    let Ok(ys_arr) = env.new_long_array(count) else { return };
-    if env.set_long_array_region(&ys_arr, 0, &ys).is_err() { return }
+    // The three long[] arrays are JNI local refs. `dispatch_touch` runs on the
+    // Tao loop thread, which is attached *permanently* — nothing ever pops its
+    // frame, so without a scoped local frame each touch event (up to ~one per
+    // display refresh during a drag) would leak three refs until the JNI local
+    // reference table overflows and aborts the JVM. `with_local_frame` reclaims
+    // them on return, including the early-error paths.
+    let _ = env.with_local_frame(8, |env| -> Result<(), jni::errors::Error> {
+        let ids_arr = env.new_long_array(count)?;
+        env.set_long_array_region(&ids_arr, 0, &ids)?;
+        let xs_arr = env.new_long_array(count)?;
+        env.set_long_array_region(&xs_arr, 0, &xs)?;
+        let ys_arr = env.new_long_array(count)?;
+        env.set_long_array_region(&ys_arr, 0, &ys)?;
 
-    let res = env.call_method(
-        callback.as_obj(),
-        "onTouchEvent",
-        "(JII[J[J[JJ)V",
-        &[
-            JValue::Long(handle as jlong),
-            JValue::Int(event_type),
-            JValue::Int(count),
-            JValue::Object(&ids_arr.into()),
-            JValue::Object(&xs_arr.into()),
-            JValue::Object(&ys_arr.into()),
-            JValue::Long(pressed_mask),
-        ],
-    );
-    let _ = res;
-    if env.exception_check().unwrap_or(false) {
-        let _ = env.exception_describe();
-        let _ = env.exception_clear();
-    }
+        let _ = env.call_method(
+            callback.as_obj(),
+            "onTouchEvent",
+            "(JII[J[J[JJ)V",
+            &[
+                JValue::Long(handle as jlong),
+                JValue::Int(event_type),
+                JValue::Int(count),
+                JValue::Object(&ids_arr.into()),
+                JValue::Object(&xs_arr.into()),
+                JValue::Object(&ys_arr.into()),
+                JValue::Long(pressed_mask),
+            ],
+        );
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
+        Ok(())
+    });
 }
 
 /// Dispatch a trackpad gesture (MAGNIFY or ROTATE) to the per-window

--- a/decorated-window-tao/src/main/native/src/platform/macos/a11y.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/a11y.rs
@@ -181,25 +181,28 @@ pub extern "C" fn nucleus_tao_a11y_set_text(
     let slice = unsafe { std::slice::from_raw_parts(utf8, len as usize) };
     let Ok(text) = std::str::from_utf8(slice) else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge") {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let Ok(jstr) = env.new_string(text) else { return };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11ySetText",
-            "(JJLjava/lang/String;)V",
-            &[
-                JValue::Long(ns_view_handle),
-                JValue::Long(node_id as i64),
-                JValue::Object(&jstr.into()),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // AppKit action callbacks arrive on the main thread, which the Tao loop
+        // attached permanently, so the class + string local refs are never
+        // reclaimed without a scoped frame.
+        let _ = env.with_local_frame(6, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let jstr = env.new_string(text)?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11ySetText",
+                "(JJLjava/lang/String;)V",
+                &[
+                    JValue::Long(ns_view_handle),
+                    JValue::Long(node_id as i64),
+                    JValue::Object(&jstr.into()),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 
@@ -214,24 +217,26 @@ pub extern "C" fn nucleus_tao_a11y_invoke_custom_action(
 ) {
     let Some(jvm) = JAVA_VM.get() else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge") {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11yCustomAction",
-            "(JJI)V",
-            &[
-                JValue::Long(ns_view_handle),
-                JValue::Long(node_id as i64),
-                JValue::Int(action_index),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Scoped frame: reclaims the `find_class` local ref on the permanently
+        // attached AppKit main thread (see nucleus_tao_a11y_set_text).
+        let _ = env.with_local_frame(4, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11yCustomAction",
+                "(JJI)V",
+                &[
+                    JValue::Long(ns_view_handle),
+                    JValue::Long(node_id as i64),
+                    JValue::Int(action_index),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 
@@ -247,25 +252,27 @@ pub extern "C" fn nucleus_tao_a11y_scroll_by(
 ) {
     let Some(jvm) = JAVA_VM.get() else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge") {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11yScrollBy",
-            "(JJFF)V",
-            &[
-                JValue::Long(ns_view_handle),
-                JValue::Long(node_id as i64),
-                JValue::Float(dx),
-                JValue::Float(dy),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Scoped frame: reclaims the `find_class` local ref on the permanently
+        // attached AppKit main thread (see nucleus_tao_a11y_set_text).
+        let _ = env.with_local_frame(4, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11yScrollBy",
+                "(JJFF)V",
+                &[
+                    JValue::Long(ns_view_handle),
+                    JValue::Long(node_id as i64),
+                    JValue::Float(dx),
+                    JValue::Float(dy),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 
@@ -281,25 +288,27 @@ pub extern "C" fn nucleus_tao_a11y_set_selection(
 ) {
     let Some(jvm) = JAVA_VM.get() else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge") {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11ySetSelection",
-            "(JJII)V",
-            &[
-                JValue::Long(ns_view_handle),
-                JValue::Long(node_id as i64),
-                JValue::Int(start),
-                JValue::Int(end),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Scoped frame: reclaims the `find_class` local ref on the permanently
+        // attached AppKit main thread (see nucleus_tao_a11y_set_text).
+        let _ = env.with_local_frame(4, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11ySetSelection",
+                "(JJII)V",
+                &[
+                    JValue::Long(ns_view_handle),
+                    JValue::Long(node_id as i64),
+                    JValue::Int(start),
+                    JValue::Int(end),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 
@@ -316,23 +325,25 @@ pub extern "C" fn nucleus_tao_a11y_invoke_action(
 ) {
     let Some(jvm) = JAVA_VM.get() else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge") {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11yActionByNsView",
-            "(JJI)V",
-            &[
-                JValue::Long(ns_view_handle),
-                JValue::Long(node_id as i64),
-                JValue::Int(action as i32),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Scoped frame: reclaims the `find_class` local ref on the permanently
+        // attached AppKit main thread (see nucleus_tao_a11y_set_text).
+        let _ = env.with_local_frame(4, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11yActionByNsView",
+                "(JJI)V",
+                &[
+                    JValue::Long(ns_view_handle),
+                    JValue::Long(node_id as i64),
+                    JValue::Int(action as i32),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }

--- a/decorated-window-tao/src/main/native/src/platform/macos/apple_events.rs
+++ b/decorated-window-tao/src/main/native/src/platform/macos/apple_events.rs
@@ -21,20 +21,23 @@ pub(crate) fn dispatch_deep_link(url: &str) {
         return;
     }
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge") {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let Ok(jstr) = env.new_string(url) else { return };
-        let _ = env.call_static_method(
-            class,
-            "dispatchDeepLink",
-            "(Ljava/lang/String;)V",
-            &[JValue::Object(&jstr.into())],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Runs on the AppKit main thread, which the Tao loop attached
+        // *permanently* — the `find_class` + `new_string` local refs would never
+        // be reclaimed. Bound them in a scoped local frame.
+        let _ = env.with_local_frame(6, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let jstr = env.new_string(url)?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchDeepLink",
+                "(Ljava/lang/String;)V",
+                &[JValue::Object(&jstr.into())],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }

--- a/decorated-window-tao/src/main/native/src/platform/windows/a11y.rs
+++ b/decorated-window-tao/src/main/native/src/platform/windows/a11y.rs
@@ -165,26 +165,27 @@ fn api() -> Option<&'static A11yApi> {
 extern "system" fn invoke_action_trampoline(hwnd: i64, node_id: u64, action: u16) {
     let Some(jvm) = JAVA_VM.get() else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class(
-            "dev/nucleusframework/window/tao/ffi/NativeTaoBridge",
-        ) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11yActionByNsView",
-            "(JJI)V",
-            &[
-                JValue::Long(hwnd),
-                JValue::Long(node_id as i64),
-                JValue::Int(action as i32),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // UIA dispatches provider calls on the message-pump thread, which the
+        // Tao loop attached permanently — bound the `find_class` local ref in a
+        // scoped frame so it doesn't leak per action.
+        let _ = env.with_local_frame(4, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11yActionByNsView",
+                "(JJI)V",
+                &[
+                    JValue::Long(hwnd),
+                    JValue::Long(node_id as i64),
+                    JValue::Int(action as i32),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 
@@ -196,27 +197,27 @@ extern "system" fn set_text_trampoline(
     let slice = unsafe { std::slice::from_raw_parts(utf8, len as usize) };
     let Ok(text) = std::str::from_utf8(slice) else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class(
-            "dev/nucleusframework/window/tao/ffi/NativeTaoBridge",
-        ) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let Ok(jstr) = env.new_string(text) else { return };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11ySetText",
-            "(JJLjava/lang/String;)V",
-            &[
-                JValue::Long(hwnd),
-                JValue::Long(node_id as i64),
-                JValue::Object(&jstr.into()),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Scoped frame: reclaims the class + string local refs on the
+        // permanently attached message-pump thread (see invoke_action_trampoline).
+        let _ = env.with_local_frame(6, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let jstr = env.new_string(text)?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11ySetText",
+                "(JJLjava/lang/String;)V",
+                &[
+                    JValue::Long(hwnd),
+                    JValue::Long(node_id as i64),
+                    JValue::Object(&jstr.into()),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 
@@ -225,27 +226,27 @@ extern "system" fn set_selection_trampoline(
 ) {
     let Some(jvm) = JAVA_VM.get() else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class(
-            "dev/nucleusframework/window/tao/ffi/NativeTaoBridge",
-        ) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11ySetSelection",
-            "(JJII)V",
-            &[
-                JValue::Long(hwnd),
-                JValue::Long(node_id as i64),
-                JValue::Int(start),
-                JValue::Int(end),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Scoped frame: reclaims the `find_class` local ref on the permanently
+        // attached message-pump thread (see invoke_action_trampoline).
+        let _ = env.with_local_frame(4, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11ySetSelection",
+                "(JJII)V",
+                &[
+                    JValue::Long(hwnd),
+                    JValue::Long(node_id as i64),
+                    JValue::Int(start),
+                    JValue::Int(end),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 
@@ -254,27 +255,27 @@ extern "system" fn scroll_by_trampoline(
 ) {
     let Some(jvm) = JAVA_VM.get() else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class(
-            "dev/nucleusframework/window/tao/ffi/NativeTaoBridge",
-        ) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11yScrollBy",
-            "(JJFF)V",
-            &[
-                JValue::Long(hwnd),
-                JValue::Long(node_id as i64),
-                JValue::Float(dx),
-                JValue::Float(dy),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Scoped frame: reclaims the `find_class` local ref on the permanently
+        // attached message-pump thread (see invoke_action_trampoline).
+        let _ = env.with_local_frame(4, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11yScrollBy",
+                "(JJFF)V",
+                &[
+                    JValue::Long(hwnd),
+                    JValue::Long(node_id as i64),
+                    JValue::Float(dx),
+                    JValue::Float(dy),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 
@@ -283,26 +284,26 @@ extern "system" fn set_value_trampoline(
 ) {
     let Some(jvm) = JAVA_VM.get() else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class(
-            "dev/nucleusframework/window/tao/ffi/NativeTaoBridge",
-        ) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11ySetValue",
-            "(JJD)V",
-            &[
-                JValue::Long(hwnd),
-                JValue::Long(node_id as i64),
-                JValue::Double(value),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Scoped frame: reclaims the `find_class` local ref on the permanently
+        // attached message-pump thread (see invoke_action_trampoline).
+        let _ = env.with_local_frame(4, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11ySetValue",
+                "(JJD)V",
+                &[
+                    JValue::Long(hwnd),
+                    JValue::Long(node_id as i64),
+                    JValue::Double(value),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 
@@ -311,26 +312,26 @@ extern "system" fn custom_action_trampoline(
 ) {
     let Some(jvm) = JAVA_VM.get() else { return };
     if let Ok(mut env) = jvm.attach_current_thread() {
-        let class = match env.find_class(
-            "dev/nucleusframework/window/tao/ffi/NativeTaoBridge",
-        ) {
-            Ok(c) => c,
-            Err(_) => return,
-        };
-        let _ = env.call_static_method(
-            class,
-            "dispatchA11yCustomAction",
-            "(JJI)V",
-            &[
-                JValue::Long(hwnd),
-                JValue::Long(node_id as i64),
-                JValue::Int(index),
-            ],
-        );
-        if env.exception_check().unwrap_or(false) {
-            let _ = env.exception_describe();
-            let _ = env.exception_clear();
-        }
+        // Scoped frame: reclaims the `find_class` local ref on the permanently
+        // attached message-pump thread (see invoke_action_trampoline).
+        let _ = env.with_local_frame(4, |env| -> Result<(), jni::errors::Error> {
+            let class = env.find_class("dev/nucleusframework/window/tao/ffi/NativeTaoBridge")?;
+            let _ = env.call_static_method(
+                class,
+                "dispatchA11yCustomAction",
+                "(JJI)V",
+                &[
+                    JValue::Long(hwnd),
+                    JValue::Long(node_id as i64),
+                    JValue::Int(index),
+                ],
+            );
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            Ok(())
+        });
     }
 }
 


### PR DESCRIPTION
## Problem

Several JNI upcalls in `decorated-window-tao` create Java objects (`find_class`, `new_string`, `new_long_array`, `new_object_array`) on threads that are attached **permanently** — either via `attach_current_thread_permanently`, or via a *nested* attach on the already-permanent Tao loop thread. The local frame of those threads is never popped, so every call leaks its local references for the lifetime of the process.

This is a **slow memory leak**, not a crash: the happy path is unaffected (touch, DnD and AT actions all work), and HotSpot grows the local reference table rather than hard-capping it. The refs simply accumulate over the process lifetime, proportional to the total number of events. The touch path leaks fastest — `dispatch_touch` allocates three `long[]` per event — but you'd need an extreme, continuous touch session (hundreds of thousands of events) to see real memory impact or a `JNI local refs exceeds capacity` warning. Worth fixing as hygiene, cheap and side-effect-free; not an urgent bug.

## Fix

Each object-creating upcall body is wrapped in `env.with_local_frame(...)`, which pushes a local frame and pops it on return — **including the early-error paths** (via `?`).

| File | Site | Leak rate |
|---|---|---|
| `linux/touch.rs` | `dispatch_touch` (3 `long[]`/event) | fastest (per touch event) |
| `linux/dnd.rs` | `dispatch_drop` (`String[]` + 1 ref/file) | per drop |
| `macos/apple_events.rs` | deep link (class + string) | per URL |
| `macos/a11y.rs` | 5 VoiceOver action trampolines | per AT action |
| `windows/a11y.rs` | 6 UIA action trampolines | per AT action |

## Intentionally left untouched (not leaks)

- `linux/a11y.rs` `forward_action_to_jvm`: runs on the dedicated zbus thread whose `AttachGuard` **detaches** on each call → refs are reclaimed.
- `decoration.rs` / `monitor.rs` / `handles.rs`: these are **JNI exports** (Java→native); the JVM manages a local frame that is popped on return.

## Verification

- `cargo check --lib` on the macOS target: **exit 0**. Validates the `with_local_frame` pattern against `jni` 0.21 in both of its shapes (class-only + string).
- The Linux/Windows paths are `cfg`-gated and therefore not compiled locally, but are structurally identical to the validated macOS edits. The per-OS native CI build remains the final judge.