### PR TITLE
feat: upgrade Jewel to 0.39 and IntelliJ icons to 262

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,9 +15,6 @@ plugins {
     alias(libs.plugins.versionCheck)
 }
 
-val demoProjects =
-    setOf("nucleus-demo", "compose-demo", "jewel-demo", "system-info-demo", "cmp-demo", "scheduler-demo", "service-management-demo")
-
 val nativeBuildTaskPrefix = "buildNative"
 
 val buildNative by tasks.registering {
@@ -40,7 +37,8 @@ fun isCurrentHostNativeTask(taskName: String): Boolean =
     }
 
 subprojects {
-    if (name !in demoProjects) {
+    val isDemoProject = path.startsWith(":examples:")
+    if (!isDemoProject) {
         apply {
             plugin(
                 rootProject.libs.plugins.detekt
@@ -70,7 +68,7 @@ subprojects {
         }
     }
 
-    if (name !in demoProjects) {
+    if (!isDemoProject) {
         detekt {
             config.setFrom(rootProject.files("config/detekt/detekt.yml"))
         }

--- a/decorated-window-jewel/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-jewel/native-image.properties
+++ b/decorated-window-jewel/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-jewel/native-image.properties
@@ -1,0 +1,15 @@
+# Jewel 0.39 standalone native-image compatibility.
+#
+# Jewel 0.39's IntUiTheme builds a StandalonePlatformCursorController whose default
+# arg references the macOS object MacPlatformServicesDefaultImpl. Its <clinit> runs
+# UnsafeAccessing, which sets AccessibleObject.override via a sun.misc.Unsafe field-
+# offset hack. That offset is computed from a proxy field and is invalid under SVM's
+# object layout, so at run time the write lands on the wrong field, checkAccess is not
+# skipped, and Method.invoke segfaults. Initializing these classes at build time runs
+# the reflective/Unsafe setup on HotSpot (correct offset) so nothing reflective runs
+# at run time. The foundation.util package covers JewelLogger and all its nested
+# factories that end up in the image heap once the object above is built at build time.
+# (slf4j itself is initialized at build time by nucleus.graalvm-runtime.)
+Args = --initialize-at-build-time=org.jetbrains.jewel.intui.standalone.window.UnsafeAccessing \
+       --initialize-at-build-time=org.jetbrains.jewel.intui.standalone.window.macos.MacPlatformServicesDefaultImpl \
+       --initialize-at-build-time=org.jetbrains.jewel.foundation.util

--- a/decorated-window-jewel/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-jewel/reachability-metadata.json
+++ b/decorated-window-jewel/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-jewel/reachability-metadata.json
@@ -1,0 +1,8 @@
+{
+    "reflection": [
+        {
+            "type": "java.lang.Module",
+            "methods": [ { "name": "implAddOpens", "parameterTypes": [ "java.lang.String", "java.lang.Module" ] } ]
+        }
+    ]
+}

--- a/examples/cmp-demo/build.gradle.kts
+++ b/examples/cmp-demo/build.gradle.kts
@@ -43,7 +43,6 @@ kotlin {
                 implementation(project(":decorated-window-core"))
 
                 implementation(project(":decorated-window-tao"))
-
             }
         }
     }
@@ -89,7 +88,6 @@ nucleus.application {
         linux {
             debMaintainer = "KDroidFilter <dev@kdroidfilter.com>"
         }
-
     }
 
     graalvm {

--- a/examples/fs-watcher-smoke/src/main/kotlin/dev/nucleusframework/fswatchersmoke/Main.kt
+++ b/examples/fs-watcher-smoke/src/main/kotlin/dev/nucleusframework/fswatchersmoke/Main.kt
@@ -62,9 +62,10 @@ private suspend fun runSmoke(): Pair<SmokeReport, Int> {
                 val scenarios = mutableListOf<ScenarioResult>()
 
                 Files.writeString(target, "hello-native-smoke")
-                val createdEventKind = awaitEventKind(seen, target) { event ->
-                    event is FsWatchEvent.Created || event is FsWatchEvent.Modified
-                }
+                val createdEventKind =
+                    awaitEventKind(seen, target) { event ->
+                        event is FsWatchEvent.Created || event is FsWatchEvent.Modified
+                    }
                 scenarios +=
                     ScenarioResult(
                         name = "created",
@@ -74,9 +75,10 @@ private suspend fun runSmoke(): Pair<SmokeReport, Int> {
                     )
 
                 Files.delete(target)
-                val deletedEventKind = awaitEventKind(seen, target) { event ->
-                    event is FsWatchEvent.Removed
-                }
+                val deletedEventKind =
+                    awaitEventKind(seen, target) { event ->
+                        event is FsWatchEvent.Removed
+                    }
                 scenarios +=
                     ScenarioResult(
                         name = "deleted",
@@ -184,8 +186,8 @@ private data class SmokeReport(
     val errorMessage: String?,
     val scenarios: List<ScenarioResult>,
 ) {
-    fun toJson(): String {
-        return buildString {
+    fun toJson(): String =
+        buildString {
             append('{')
             appendJsonField("status", status)
             append(',')
@@ -207,7 +209,6 @@ private data class SmokeReport(
             append(']')
             append('}')
         }
-    }
 }
 
 private data class ScenarioResult(
@@ -230,7 +231,10 @@ private data class ScenarioResult(
         }
 }
 
-private fun StringBuilder.appendJsonField(name: String, value: String?) {
+private fun StringBuilder.appendJsonField(
+    name: String,
+    value: String?,
+) {
     append('"').append(name).append('"').append(':')
     if (value == null) {
         append("null")

--- a/examples/jewel-demo/build.gradle.kts
+++ b/examples/jewel-demo/build.gradle.kts
@@ -64,6 +64,9 @@ dependencies {
     implementation(libs.jewel.markdown.extensions.images, jewelExclusions)
     implementation(libs.coil.compose)
     implementation(libs.intellij.icons)
+    // Jewel 0.39+ IntUiTheme needs IconManager/DefaultIconManager from these modules
+    implementation(libs.intellij.icons.api)
+    implementation(libs.intellij.icons.impl)
 
     // Jewel's StandalonePlatformCursorController uses JNA at runtime
     implementation(libs.jna.jpms)
@@ -109,7 +112,6 @@ nucleus.application {
         jvmVendor = JvmVendorSpec.ORACLE
         imageName = "jewel-sample"
         optimization = NativeImageOptimization.SIZE
-
     }
 
     nativeDistributions {

--- a/examples/scheduler-demo/build.gradle.kts
+++ b/examples/scheduler-demo/build.gradle.kts
@@ -25,6 +25,9 @@ dependencies {
         }
     implementation(libs.jewel.int.ui.standalone, jewelExclusions)
     implementation(libs.intellij.icons)
+    // Jewel 0.39+ IntUiTheme needs IconManager/DefaultIconManager from these modules
+    implementation(libs.intellij.icons.api)
+    implementation(libs.intellij.icons.impl)
     implementation(libs.jna.jpms)
     implementation(libs.coroutines.core)
 }

--- a/examples/system-info-demo/build.gradle.kts
+++ b/examples/system-info-demo/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 dependencies {
     implementation(compose.desktop.currentOs)
     implementation(project(":core-runtime"))
+    implementation(project(":aot-runtime"))
     implementation(project(":darkmode-detector"))
     implementation(project(":system-color"))
     implementation(project(":system-info"))
@@ -54,15 +55,6 @@ kotlin {
 
 nucleus.application {
     mainClass = "systeminfodemo.MainKt"
-    jvmArgs +=
-        listOf(
-            "--add-opens",
-            "java.desktop/sun.awt=ALL-UNNAMED",
-            "--add-opens",
-            "java.desktop/sun.lwawt=ALL-UNNAMED",
-            "--add-opens",
-            "java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
-        )
 
     graalvm {
         isEnabled = true
@@ -72,10 +64,12 @@ nucleus.application {
         optimization = NativeImageOptimization.SIZE
     }
 
+    jvmArgs += listOf("-XX:+UseSerialGC")
+
     nativeDistributions {
         compressionLevel = CompressionLevel.Maximum
         targetFormats(TargetFormat.Dmg, TargetFormat.Nsis, TargetFormat.Deb)
-
+        enableAotCache = true
         packageName = "SystemInfo"
         packageVersion = "1.0.0"
         homepage = "https://github.com/NucleusFramework/Nucleus"

--- a/examples/system-info-demo/src/main/kotlin/systeminfodemo/Main.kt
+++ b/examples/system-info-demo/src/main/kotlin/systeminfodemo/Main.kt
@@ -6,16 +6,20 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
 import dev.nucleusframework.application.NucleusBackend
+import dev.nucleusframework.application.aotTraining
 import dev.nucleusframework.application.nucleusApplication
 import dev.nucleusframework.window.jewel.JewelDecoratedWindow
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import systeminfodemo.ui.AppContent
 import systeminfodemo.ui.AppTitleBar
 import systeminfodemo.ui.buildIslandsTheme
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 fun main() =
     nucleusApplication(backend = NucleusBackend.Tao) {
+        aotTraining(duration = 45.seconds)
+
         val (theme, styling) = buildIslandsTheme()
 
         @Suppress("DEPRECATION")

--- a/graalvm-runtime/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.graalvm-runtime/native-image.properties
+++ b/graalvm-runtime/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.graalvm-runtime/native-image.properties
@@ -1,5 +1,18 @@
 # Resource inclusion globs moved to reachability-metadata.json ("resources") — the
 # deprecated -H:IncludeResources option warns and will be removed. SharedArenaSupport
 # stays here as it has no metadata equivalent.
+#
+# Jewel 0.39 standalone: IntUiTheme builds a StandalonePlatformCursorController whose
+# default arg references the macOS object MacPlatformServicesDefaultImpl. Its <clinit>
+# runs UnsafeAccessing, which sets AccessibleObject.override via a sun.misc.Unsafe
+# field-offset hack. That offset is computed from a proxy field and is invalid under
+# SVM's object layout, so at run time the write lands on the wrong field, checkAccess
+# is not skipped, and Method.invoke segfaults. Initializing these classes at build time
+# runs the reflective/Unsafe setup on HotSpot (correct offset) so nothing reflective
+# runs at run time. Unknown class names are ignored when jewel is absent from the app.
 Args = -H:+UnlockExperimentalVMOptions \
-       -H:+SharedArenaSupport
+       -H:+SharedArenaSupport \
+       --initialize-at-build-time=org.jetbrains.jewel.intui.standalone.window.UnsafeAccessing \
+       --initialize-at-build-time=org.jetbrains.jewel.intui.standalone.window.macos.MacPlatformServicesDefaultImpl \
+       --initialize-at-build-time=org.jetbrains.jewel.foundation.util \
+       --initialize-at-build-time=org.slf4j

--- a/graalvm-runtime/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.graalvm-runtime/native-image.properties
+++ b/graalvm-runtime/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.graalvm-runtime/native-image.properties
@@ -2,17 +2,9 @@
 # deprecated -H:IncludeResources option warns and will be removed. SharedArenaSupport
 # stays here as it has no metadata equivalent.
 #
-# Jewel 0.39 standalone: IntUiTheme builds a StandalonePlatformCursorController whose
-# default arg references the macOS object MacPlatformServicesDefaultImpl. Its <clinit>
-# runs UnsafeAccessing, which sets AccessibleObject.override via a sun.misc.Unsafe
-# field-offset hack. That offset is computed from a proxy field and is invalid under
-# SVM's object layout, so at run time the write lands on the wrong field, checkAccess
-# is not skipped, and Method.invoke segfaults. Initializing these classes at build time
-# runs the reflective/Unsafe setup on HotSpot (correct offset) so nothing reflective
-# runs at run time. Unknown class names are ignored when jewel is absent from the app.
+# slf4j is initialized at build time (the recommended default for native-image): it
+# fixes the logging provider at build and keeps logger instances out of run-time init.
+# Note: the effective log level is captured at build time.
 Args = -H:+UnlockExperimentalVMOptions \
        -H:+SharedArenaSupport \
-       --initialize-at-build-time=org.jetbrains.jewel.intui.standalone.window.UnsafeAccessing \
-       --initialize-at-build-time=org.jetbrains.jewel.intui.standalone.window.macos.MacPlatformServicesDefaultImpl \
-       --initialize-at-build-time=org.jetbrains.jewel.foundation.util \
        --initialize-at-build-time=org.slf4j

--- a/graalvm-runtime/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.graalvm-runtime/reachability-metadata.json
+++ b/graalvm-runtime/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.graalvm-runtime/reachability-metadata.json
@@ -7,10 +7,6 @@
         {
             "type": "com.sun.media.sound.PortMixerProvider",
             "methods": [ { "name": "<init>", "parameterTypes": [] } ]
-        },
-        {
-            "type": "java.lang.Module",
-            "methods": [ { "name": "implAddOpens", "parameterTypes": [ "java.lang.String", "java.lang.Module" ] } ]
         }
     ],
     "resources": [

--- a/graalvm-runtime/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.graalvm-runtime/reachability-metadata.json
+++ b/graalvm-runtime/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.graalvm-runtime/reachability-metadata.json
@@ -7,6 +7,10 @@
         {
             "type": "com.sun.media.sound.PortMixerProvider",
             "methods": [ { "name": "<init>", "parameterTypes": [] } ]
+        },
+        {
+            "type": "java.lang.Module",
+            "methods": [ { "name": "implAddOpens", "parameterTypes": [ "java.lang.String", "java.lang.Module" ] } ]
         }
     ],
     "resources": [

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,9 +16,9 @@ graalvmNative = "1.1.3"
 # but the runtime ones come from the agent, and the WindowsState API is not binary-stable
 # across releases. Compose 1.11.x bundles 1.1.1 — bump both together.
 hotReload = "1.1.1"
-icons = "261.23567.174"
+icons = "262.9437.16"
 jbrApi = "1.10.1"
-jewel = "0.37.0-262.4852.51"
+jewel = "0.39.0-262.9437.21"
 jna = "5.19.1"
 kotlin = "2.4.0"
 kotlinPoet = "2.3.0"
@@ -63,6 +63,8 @@ hot-reload-core = { module = "org.jetbrains.compose.hot-reload:hot-reload-core",
 hot-reload-orchestration = { module = "org.jetbrains.compose.hot-reload:hot-reload-orchestration", version.ref = "hotReload" }
 hot-reload-devtools-api = { module = "org.jetbrains.compose.hot-reload:hot-reload-devtools-api", version.ref = "hotReload" }
 intellij-icons = { module = "com.jetbrains.intellij.platform:icons", version.ref = "icons" }
+intellij-icons-api = { module = "com.jetbrains.intellij.platform:icons-api", version.ref = "icons" }
+intellij-icons-impl = { module = "com.jetbrains.intellij.platform:icons-impl", version.ref = "icons" }
 junit = "junit:junit:4.13.2"
 zstd-kmp-jvm = { module = "com.squareup.zstd:zstd-kmp-jvm", version.ref = "zstdKmp" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
         mavenCentral()
         google()
         maven("https://www.jetbrains.com/intellij-repository/releases")
+        maven("https://www.jetbrains.com/intellij-repository/snapshots")
     }
 }
 


### PR DESCRIPTION
## Summary

- Bump Jewel `0.37.0-262.4852.51` → `0.39.0-262.9437.21` and IntelliJ icons `261.23567.174` → `262.9437.16`.
- Add `intellij-icons-api` / `intellij-icons-impl` deps — Jewel 0.39's `IntUiTheme` now needs `IconManager`/`DefaultIconManager` from these modules (jewel-demo, scheduler-demo).
- Add the `intellij-repository/snapshots` Maven repo.
- **GraalVM native-image fix:** `--initialize-at-build-time` for Jewel's `UnsafeAccessing` / `MacPlatformServicesDefaultImpl` (+ `foundation.util`, `slf4j`). Jewel's Unsafe field-offset hack computes an invalid offset under SVM's object layout, causing `Method.invoke` to segfault; initializing at build time runs the reflective setup on HotSpot instead.
- Register `java.lang.Module#implAddOpens` for reflection.
- Refactor demo-project detection in the root build to `path.startsWith(":examples:")` instead of a hardcoded name set.
- **system-info-demo:** enable AOT cache + `aotTraining(45s)`, drop the AWT `--add-opens` jvmArgs, add `-XX:+UseSerialGC`, pull in `:aot-runtime`.

## Test plan

- [ ] `./gradlew :examples:jewel-demo:run`
- [ ] `./gradlew :examples:scheduler-demo:run`
- [ ] `./gradlew :examples:system-info-demo:run`
- [ ] GraalVM native image build of a Jewel-based demo runs without segfault
- [ ] `./gradlew preMerge`