### PR TITLE
fix(tao): stop CSD shadow tracing when the window is dragged (#383)

### DIFF
--- a/decorated-window-tao/docs/linux-csd-shadow-subsurface.md
+++ b/decorated-window-tao/docs/linux-csd-shadow-subsurface.md
@@ -81,6 +81,18 @@ Set the content **and** shadow subsurfaces to **sync** during an interactive
 resize grab so they apply atomically with the parent's transaction (no lag /
 spill), back to `desync` when idle for independent vsync-paced content swaps.
 
+### Move (issue #383)
+
+The shadow subsurface overflows the toplevel's window geometry (negative
+offset). In `desync` mode Mutter/GNOME computes interactive-move damage from the
+window geometry and skips that overflow, so the shadow ring traces at the old
+position while the window is dragged and only clears when the grab ends. Flip
+the shadow subsurface to **sync** for the duration of the compositor move grab
+(`nativeShadowSetSync`) so it rides the toplevel's atomic surface tree and the
+compositor moves + repaints it together with the window; restore `desync` when
+the grab ends. Wired in `TaoComposeSceneHostLinux.onNativeWindowDragStarted` /
+`endShadowMoveSync`.
+
 ## Scope: Wayland only
 
 This effort targets **Wayland only**. X11 keeps the current flat, shadowless

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
@@ -194,6 +194,24 @@ internal object NativeTaoEglBridge {
     external fun nativeShadowHide(handle: Long)
 
     /**
+     * Switches the shadow subsurface between synchronized ([sync] = true) and
+     * desynchronized commit modes (`wl_subsurface.set_sync` / `set_desync`).
+     *
+     * The shadow normally runs desync so its buffer swaps (focus fade, resize)
+     * land independently of GTK's parent commits. During a compositor **move**
+     * grab it is flipped to sync so the shadow is part of the toplevel's atomic
+     * surface tree: Mutter/GNOME then moves and repaints it together with the
+     * window instead of leaving its overflowing ring as a trace at the old
+     * position (issue #383). Restored to desync when the grab ends. No-op until
+     * the shadow subsurface exists.
+     */
+    @JvmStatic
+    external fun nativeShadowSetSync(
+        handle: Long,
+        sync: Boolean,
+    )
+
+    /**
      * Returns the address of a C function `void* fn(void* ctx, const char*
      * name)` matching Skia's `GrGLGetProc` signature. Pass to
      * [org.jetbrains.skia.GLAssembledInterface.createFromNativePointers] with

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -317,6 +317,25 @@ internal class TaoComposeSceneHostLinux(
      */
     private var compositorDragActive = false
 
+    /**
+     * True while a compositor **move** grab has the drop shadow in synchronized
+     * mode.
+     *
+     * The shadow rides a sibling `wl_subsurface` at a negative offset that
+     * deliberately overflows the toplevel's window geometry (that is how it
+     * avoids growing the surface / shifting the input coordinate system). In its
+     * normal desync mode Mutter/GNOME computes interactive-move damage from the
+     * window geometry, which excludes that overflow, so the shadow "frame" is
+     * never repainted at the old position while the window is dragged — it traces
+     * behind until the grab ends and a full repaint clears it (issue #383).
+     * Flipping the shadow subsurface to sync for the duration of the move makes
+     * it part of the toplevel's atomic surface tree, so the compositor moves and
+     * repaints it together with the window; it is restored to desync the instant
+     * the grab ends. Move-only: a resize grab keeps the shadow desync (it tracks
+     * the resizing frame, which stays inside the repainted region).
+     */
+    private var shadowSyncedForMove = false
+
     /** True while the EGL attachment is torn down because the window is hidden. */
     private var gpuSuspended: Boolean = false
 
@@ -1238,6 +1257,21 @@ internal class TaoComposeSceneHostLinux(
     }
 
     /**
+     * Ends move-grab shadow sync (see [shadowSyncedForMove]): restores the
+     * shadow subsurface to desync and schedules a redraw so the next
+     * [commitShadow] re-commits it at the window's new position. No-op unless a
+     * move grab had it synced.
+     */
+    private fun endShadowMoveSync() {
+        if (!shadowSyncedForMove) return
+        shadowSyncedForMove = false
+        if (windowShadow.isActive && attachmentHandle != 0L) {
+            NativeTaoEglBridge.nativeShadowSetSync(attachmentHandle, false)
+        }
+        requestRedrawCoalesced()
+    }
+
+    /**
      * Post-render frame decoration: carves the rounded corners out of the
      * fully-rendered surface. Clears everything outside the rounded frame to
      * transparent so the compositor blends the content behind those corner
@@ -1332,6 +1366,7 @@ internal class TaoComposeSceneHostLinux(
         // [onFocusChanged].
         if (compositorDragActive) {
             compositorDragActive = false
+            endShadowMoveSync()
             windowShadow.onFocusChanged(windowInfo.isWindowFocused)
         }
         currentKeyboardModifiers = taoKeyboardModifiers(window.modifierState)
@@ -1372,6 +1407,15 @@ internal class TaoComposeSceneHostLinux(
         // The move grab also steals the focus notify — keep the focused
         // shadow for the whole drag (see [compositorDragActive]).
         compositorDragActive = true
+        // Flip the drop shadow to synchronized mode for the whole move grab so
+        // the compositor moves and repaints its overflowing sibling subsurface
+        // atomically with the window instead of leaving a trace at the old
+        // position (issue #383). Restored to desync when the grab ends (see
+        // [onPointerMove] / [endShadowMoveSync]).
+        if (windowShadow.isActive && attachmentHandle != 0L) {
+            shadowSyncedForMove = true
+            NativeTaoEglBridge.nativeShadowSetSync(attachmentHandle, true)
+        }
         // The compositor's interactive-move grab swallows the button release, so
         // neither the Compose scene nor the title-bar drag gesture ever see it:
         // the pointer stays "pressed" and the window ignores hover/clicks until a
@@ -1426,7 +1470,10 @@ internal class TaoComposeSceneHostLinux(
             }
         }
         // Any other real press means no compositor grab is in flight.
-        if (pressed) compositorDragActive = false
+        if (pressed) {
+            compositorDragActive = false
+            endShadowMoveSync()
+        }
         if (pressed) pressedButtons.add(buttonCode) else pressedButtons.remove(buttonCode)
 
         // A press reaching the parent scene is outside every popup layer (the

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
@@ -1717,6 +1717,25 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeShadowHide(
     if (p_wl_display_flush && att->wl_display_conn) p_wl_display_flush(att->wl_display_conn);
 }
 
+/**
+ * Flips the shadow subsurface between synchronized and desynchronized commit
+ * modes. Sync during a compositor move grab makes Mutter treat the shadow as
+ * part of the toplevel's atomic surface tree, so its overflowing ring is moved
+ * and repainted with the window instead of tracing at the old position (#383).
+ */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeShadowSetSync(
+    JNIEnv *env, jclass clazz, jlong handle, jboolean sync)
+{
+    (void) env; (void) clazz;
+    EglAttachment *att = (EglAttachment *) (uintptr_t) handle;
+    if (!att || !att->wl_shadow_subsurface || !p_wl_proxy_marshal_flags) return;
+    p_wl_proxy_marshal_flags(att->wl_shadow_subsurface,
+        sync ? WL_SUBSURFACE_SET_SYNC : WL_SUBSURFACE_SET_DESYNC, NULL,
+        p_wl_proxy_get_version(att->wl_shadow_subsurface), 0);
+    if (p_wl_display_flush && att->wl_display_conn) p_wl_display_flush(att->wl_display_conn);
+}
+
 JNIEXPORT void JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeDetach(
     JNIEnv *env, jclass clazz, jlong handle)


### PR DESCRIPTION
## Summary

Fixes the Linux CSD drop-shadow "frame" tracing behind the window when it is dragged on GNOME/Mutter Wayland (#383).

- The shadow (approach B) rides a sibling `wl_subsurface` at a negative offset that deliberately overflows the toplevel window geometry (that's how it keeps the content subsurface at `(0,0)` and leaves input/resize untouched).
- In its normal `desync` mode, Mutter computes interactive-**move** damage from the window geometry, which excludes that overflow — so the shadow ring is never repainted at the old position during a drag and traces behind until the grab ends.
- Fix: flip the shadow subsurface to **`sync`** for the duration of a compositor **move** grab so it rides the toplevel's atomic surface tree and the compositor moves + repaints it together with the window; restore `desync` the instant the grab ends. Move-only — a resize grab keeps the shadow `desync` (it tracks the resizing frame, which stays inside the repainted region).

### Changes
- **native** (`nucleus_tao_egl.c`): new `nativeShadowSetSync` → `wl_subsurface.set_sync` / `set_desync` on the shadow subsurface + flush.
- **bridge** (`NativeTaoEglBridge.kt`): `external fun nativeShadowSetSync`.
- **scene** (`TaoComposeSceneHostLinux.kt`): sync on `onNativeWindowDragStarted`, desync on grab end via `endShadowMoveSync` (called where `compositorDragActive` clears — first real pointer motion / next press).
- **docs**: documented the move handling alongside the existing sync-during-resize guidance.

Requires a native rebuild: `bash decorated-window-tao/src/main/native/linux/build.sh` (the script clears the `NativeLibraryLoader` cache).

## Regression risk
None for users who don't have the bug: during a static move the shadow is displayed either way and moves with the window; `sync` only changes commit *timing* for the duration of the grab, then reverts to `desync`. `sync` subsurfaces are standard Wayland (GDK uses them). No effect on X11 or when `NUCLEUS_TAO_LINUX_SHADOW=0`.

## Test plan
- [x] `:decorated-window-tao:compileKotlin` — BUILD SUCCESSFUL
- [x] `gcc -fsyntax-only` on `nucleus_tao_egl.c` — clean
- [ ] **Validate on the reporter's stack** (NixOS + Mesa/AMD + GNOME Wayland — the only known repro): drag the window around; the shadow follows with no trace at the old position. Could not be reproduced by maintainers, so the `sync`-tracks-overflow-in-move-damage behavior needs on-device confirmation.

## Not covered here
The **square corners** reported on the same stack are a *separate* symptom of the #374 opaque-EGL-buffer driver quirk (the rounded-corner `BlendMode.CLEAR` carve relies on the content buffer's alpha, which that driver ignores) — independent of the shadow and not addressed by this PR.