### PR TITLE
fix(sandboxing): extract the target-arch native lib, not the first match

### DIFF
--- a/examples/tao-demo/build.gradle.kts
+++ b/examples/tao-demo/build.gradle.kts
@@ -78,11 +78,29 @@ nucleus.application {
     }
 
     nativeDistributions {
-        targetFormats(TargetFormat.Dmg, TargetFormat.Nsis, TargetFormat.Pkg)
+        targetFormats(TargetFormat.Dmg, TargetFormat.Nsis, TargetFormat.Pkg, TargetFormat.AppX)
         compressionLevel = CompressionLevel.Maximum
         appName = "Sample Tao"
         packageName = "SampleTao"
         packageVersion = "1.0.0"
+
+        windows {
+            // AppX (Windows Store) is a store format → activates the sandboxed pipeline, so the
+            // zstd-kmp marker/shim rewrite is exercised end-to-end on Windows too (issue #399/#317),
+            // mirroring what the Pkg format does on macOS.
+            //
+            // To actually sideload + launch it locally (`:examples:tao-demo:runAppX`), add a
+            // `signing { certificateFile = … }` block with a dev cert trusted on the machine and set
+            // `publisher` to that cert's subject — Windows refuses unsigned AppX packages.
+            appx {
+                identityName = "NucleusFramework.SampleTao"
+                publisher = "CN=NucleusFramework"
+                publisherDisplayName = "Nucleus Framework"
+                displayName = "Sample Tao"
+                applicationId = "SampleTao"
+                languages = listOf("en-US")
+            }
+        }
 
         macOS {
             bundleID = "dev.nucleusframework.sampletao"

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractExtractNativeLibsTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractExtractNativeLibsTask.kt
@@ -31,6 +31,11 @@ import java.util.zip.ZipInputStream
  */
 @DisableCachingByDefault(because = "Extracts native libs from JARs; output depends on JAR content order")
 abstract class AbstractExtractNativeLibsTask : AbstractNucleusTask() {
+    private companion object {
+        /** Bytes read from each native lib to reach the PE/ELF/Mach-O machine field for arch detection. */
+        const val HEADER_BYTES = 4096
+    }
+
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.NAME_ONLY)
     abstract val inputJars: ConfigurableFileCollection
@@ -113,17 +118,31 @@ abstract class AbstractExtractNativeLibsTask : AbstractNucleusTask() {
         zis: ZipInputStream,
     ): NativeLibArchDetector.NativeInfo {
         val pathInfo = NativeLibArchDetector.detectFromPath(entryName)
+        // Path detection is authoritative once it fully resolves the platform.
         if (pathInfo.os != NativeOs.UNKNOWN && pathInfo.arch != NativeArch.UNKNOWN) {
             return pathInfo
         }
-        // Fall back to binary header detection
-        @Suppress("MagicNumber")
-        val header = ByteArray(64)
+        // Otherwise complement — not replace — the path result with binary header detection.
+        // Layouts like zstd-kmp's "jni/aarch64/foo.dll" encode the arch in the path but carry
+        // no OS token, while the PE/ELF/Mach-O header supplies the OS. Discarding the
+        // path-detected arch here previously let an ARM64 .dll be extracted for an x64 target
+        // (its arch reads as UNKNOWN and passes the filter), see issue #399.
+        val headerInfo = detectFromHeaderBytes(zis)
+        return NativeLibArchDetector.NativeInfo(
+            os = if (pathInfo.os != NativeOs.UNKNOWN) pathInfo.os else headerInfo.os,
+            arch = if (pathInfo.arch != NativeArch.UNKNOWN) pathInfo.arch else headerInfo.arch,
+        )
+    }
+
+    private fun detectFromHeaderBytes(zis: ZipInputStream): NativeLibArchDetector.NativeInfo {
+        // Must be large enough to reach the PE machine field: it sits at e_lfanew (a 4-byte
+        // value at offset 0x3C) + 4, which for real DLLs is routinely past the first 64 bytes.
+        val header = ByteArray(HEADER_BYTES)
         val bytesRead = readFully(zis, header)
-        if (bytesRead > 0) {
-            return NativeLibArchDetector.detectFromHeader(header.copyOf(bytesRead))
+        if (bytesRead <= 0) {
+            return NativeLibArchDetector.NativeInfo(NativeOs.UNKNOWN, NativeArch.UNKNOWN)
         }
-        return pathInfo
+        return NativeLibArchDetector.detectFromHeader(header.copyOf(bytesRead))
     }
 
     private fun shouldExtract(

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractExtractNativeLibsTaskTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractExtractNativeLibsTaskTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.tasks
+
+import dev.nucleusframework.desktop.application.internal.NativeLibArchDetector
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Regression coverage for issue #399: on a Windows x64 store build the extractor picked the ARM64
+ * `zstd-kmp.dll` because its arch (present in the path) was discarded and the PE machine field sat
+ * past the old 64-byte header buffer, reading back as UNKNOWN and slipping through the arch filter.
+ *
+ * Headers mirror the real `com.squareup.zstd:zstd-kmp-jvm` jar: arch dirs (`aarch64`, `amd64`,
+ * `x86_64`) carry no OS token and mix `.dll`/`.so`/`.dylib`; the Windows `.dll`s use `e_lfanew`
+ * 0x78, exactly as the shipped binaries do.
+ */
+class AbstractExtractNativeLibsTaskTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Suppress("MagicNumber")
+    private fun pe(machine: Int): ByteArray {
+        // Minimal PE: "MZ", e_lfanew (0x3C) = 0x78 (as in the real zstd dlls), machine at +4.
+        val buf = ByteArray(256)
+        buf[0] = 0x4D // 'M'
+        buf[1] = 0x5A // 'Z'
+        val peOffset = 0x78
+        buf[0x3C] = (peOffset and 0xFF).toByte()
+        buf[0x3D] = ((peOffset ushr 8) and 0xFF).toByte()
+        buf[peOffset + 4] = (machine and 0xFF).toByte()
+        buf[peOffset + 5] = ((machine ushr 8) and 0xFF).toByte()
+        return buf
+    }
+
+    @Suppress("MagicNumber")
+    private fun elf(eMachine: Int): ByteArray {
+        val buf = ByteArray(64)
+        buf[0] = 0x7F
+        buf[1] = 0x45 // 'E'
+        buf[2] = 0x4C // 'L'
+        buf[3] = 0x46 // 'F'
+        buf[4] = 2 // ELFCLASS64
+        buf[5] = 1 // little-endian
+        buf[18] = (eMachine and 0xFF).toByte()
+        buf[19] = ((eMachine ushr 8) and 0xFF).toByte()
+        return buf
+    }
+
+    @Suppress("MagicNumber")
+    private fun macho(cpuType: Int): ByteArray {
+        // Bytes FE ED FA CF read big-endian == 0xFEEDFACF, decoded with LITTLE_ENDIAN cpuType.
+        val buf = ByteArray(16)
+        buf[0] = 0xFE.toByte()
+        buf[1] = 0xED.toByte()
+        buf[2] = 0xFA.toByte()
+        buf[3] = 0xCF.toByte()
+        buf[4] = (cpuType and 0xFF).toByte()
+        buf[5] = ((cpuType ushr 8) and 0xFF).toByte()
+        buf[6] = ((cpuType ushr 16) and 0xFF).toByte()
+        buf[7] = ((cpuType ushr 24) and 0xFF).toByte()
+        return buf
+    }
+
+    private val winArm64Dll = pe(0xAA64)
+    private val winX64Dll = pe(0x8664)
+
+    /** Entry set mirroring zstd-kmp-jvm 0.4.0 exactly. */
+    private fun buildInputJar(file: File): File {
+        val entries =
+            linkedMapOf(
+                "jni/aarch64/libzstd-kmp.dylib" to macho(0x0100000C), // macOS arm64
+                "jni/aarch64/libzstd-kmp.so" to elf(0xB7), // linux arm64
+                "jni/aarch64/zstd-kmp.dll" to winArm64Dll, // windows arm64
+                "jni/amd64/libzstd-kmp.so" to elf(0x3E), // linux x64
+                "jni/amd64/zstd-kmp.dll" to winX64Dll, // windows x64
+                "jni/x86_64/libzstd-kmp.dylib" to macho(0x01000007), // macOS x64
+            )
+        ZipOutputStream(file.outputStream().buffered()).use { zos ->
+            for ((name, bytes) in entries) {
+                zos.putNextEntry(ZipEntry(name))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return file
+    }
+
+    private fun runExtract(os: String, arch: String): File {
+        val jar = buildInputJar(tmp.newFile("zstd-kmp-jvm-0.4.0.jar"))
+        val outDir = tmp.newFolder("out")
+        val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+        val task =
+            project.tasks.register("extractNatives", AbstractExtractNativeLibsTask::class.java) {
+                it.inputJars.setFrom(jar)
+                it.targetOs.set(os)
+                it.targetArch.set(arch)
+                it.outputDir.set(outDir)
+            }.get()
+        task.extract()
+        return outDir
+    }
+
+    @Test
+    fun `windows x64 target extracts the x64 dll, not the arm64 one with the same name`() {
+        val outDir = runExtract(os = "windows", arch = "x64")
+
+        val extracted = outDir.resolve("zstd-kmp.dll")
+        assertTrue("expected the flattened dll to be extracted", extracted.isFile)
+
+        val bytes = extracted.readBytes()
+        assertArrayEquals("wrong-arch dll was extracted for an x64 target (issue #399)", winX64Dll, bytes)
+
+        val info = NativeLibArchDetector.detectFromHeader(bytes)
+        assertEquals(NativeLibArchDetector.NativeOs.WINDOWS, info.os)
+        assertEquals(NativeLibArchDetector.NativeArch.X64, info.arch)
+
+        // Only the Windows dll belongs on a Windows target — no cross-OS siblings leak through.
+        assertFalse(outDir.resolve("libzstd-kmp.so").exists())
+        assertFalse(outDir.resolve("libzstd-kmp.dylib").exists())
+    }
+
+    @Test
+    fun `windows arm64 target extracts the arm64 dll`() {
+        val outDir = runExtract(os = "windows", arch = "arm64")
+
+        val extracted = outDir.resolve("zstd-kmp.dll")
+        assertTrue(extracted.isFile)
+        assertArrayEquals(winArm64Dll, extracted.readBytes())
+    }
+
+    @Test
+    fun `linux x64 target extracts only the x64 so`() {
+        val outDir = runExtract(os = "linux", arch = "x64")
+
+        val extracted = outDir.resolve("libzstd-kmp.so")
+        assertTrue(extracted.isFile)
+        assertArrayEquals(elf(0x3E), extracted.readBytes())
+        assertFalse(outDir.resolve("zstd-kmp.dll").exists())
+        assertFalse(outDir.resolve("libzstd-kmp.dylib").exists())
+    }
+}


### PR DESCRIPTION
Fixes #399.

## Summary

Native libraries whose JAR path encodes an architecture but no OS token — e.g. `zstd-kmp`'s `jni/{aarch64,amd64,x86_64}/…` — were extracted for the wrong architecture in the sandboxed (store-format) pipeline. On a Windows x64 build the ARM64 `zstd-kmp.dll` won the flattening race and the app crashed at load:

```
UnsatisfiedLinkError: ...\app\resources\zstd-kmp.dll:
Can't load ARM 64-bit .dll on a AMD 64-bit platform
```

Two compounding defects in `AbstractExtractNativeLibsTask`:

- `detectInfo` **discarded** the path-detected arch whenever the OS came back `UNKNOWN`, falling back to header detection alone. For `jni/aarch64/zstd-kmp.dll` the path knows the arch (ARM64) and the header knows the OS (Windows) — neither alone is enough.
- The header buffer was **64 bytes**, too small to reach the PE machine field: `e_lfanew` is `0x78` in the shipped zstd dlls, putting the machine field at byte 124. It read back `UNKNOWN`.

Net result: `(WINDOWS, UNKNOWN)`, which passes the arch filter.

## Changes

- `detectInfo` now **merges** path and header info field by field (prefer whichever source resolved each field) instead of replacing one with the other.
- Header read bumped 64 → 4096 bytes (`HEADER_BYTES`), so PE/ELF/Mach-O machine fields are actually reachable. This also fixes flat layouts with no arch dir at all.
- `AbstractExtractNativeLibsTaskTest`: regression coverage built from the real `com.squareup.zstd:zstd-kmp-jvm:0.4.0` entry set (arch dirs mixing `.dll`/`.so`/`.dylib`, real PE/ELF/Mach-O headers, `e_lfanew=0x78`). Fails without the fix.
- `examples/tao-demo`: adds `TargetFormat.AppX` + an `appx {}` block, so the sandboxed pipeline is exercised on Windows the way `Pkg` already exercises it on macOS.

No change needed in the strip task or the runtime shim: every arch marker already maps to the single flattened `zstd-kmp.dll`, and now only the correct-arch copy is extracted.

## Test plan

- [x] `:plugin:test --tests AbstractExtractNativeLibsTaskTest` — passes; fails without the fix
- [x] ktlint clean; detekt reports only pre-existing findings in untouched files
- [x] `:examples:tao-demo:packageAppX` — extracted `app/resources/zstd-kmp.dll` verified as PE machine `0x8664` (x64), previously `0xAA64` (ARM64)
- [x] End-to-end on Windows: signed `.appx` sideloaded into `C:\Program Files\WindowsApps\…` (the exact install layout from the issue) and launched via `:examples:tao-demo:runAppX` — the zstd extract-and-load probe returns `zstd-sandbox-roundtrip: roundtrip=true compLen=48 decLen=39`
- [x] End-to-end on macOS (26.5.2, arm64): `:examples:tao-demo:createSandboxedDistributable` + `packagePkg` — the `.pkg` payload ships an arm64 `Contents/Frameworks/libzstd-kmp.dylib`, and the launched `SampleTao.app` prints `zstd-sandbox-roundtrip: roundtrip=true compLen=48 decLen=39`. Same for `:examples:zstd-demo`.
- [x] macOS `Pkg` pipeline: no regression. Extraction output is byte-identical (sha256) before/after the fix on both sandboxed samples — `tao-demo` (10 libs) and `zstd-demo` (12 libs, incl. JNA). Replaying both algorithms over every native entry of the local Gradle cache (1468 JARs / 1074 entries) yields exactly **2** selection changes for the `MACOS/{ARM64,X64}` targets, both of them corrections:

  ```
  MACOS/X64    jni/aarch64/libzstd-kmp.dylib   old=(MACOS,UNKNOWN)->kept   new=(MACOS,ARM64)->rejected
  MACOS/ARM64  jni/x86_64/libzstd-kmp.dylib    old=(MACOS,UNKNOWN)->kept   new=(MACOS,X64)->rejected
  ```

### macOS x64 was hit by #399 too

Worth recording: this is not a Windows-only fix. Before the change, **both** zstd dylibs passed the arch filter on macOS — the build logged `Sandboxing: skipping duplicate native lib 'libzstd-kmp.dylib'` and only the JAR entry order decided the winner. `jni/aarch64/…` comes first, so Apple Silicon was correct by luck while an Intel target bundled the ARM64 dylib — the exact crash from the issue. That warning is gone after the fix.

The reason the header could not break the tie: `NativeLibArchDetector.detectMachO` maps magic `0xCFFAEDFE` to `BIG_ENDIAN`, but that magic *is* the little-endian thin Mach-O every macOS `.dylib` starts with (`cf fa ed fe`), so `cpu_type` is read byte-swapped (`0x07000001` instead of `0x01000007`) and both dylibs report `arch=UNKNOWN`:

```
zstd-kmp jni/aarch64/libzstd-kmp.dylib  detectFromHeader -> NativeInfo(os=MACOS, arch=UNKNOWN)
zstd-kmp jni/x86_64/libzstd-kmp.dylib   detectFromHeader -> NativeInfo(os=MACOS, arch=UNKNOWN)
```

The path-arch merge in this PR is what fixes macOS. The endianness mapping itself is pre-existing and left alone here — follow-up, together with a macOS-target test case using the real `cf fa ed fe` byte order (the current test helper writes the reverse order, so it does not cover the real Mach-O shape).
