### PR TITLE
fix(sandboxing): decode Mach-O cpu_type in the file's own byte order

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanNativeLibsTransform.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/CleanNativeLibsTransform.kt
@@ -74,23 +74,12 @@ internal abstract class CleanNativeLibsTransform : TransformAction<CleanNativeLi
                 if (!entry.isDirectory && NativeLibArchDetector.isNativeLib(entry.name)) {
                     // Only process files with native extensions (.dll, .so, .dylib, .jnilib)
                     // Never touch .class or other Java files
-                    val pathInfo = NativeLibArchDetector.detectFromPath(entry.name)
-
-                    if (pathInfo.os != NativeOs.UNKNOWN && pathInfo.arch != NativeArch.UNKNOWN) {
-                        // Path has both OS and arch indicators
-                        if (shouldRemoveByInfo(pathInfo, expectedOs, expectedArch)) {
-                            entriesToRemove.add(entry.name)
+                    val remove =
+                        shouldRemoveNativeLib(entry.name, expectedOs, expectedArch) {
+                            NativeLibArchDetector.readHeaderBytes(zis)
                         }
-                    } else {
-                        // Fall back to binary header detection
-                        val header = ByteArray(64)
-                        val bytesRead = readFully(zis, header)
-                        if (bytesRead > 0) {
-                            val headerInfo = NativeLibArchDetector.detectFromHeader(header.copyOf(bytesRead))
-                            if (shouldRemoveByInfo(headerInfo, expectedOs, expectedArch)) {
-                                entriesToRemove.add(entry.name)
-                            }
-                        }
+                    if (remove) {
+                        entriesToRemove.add(entry.name)
                     }
                 }
                 entry = zis.nextEntry
@@ -133,28 +122,6 @@ internal abstract class CleanNativeLibsTransform : TransformAction<CleanNativeLi
         }
     }
 
-    private fun shouldRemoveByInfo(
-        info: NativeInfo,
-        expectedOs: NativeOs,
-        expectedArch: NativeArch,
-    ): Boolean {
-        // Exotic/unsupported OS (freebsd, aix, android, etc.) → always remove
-        if (info.os == NativeOs.OTHER) return true
-        // Known OS that doesn't match target → remove
-        if (info.os != NativeOs.UNKNOWN && info.os != expectedOs) return true
-        // OS matches but exotic/unsupported arch (ppc, arm32, riscv, etc.) → remove
-        if (info.arch == NativeArch.OTHER) return true
-        // OS matches but arch doesn't → remove (unless arch is unknown/universal)
-        if (info.os == expectedOs &&
-            info.arch != NativeArch.UNKNOWN &&
-            info.arch != NativeArch.UNIVERSAL &&
-            info.arch != expectedArch
-        ) {
-            return true
-        }
-        return false
-    }
-
     private fun mapOs(os: String): NativeOs? =
         when (os) {
             "windows" -> NativeOs.WINDOWS
@@ -169,19 +136,42 @@ internal abstract class CleanNativeLibsTransform : TransformAction<CleanNativeLi
             "arm64" -> NativeArch.ARM64
             else -> null
         }
+}
 
-    private fun readFully(
-        input: java.io.InputStream,
-        buffer: ByteArray,
-    ): Int {
-        var totalRead = 0
-        while (totalRead < buffer.size) {
-            val read = input.read(buffer, totalRead, buffer.size - totalRead)
-            if (read == -1) break
-            totalRead += read
-        }
-        return totalRead
+/**
+ * Whether a native lib entry can be stripped from a JAR for the given target.
+ *
+ * Deliberately conservative: anything the detector can't pin down is kept, so an unrecognised
+ * layout costs a few bytes rather than a missing library at runtime. Extracted from the transform
+ * so the decision can be unit-tested without a Gradle artifact-transform execution.
+ */
+internal fun shouldRemoveNativeLib(
+    entryPath: String,
+    expectedOs: NativeOs,
+    expectedArch: NativeArch,
+    readHeader: () -> ByteArray,
+): Boolean = shouldRemoveByInfo(NativeLibArchDetector.detectEntry(entryPath, readHeader), expectedOs, expectedArch)
+
+private fun shouldRemoveByInfo(
+    info: NativeInfo,
+    expectedOs: NativeOs,
+    expectedArch: NativeArch,
+): Boolean {
+    // Exotic/unsupported OS (freebsd, aix, android, etc.) → always remove
+    if (info.os == NativeOs.OTHER) return true
+    // Known OS that doesn't match target → remove
+    if (info.os != NativeOs.UNKNOWN && info.os != expectedOs) return true
+    // OS matches but exotic/unsupported arch (ppc, arm32, riscv, etc.) → remove
+    if (info.arch == NativeArch.OTHER) return true
+    // OS matches but arch doesn't → remove (unless arch is unknown/universal)
+    if (info.os == expectedOs &&
+        info.arch != NativeArch.UNKNOWN &&
+        info.arch != NativeArch.UNIVERSAL &&
+        info.arch != expectedArch
+    ) {
+        return true
     }
+    return false
 }
 
 private val NATIVE_LIBS_CLEANED = Attribute.of("native-libs-cleaned", Boolean::class.javaObjectType)

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NativeLibArchDetector.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/NativeLibArchDetector.kt
@@ -18,11 +18,60 @@ internal object NativeLibArchDetector {
         val arch: NativeArch,
     )
 
+    /**
+     * Bytes to read from a native lib for [detectFromHeader] to reach the machine field.
+     * The PE one is the furthest away: it sits at `e_lfanew + 4`, and `e_lfanew` is routinely
+     * past the first 64 bytes (0x78 in the zstd-kmp dlls, for instance).
+     */
+    const val HEADER_BYTES = 4096
+
     private val NATIVE_EXTENSIONS = setOf(".dll", ".so", ".dylib", ".jnilib")
 
     fun isNativeLib(fileName: String): Boolean {
         val lower = fileName.lowercase()
         return NATIVE_EXTENSIONS.any { lower.endsWith(it) }
+    }
+
+    // --- Entry resolution (path + header) ---
+
+    /**
+     * Resolve a native lib entry, preferring path tokens and completing whatever they leave
+     * unresolved with the binary header.
+     *
+     * Neither source is sufficient on its own: `jni/aarch64/zstd-kmp.dll` names an arch but no
+     * OS, while a flat `libfoo.dylib` names neither. Replacing one with the other (rather than
+     * merging) let a wrong-arch lib pass the packaging filters, see issue #399.
+     *
+     * [readHeader] is invoked at most once, only when the path leaves a field unresolved, and
+     * must return up to [HEADER_BYTES] bytes from the start of the entry (empty if unreadable).
+     */
+    fun detectEntry(
+        entryPath: String,
+        readHeader: () -> ByteArray,
+    ): NativeInfo {
+        val pathInfo = detectFromPath(entryPath)
+        if (pathInfo.os != NativeOs.UNKNOWN && pathInfo.arch != NativeArch.UNKNOWN) {
+            return pathInfo
+        }
+        val header = readHeader()
+        if (header.isEmpty()) return pathInfo
+        val headerInfo = detectFromHeader(header)
+        return NativeInfo(
+            os = if (pathInfo.os != NativeOs.UNKNOWN) pathInfo.os else headerInfo.os,
+            arch = if (pathInfo.arch != NativeArch.UNKNOWN) pathInfo.arch else headerInfo.arch,
+        )
+    }
+
+    /** Reads up to [HEADER_BYTES] bytes from [input], returning exactly what was available. */
+    fun readHeaderBytes(input: java.io.InputStream): ByteArray {
+        val buffer = ByteArray(HEADER_BYTES)
+        var totalRead = 0
+        while (totalRead < buffer.size) {
+            val read = input.read(buffer, totalRead, buffer.size - totalRead)
+            if (read == -1) break
+            totalRead += read
+        }
+        return if (totalRead == buffer.size) buffer else buffer.copyOf(totalRead)
     }
 
     // --- Path-based detection ---
@@ -167,14 +216,19 @@ internal object NativeLibArchDetector {
             return detectELF(bytes)
         }
 
-        // Mach-O / fat binary
+        // Mach-O / fat binary. `magic` is the first 4 bytes read big-endian, so it tells us how
+        // the file itself is laid out: reading back MH_MAGIC_64 (0xFEEDFACF) means the file stores
+        // it big-endian, while the byte-swapped 0xCFFAEDFE means little-endian — which is what
+        // every macOS x86_64/arm64 dylib on disk actually starts with ("cf fa ed fe"). The rest of
+        // the header, cpu_type included, must be read in that same order.
         val magic = ByteBuffer.wrap(bytes, 0, 4).int
         return when (magic) {
-            0xFEEDFACF.toInt() -> detectMachO(bytes, ByteOrder.LITTLE_ENDIAN)
-            0xCFFAEDFE.toInt() -> detectMachO(bytes, ByteOrder.BIG_ENDIAN)
-            0xFEEDFACE.toInt() -> detectMachO(bytes, ByteOrder.LITTLE_ENDIAN)
-            0xCEFAEDFE.toInt() -> detectMachO(bytes, ByteOrder.BIG_ENDIAN)
-            0xCAFEBABE.toInt() -> NativeInfo(NativeOs.MACOS, NativeArch.UNIVERSAL)
+            0xFEEDFACF.toInt() -> detectMachO(bytes, ByteOrder.BIG_ENDIAN)
+            0xCFFAEDFE.toInt() -> detectMachO(bytes, ByteOrder.LITTLE_ENDIAN)
+            0xFEEDFACE.toInt() -> detectMachO(bytes, ByteOrder.BIG_ENDIAN)
+            0xCEFAEDFE.toInt() -> detectMachO(bytes, ByteOrder.LITTLE_ENDIAN)
+            // Fat headers are always big-endian; 0xCAFEBABF is the 64-bit variant.
+            0xCAFEBABE.toInt(), 0xCAFEBABF.toInt() -> NativeInfo(NativeOs.MACOS, NativeArch.UNIVERSAL)
             else -> NativeInfo(NativeOs.UNKNOWN, NativeArch.UNKNOWN)
         }
     }

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractExtractNativeLibsTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractExtractNativeLibsTask.kt
@@ -31,11 +31,6 @@ import java.util.zip.ZipInputStream
  */
 @DisableCachingByDefault(because = "Extracts native libs from JARs; output depends on JAR content order")
 abstract class AbstractExtractNativeLibsTask : AbstractNucleusTask() {
-    private companion object {
-        /** Bytes read from each native lib to reach the PE/ELF/Mach-O machine field for arch detection. */
-        const val HEADER_BYTES = 4096
-    }
-
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.NAME_ONLY)
     abstract val inputJars: ConfigurableFileCollection
@@ -116,34 +111,8 @@ abstract class AbstractExtractNativeLibsTask : AbstractNucleusTask() {
     private fun detectInfo(
         entryName: String,
         zis: ZipInputStream,
-    ): NativeLibArchDetector.NativeInfo {
-        val pathInfo = NativeLibArchDetector.detectFromPath(entryName)
-        // Path detection is authoritative once it fully resolves the platform.
-        if (pathInfo.os != NativeOs.UNKNOWN && pathInfo.arch != NativeArch.UNKNOWN) {
-            return pathInfo
-        }
-        // Otherwise complement — not replace — the path result with binary header detection.
-        // Layouts like zstd-kmp's "jni/aarch64/foo.dll" encode the arch in the path but carry
-        // no OS token, while the PE/ELF/Mach-O header supplies the OS. Discarding the
-        // path-detected arch here previously let an ARM64 .dll be extracted for an x64 target
-        // (its arch reads as UNKNOWN and passes the filter), see issue #399.
-        val headerInfo = detectFromHeaderBytes(zis)
-        return NativeLibArchDetector.NativeInfo(
-            os = if (pathInfo.os != NativeOs.UNKNOWN) pathInfo.os else headerInfo.os,
-            arch = if (pathInfo.arch != NativeArch.UNKNOWN) pathInfo.arch else headerInfo.arch,
-        )
-    }
-
-    private fun detectFromHeaderBytes(zis: ZipInputStream): NativeLibArchDetector.NativeInfo {
-        // Must be large enough to reach the PE machine field: it sits at e_lfanew (a 4-byte
-        // value at offset 0x3C) + 4, which for real DLLs is routinely past the first 64 bytes.
-        val header = ByteArray(HEADER_BYTES)
-        val bytesRead = readFully(zis, header)
-        if (bytesRead <= 0) {
-            return NativeLibArchDetector.NativeInfo(NativeOs.UNKNOWN, NativeArch.UNKNOWN)
-        }
-        return NativeLibArchDetector.detectFromHeader(header.copyOf(bytesRead))
-    }
+    ): NativeLibArchDetector.NativeInfo =
+        NativeLibArchDetector.detectEntry(entryName) { NativeLibArchDetector.readHeaderBytes(zis) }
 
     private fun shouldExtract(
         info: NativeLibArchDetector.NativeInfo,
@@ -201,16 +170,4 @@ abstract class AbstractExtractNativeLibsTask : AbstractNucleusTask() {
             else -> null
         }
 
-    private fun readFully(
-        input: java.io.InputStream,
-        buffer: ByteArray,
-    ): Int {
-        var totalRead = 0
-        while (totalRead < buffer.size) {
-            val read = input.read(buffer, totalRead, buffer.size - totalRead)
-            if (read == -1) break
-            totalRead += read
-        }
-        return totalRead
-    }
 }

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/CleanNativeLibsTransformTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/CleanNativeLibsTransformTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.desktop.application.internal.NativeLibArchDetector.NativeArch
+import dev.nucleusframework.desktop.application.internal.NativeLibArchDetector.NativeOs
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Strip decisions for `cleanupNativeLibs`, using the `com.squareup.zstd:zstd-kmp-jvm` layout
+ * (arch dirs with no OS token) plus the OS+arch layouts of skiko and JNA.
+ *
+ * The rule the transform must never break: keep anything that can't be pinned down. Over-keeping
+ * costs a few bytes in the JAR; over-removing costs an `UnsatisfiedLinkError` at runtime.
+ */
+class CleanNativeLibsTransformTest {
+    @Suppress("MagicNumber")
+    private fun macho(cpuType: Int): ByteArray =
+        byteArrayOf(
+            0xCF.toByte(), 0xFA.toByte(), 0xED.toByte(), 0xFE.toByte(),
+            (cpuType and 0xFF).toByte(),
+            ((cpuType ushr 8) and 0xFF).toByte(),
+            ((cpuType ushr 16) and 0xFF).toByte(),
+            ((cpuType ushr 24) and 0xFF).toByte(),
+        )
+
+    @Suppress("MagicNumber")
+    private fun elf(eMachine: Int): ByteArray {
+        val buf = ByteArray(20)
+        buf[0] = 0x7F
+        buf[1] = 0x45
+        buf[2] = 0x4C
+        buf[3] = 0x46
+        buf[4] = 2
+        buf[5] = 1
+        buf[18] = (eMachine and 0xFF).toByte()
+        return buf
+    }
+
+    @Suppress("MagicNumber")
+    private fun pe(machine: Int): ByteArray {
+        val buf = ByteArray(256)
+        buf[0] = 0x4D
+        buf[1] = 0x5A
+        buf[0x3C] = 0x78
+        buf[0x7C] = (machine and 0xFF).toByte()
+        buf[0x7D] = ((machine ushr 8) and 0xFF).toByte()
+        return buf
+    }
+
+    @Suppress("MagicNumber")
+    private val macArm64 = macho(0x0100000C)
+
+    @Suppress("MagicNumber")
+    private val macX64 = macho(0x01000007)
+
+    private fun removed(
+        path: String,
+        os: NativeOs,
+        arch: NativeArch,
+        header: ByteArray = ByteArray(0),
+    ) = shouldRemoveNativeLib(path, os, arch) { header }
+
+    @Test
+    fun `arch dirs without an OS token are stripped by arch on macOS`() {
+        // The header alone says only "macOS"; the arch comes from the path. Before both were
+        // merged, the opposite-arch dylib was kept for lack of a verdict.
+        assertTrue(
+            removed("jni/x86_64/libzstd-kmp.dylib", NativeOs.MACOS, NativeArch.ARM64, macX64),
+        )
+        assertFalse(
+            removed("jni/aarch64/libzstd-kmp.dylib", NativeOs.MACOS, NativeArch.ARM64, macArm64),
+        )
+        assertTrue(
+            removed("jni/aarch64/libzstd-kmp.dylib", NativeOs.MACOS, NativeArch.X64, macArm64),
+        )
+        assertFalse(
+            removed("jni/x86_64/libzstd-kmp.dylib", NativeOs.MACOS, NativeArch.X64, macX64),
+        )
+    }
+
+    @Test
+    fun `same rule applies to windows and linux arch dirs`() {
+        assertTrue(removed("jni/aarch64/zstd-kmp.dll", NativeOs.WINDOWS, NativeArch.X64, pe(0xAA64)))
+        assertFalse(removed("jni/amd64/zstd-kmp.dll", NativeOs.WINDOWS, NativeArch.X64, pe(0x8664)))
+        assertTrue(removed("jni/aarch64/libzstd-kmp.so", NativeOs.LINUX, NativeArch.X64, elf(0xB7)))
+        assertFalse(removed("jni/amd64/libzstd-kmp.so", NativeOs.LINUX, NativeArch.X64, elf(0x3E)))
+    }
+
+    @Test
+    fun `a flat dylib is filtered on its header alone`() {
+        // No path token at all, so the verdict rests entirely on the Mach-O cpu_type — the field
+        // that decoded to garbage while the magic was mapped to the wrong byte order.
+        assertTrue(removed("libfoo.dylib", NativeOs.MACOS, NativeArch.X64, macArm64))
+        assertFalse(removed("libfoo.dylib", NativeOs.MACOS, NativeArch.ARM64, macArm64))
+        assertTrue(removed("libfoo.dylib", NativeOs.MACOS, NativeArch.ARM64, macX64))
+        assertFalse(removed("libfoo.dylib", NativeOs.MACOS, NativeArch.X64, macX64))
+    }
+
+    @Test
+    fun `libs for another OS are stripped whatever the layout`() {
+        assertTrue(removed("jni/aarch64/zstd-kmp.dll", NativeOs.MACOS, NativeArch.ARM64, pe(0xAA64)))
+        assertTrue(removed("jni/aarch64/libzstd-kmp.so", NativeOs.MACOS, NativeArch.ARM64, elf(0xB7)))
+        assertTrue(removed("libskiko-macos-x64.dylib", NativeOs.MACOS, NativeArch.ARM64, macX64))
+        assertTrue(removed("com/sun/jna/linux-x86-64/libjnidispatch.so", NativeOs.MACOS, NativeArch.ARM64))
+    }
+
+    @Test
+    fun `libs matching the target are kept`() {
+        assertFalse(removed("libskiko-macos-arm64.dylib", NativeOs.MACOS, NativeArch.ARM64, macArm64))
+        assertFalse(removed("com/sun/jna/darwin-aarch64/libjnidispatch.jnilib", NativeOs.MACOS, NativeArch.ARM64))
+        assertFalse(removed("nucleus/native/darwin-aarch64/libnucleus_tao.dylib", NativeOs.MACOS, NativeArch.ARM64))
+    }
+
+    @Test
+    fun `undecidable entries are kept`() {
+        // No usable path token and no recognisable magic → keep, never guess.
+        assertFalse(removed("libmystery.dylib", NativeOs.MACOS, NativeArch.ARM64, byteArrayOf(1, 2, 3, 4)))
+        assertFalse(removed("libmystery.dylib", NativeOs.MACOS, NativeArch.ARM64))
+        // Universal binaries serve every arch.
+        assertFalse(
+            removed(
+                "libuniversal.dylib",
+                NativeOs.MACOS,
+                NativeArch.ARM64,
+                byteArrayOf(0xCA.toByte(), 0xFE.toByte(), 0xBA.toByte(), 0xBE.toByte()),
+            ),
+        )
+    }
+
+    @Test
+    fun `exotic platforms are always stripped`() {
+        assertTrue(removed("native/freebsd-x86-64/libfoo.so", NativeOs.LINUX, NativeArch.X64))
+        assertTrue(removed("native/linux-android/libfoo.so", NativeOs.LINUX, NativeArch.X64))
+        assertTrue(removed("native/linux-ppc64le/libfoo.so", NativeOs.LINUX, NativeArch.X64))
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/NativeLibArchDetectorTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/internal/NativeLibArchDetectorTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2020-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package dev.nucleusframework.desktop.application.internal
+
+import dev.nucleusframework.desktop.application.internal.NativeLibArchDetector.NativeArch
+import dev.nucleusframework.desktop.application.internal.NativeLibArchDetector.NativeInfo
+import dev.nucleusframework.desktop.application.internal.NativeLibArchDetector.NativeOs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Byte-order coverage for [NativeLibArchDetector.detectFromHeader] and merge semantics for
+ * [NativeLibArchDetector.detectEntry].
+ *
+ * The Mach-O cases matter because every macOS `.dylib` on disk is little-endian and therefore
+ * starts with the byte-swapped magic `cf fa ed fe`. Mapping that magic to a big-endian read (as
+ * this detector used to) makes `cpu_type` decode to `0x07000001` instead of `0x01000007`, so real
+ * dylibs reported `arch=UNKNOWN` and no packaging filter could tell arm64 from x86_64.
+ */
+class NativeLibArchDetectorTest {
+    @Suppress("MagicNumber")
+    private fun bytes(vararg values: Int): ByteArray = ByteArray(values.size) { values[it].toByte() }
+
+    // --- Mach-O ---
+
+    @Test
+    fun `little-endian 64-bit mach-o reports its cpu type`() {
+        // "cf fa ed fe" + cpu_type little-endian — the exact prefix of every shipped arm64/x64 dylib.
+        assertEquals(
+            NativeInfo(NativeOs.MACOS, NativeArch.ARM64),
+            NativeLibArchDetector.detectFromHeader(bytes(0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01)),
+        )
+        assertEquals(
+            NativeInfo(NativeOs.MACOS, NativeArch.X64),
+            NativeLibArchDetector.detectFromHeader(bytes(0xCF, 0xFA, 0xED, 0xFE, 0x07, 0x00, 0x00, 0x01)),
+        )
+    }
+
+    @Test
+    fun `big-endian 64-bit mach-o is read in big-endian order`() {
+        // Magic stored unswapped means the whole header is big-endian, cpu_type included.
+        assertEquals(
+            NativeInfo(NativeOs.MACOS, NativeArch.X64),
+            NativeLibArchDetector.detectFromHeader(bytes(0xFE, 0xED, 0xFA, 0xCF, 0x01, 0x00, 0x00, 0x07)),
+        )
+    }
+
+    @Test
+    fun `32-bit mach-o follows the same byte-order rule`() {
+        assertEquals(
+            NativeInfo(NativeOs.MACOS, NativeArch.ARM64),
+            NativeLibArchDetector.detectFromHeader(bytes(0xCE, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01)),
+        )
+        assertEquals(
+            NativeInfo(NativeOs.MACOS, NativeArch.ARM64),
+            NativeLibArchDetector.detectFromHeader(bytes(0xFE, 0xED, 0xFA, 0xCE, 0x01, 0x00, 0x00, 0x0C)),
+        )
+    }
+
+    @Test
+    fun `fat binaries report UNIVERSAL in both 32- and 64-bit flavours`() {
+        // Fat headers are always big-endian; 0xCAFEBABF is the 64-bit variant.
+        assertEquals(
+            NativeInfo(NativeOs.MACOS, NativeArch.UNIVERSAL),
+            NativeLibArchDetector.detectFromHeader(bytes(0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x02)),
+        )
+        assertEquals(
+            NativeInfo(NativeOs.MACOS, NativeArch.UNIVERSAL),
+            NativeLibArchDetector.detectFromHeader(bytes(0xCA, 0xFE, 0xBA, 0xBF, 0x00, 0x00, 0x00, 0x02)),
+        )
+    }
+
+    @Test
+    fun `unknown cpu type still resolves the OS`() {
+        assertEquals(
+            NativeInfo(NativeOs.MACOS, NativeArch.UNKNOWN),
+            NativeLibArchDetector.detectFromHeader(bytes(0xCF, 0xFA, 0xED, 0xFE, 0x12, 0x00, 0x00, 0x00)),
+        )
+    }
+
+    // --- PE / ELF ---
+
+    @Test
+    fun `PE machine field is reachable past the first 64 bytes`() {
+        // e_lfanew = 0x78 (as in the shipped zstd-kmp dlls) puts the machine field at byte 124.
+        val pe = ByteArray(256)
+        pe[0] = 0x4D
+        pe[1] = 0x5A
+        pe[0x3C] = 0x78
+        pe[0x7C] = 0x64
+        pe[0x7D] = 0x86.toByte()
+        assertEquals(NativeInfo(NativeOs.WINDOWS, NativeArch.X64), NativeLibArchDetector.detectFromHeader(pe))
+        // Truncated to the old buffer size the machine field is simply out of reach.
+        assertEquals(
+            NativeInfo(NativeOs.WINDOWS, NativeArch.UNKNOWN),
+            NativeLibArchDetector.detectFromHeader(pe.copyOf(64)),
+        )
+    }
+
+    @Test
+    fun `ELF machine field is decoded per its endianness flag`() {
+        val elf = ByteArray(64)
+        elf[0] = 0x7F
+        elf[1] = 0x45
+        elf[2] = 0x4C
+        elf[3] = 0x46
+        elf[4] = 2
+        elf[5] = 1 // little-endian
+        elf[18] = 0xB7.toByte()
+        assertEquals(NativeInfo(NativeOs.LINUX, NativeArch.ARM64), NativeLibArchDetector.detectFromHeader(elf))
+
+        elf[5] = 2 // big-endian
+        elf[18] = 0x00
+        elf[19] = 0x3E
+        assertEquals(NativeInfo(NativeOs.LINUX, NativeArch.X64), NativeLibArchDetector.detectFromHeader(elf))
+    }
+
+    // --- detectEntry: path + header merge ---
+
+    @Test
+    fun `path arch and header OS complement each other`() {
+        // zstd-kmp's layout: the arch is in the path, the OS only in the binary.
+        val info =
+            NativeLibArchDetector.detectEntry("jni/aarch64/libzstd-kmp.dylib") {
+                bytes(0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01)
+            }
+        assertEquals(NativeInfo(NativeOs.MACOS, NativeArch.ARM64), info)
+    }
+
+    @Test
+    fun `path wins over a disagreeing header`() {
+        val info =
+            NativeLibArchDetector.detectEntry("jni/x86_64/libzstd-kmp.dylib") {
+                bytes(0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00, 0x00, 0x01) // says arm64
+            }
+        assertEquals(NativeInfo(NativeOs.MACOS, NativeArch.X64), info)
+    }
+
+    @Test
+    fun `a fully resolved path never reads the header`() {
+        var read = false
+        val info =
+            NativeLibArchDetector.detectEntry("com/sun/jna/darwin-aarch64/libjnidispatch.jnilib") {
+                read = true
+                ByteArray(0)
+            }
+        assertFalse("header must not be read when the path resolves both fields", read)
+        assertEquals(NativeInfo(NativeOs.MACOS, NativeArch.ARM64), info)
+    }
+
+    @Test
+    fun `an unreadable header leaves the path result untouched`() {
+        val info = NativeLibArchDetector.detectEntry("jni/aarch64/libzstd-kmp.dylib") { ByteArray(0) }
+        assertEquals(NativeInfo(NativeOs.UNKNOWN, NativeArch.ARM64), info)
+    }
+
+    @Test
+    fun `readHeaderBytes returns exactly what the stream had`() {
+        val short = NativeLibArchDetector.readHeaderBytes(ByteArray(10).inputStream())
+        assertEquals(10, short.size)
+        val long = NativeLibArchDetector.readHeaderBytes(ByteArray(NativeLibArchDetector.HEADER_BYTES * 2).inputStream())
+        assertEquals(NativeLibArchDetector.HEADER_BYTES, long.size)
+        assertTrue(NativeLibArchDetector.readHeaderBytes(ByteArray(0).inputStream()).isEmpty())
+    }
+}

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractExtractNativeLibsTaskTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractExtractNativeLibsTaskTest.kt
@@ -61,12 +61,14 @@ class AbstractExtractNativeLibsTaskTest {
 
     @Suppress("MagicNumber")
     private fun macho(cpuType: Int): ByteArray {
-        // Bytes FE ED FA CF read big-endian == 0xFEEDFACF, decoded with LITTLE_ENDIAN cpuType.
+        // Real thin Mach-O layout: the file is little-endian, so MH_MAGIC_64 is stored byte-swapped
+        // as "cf fa ed fe" — the prefix every shipped dylib actually starts with — and cpu_type
+        // follows in that same order.
         val buf = ByteArray(16)
-        buf[0] = 0xFE.toByte()
-        buf[1] = 0xED.toByte()
-        buf[2] = 0xFA.toByte()
-        buf[3] = 0xCF.toByte()
+        buf[0] = 0xCF.toByte()
+        buf[1] = 0xFA.toByte()
+        buf[2] = 0xED.toByte()
+        buf[3] = 0xFE.toByte()
         buf[4] = (cpuType and 0xFF).toByte()
         buf[5] = ((cpuType ushr 8) and 0xFF).toByte()
         buf[6] = ((cpuType ushr 16) and 0xFF).toByte()
@@ -76,17 +78,19 @@ class AbstractExtractNativeLibsTaskTest {
 
     private val winArm64Dll = pe(0xAA64)
     private val winX64Dll = pe(0x8664)
+    private val macArm64Dylib = macho(0x0100000C)
+    private val macX64Dylib = macho(0x01000007)
 
     /** Entry set mirroring zstd-kmp-jvm 0.4.0 exactly. */
     private fun buildInputJar(file: File): File {
         val entries =
             linkedMapOf(
-                "jni/aarch64/libzstd-kmp.dylib" to macho(0x0100000C), // macOS arm64
+                "jni/aarch64/libzstd-kmp.dylib" to macArm64Dylib, // macOS arm64
                 "jni/aarch64/libzstd-kmp.so" to elf(0xB7), // linux arm64
                 "jni/aarch64/zstd-kmp.dll" to winArm64Dll, // windows arm64
                 "jni/amd64/libzstd-kmp.so" to elf(0x3E), // linux x64
                 "jni/amd64/zstd-kmp.dll" to winX64Dll, // windows x64
-                "jni/x86_64/libzstd-kmp.dylib" to macho(0x01000007), // macOS x64
+                "jni/x86_64/libzstd-kmp.dylib" to macX64Dylib, // macOS x64
             )
         ZipOutputStream(file.outputStream().buffered()).use { zos ->
             for ((name, bytes) in entries) {
@@ -139,6 +143,32 @@ class AbstractExtractNativeLibsTaskTest {
         val extracted = outDir.resolve("zstd-kmp.dll")
         assertTrue(extracted.isFile)
         assertArrayEquals(winArm64Dll, extracted.readBytes())
+    }
+
+    /**
+     * The two dylibs flatten to the same `libzstd-kmp.dylib`, so exactly one may survive the
+     * filter. Before the arch merge both did — they were `(MACOS, UNKNOWN)` — and the winner was
+     * whichever came first in the JAR, i.e. the arm64 one on an Intel target.
+     */
+    @Test
+    fun `macos x64 target extracts the x64 dylib, not the arm64 one listed before it`() {
+        val outDir = runExtract(os = "macos", arch = "x64")
+
+        val extracted = outDir.resolve("libzstd-kmp.dylib")
+        assertTrue("expected the flattened dylib to be extracted", extracted.isFile)
+        assertArrayEquals("wrong-arch dylib was extracted for an x64 target", macX64Dylib, extracted.readBytes())
+
+        assertFalse(outDir.resolve("zstd-kmp.dll").exists())
+        assertFalse(outDir.resolve("libzstd-kmp.so").exists())
+    }
+
+    @Test
+    fun `macos arm64 target extracts the arm64 dylib`() {
+        val outDir = runExtract(os = "macos", arch = "arm64")
+
+        val extracted = outDir.resolve("libzstd-kmp.dylib")
+        assertTrue(extracted.isFile)
+        assertArrayEquals(macArm64Dylib, extracted.readBytes())
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #401, which fixed the path-token half of #399.

## Summary

`NativeLibArchDetector.detectMachO` mapped the two Mach-O magics to the wrong byte orders:

```kotlin
0xFEEDFACF.toInt() -> detectMachO(bytes, ByteOrder.LITTLE_ENDIAN)
0xCFFAEDFE.toInt() -> detectMachO(bytes, ByteOrder.BIG_ENDIAN)
```

Apple's `loader.h` defines `MH_CIGAM_64 0xcffaedfe /* NXSwapInt(MH_MAGIC_64) */` — that value *is* the byte-swapped magic, and it is what every little-endian macOS dylib starts with on disk (`cf fa ed fe`). Reading back `0xCFFAEDFE` therefore means the file is little-endian, so `cpu_type` must be read little-endian too. It was read big-endian instead, yielding `0x07000001` where `CPU_TYPE_X86_64` is `0x01000007`, so **every thin dylib reported `arch=UNKNOWN`**.

Cross-checked against `lipo -archs` on 57 real dylibs (`/usr/lib`, the JBR runtime, a packaged `.app`, the zstd-kmp libs):

```
before : 13 ok, 44 unknown, 0 mismatch     (the 13 are universal binaries — the 0xCAFEBABE path, unaffected)
after  : 57 ok,  0 unknown, 0 mismatch
```

Nothing crashed because of it: `UNKNOWN` deliberately passes both packaging filters. The consequences were silent — `cleanupNativeLibs` kept the opposite-arch dylib, and the sandboxed pipeline, which flattens every lib to a bare filename, had no tiebreaker and took whichever came first in the JAR. #401 fixed that for layouts whose path names an arch; this removes the remaining guesswork.

## Changes

- `detectMachO`: swap the two byte-order branches, 32-bit variants (`0xFEEDFACE` / `0xCEFAEDFE`) included.
- Recognise `FAT_MAGIC_64` (`0xCAFEBABF`) next to `FAT_MAGIC`. Fat headers are always big-endian per `fat.h`, so the `FAT_CIGAM` forms cannot occur on disk and stay unhandled.
- Hoist the path+header merge from #401 into `NativeLibArchDetector.detectEntry(entryPath) { header }`, and use it in **both** consumers. `CleanNativeLibsTransform` previously duplicated the old "header replaces path" logic with a 64-byte buffer, so it never saw the merge; it now shares `HEADER_BYTES = 4096` and the merge with the extract task.
- Extract the transform's verdict into `shouldRemoveNativeLib(...)` so it can be unit-tested without running a Gradle artifact transform.
- New `NativeLibArchDetectorTest` (12 cases) and `CleanNativeLibsTransformTest` (7 cases); `AbstractExtractNativeLibsTaskTest` gains the two macOS-target cases it was missing, and its `macho()` helper now emits the real on-disk byte order (it previously wrote the reverse, which only decoded correctly *because* of the bug).

## Effect on packaging

`cleanupNativeLibs` now strips the opposite-arch lib in layouts where the arch lives in the path but the OS only in the binary. On `zstd-demo` with cleanup enabled, `jni/x86_64/libzstd-kmp.dylib` (648 KB) is dropped on an arm64 target; before, both dylibs shipped.

Replaying old vs new over every native entry of a local Gradle cache (1468 JARs, 1074 entries) across all 6 OS/arch targets:

- strip transform: **7** entries newly removed, all wrong-arch; **0** newly kept.
- extract task: **0** divergences from `main`.

The only non-macOS change: on a Windows arm64 target the two jansi dlls in `kotlin-compiler-embeddable` (x86 and x64) are now stripped. An arm64 JVM cannot load either, so this is strictly a size win.

## Test plan

- [x] `:plugin:test` — 210 tests, 21 new. The one failure, `LinuxSignerTest`, is pre-existing and environmental (`gpg --gen-key` fails locally); it is unrelated to these files
- [x] Mutation check: reinstating the old byte-order mapping fails 2 detector tests
- [x] detekt 210 → 208 findings (`transform` drops back under the complexity threshold); ktlint clean
- [x] Verified against `loader.h`, `fat.h`, `machine.h`, the Microsoft PE spec and the ELF gABI — see the constants quoted above
- [x] macOS arm64 e2e, sandboxed pipeline: extraction byte-identical to `main`, `SampleTao.app` prints `zstd-sandbox-roundtrip: roundtrip=true compLen=48 decLen=39`
- [x] macOS arm64 e2e, `cleanupNativeLibs` pipeline: `nucleus-demo` keeps the same 19 native libs as `main` and launches clean; `zstd-demo` with cleanup temporarily enabled keeps only `jni/aarch64/libzstd-kmp.dylib` and runs
- [x] CI on Windows and Linux
