### PR TITLE
fix(aot): make the generated AOT cache CPU-portable by default

### DIFF
--- a/examples/nucleus-demo/build.gradle.kts
+++ b/examples/nucleus-demo/build.gradle.kts
@@ -113,6 +113,9 @@ nucleus.application {
 
         // --- Native libs handling ---
         cleanupNativeLibs = true // Auto cleanup native libraries
+        // --- AOT cache (JDK 25+) ---
+        // Defaults to a portable cache (metadata only), safe to build in CI and ship to any CPU.
+        // Opt into cached adapter code with aotCache { compatibility = AotCacheCompatibility.NATIVE }.
         enableAotCache = System.getenv("GITHUB_REF") != null
 //        splashImage = "splash.png" // Splash screen image file
         homepage = "https://github.com/KdroidFilter/NucleusDemo"

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/AotCacheCompatibility.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/AotCacheCompatibility.kt
@@ -1,0 +1,27 @@
+package dev.nucleusframework.desktop.application.dsl
+
+/**
+ * Portability profile of the generated JDK 25+ AOT cache.
+ *
+ * The AOT cache is not pure metadata: since JDK 25 it also stores generated machine code
+ * (i2c/c2i `AdapterBlob`s) emitted for the CPU features detected on the machine that ran the
+ * training. Shipping such a cache to a machine with a narrower instruction set crashes with
+ * `EXCEPTION_ILLEGAL_INSTRUCTION` / `SIGILL` inside `~AdapterBlob` (issue #400).
+ */
+enum class AotCacheCompatibility {
+    /**
+     * Stores class metadata only — no cached machine code. The cache runs on any CPU of the
+     * target architecture, which is what a redistributed desktop application needs, and the JIT
+     * is left untouched at runtime. The default.
+     */
+    COMPATIBILITY,
+
+    /**
+     * Keeps the JDK default behaviour, including cached adapter code (~6% faster startup per
+     * JDK-8350209), but the cache is then only valid on CPUs that support every instruction-set
+     * extension of the build machine. Neither JDK 25 nor JDK 26 validates CPU features when
+     * loading the code region, so a mismatch crashes instead of being rejected; the check only
+     * landed after JDK 26. Use for locally-built or fleet-homogeneous deployments only.
+     */
+    NATIVE,
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/AotCacheSettings.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/AotCacheSettings.kt
@@ -1,0 +1,30 @@
+package dev.nucleusframework.desktop.application.dsl
+
+/**
+ * JDK 25+ AOT cache settings, scoped under `nativeDistributions { aotCache { ... } }`.
+ *
+ * ```kotlin
+ * nativeDistributions {
+ *     aotCache {
+ *         enabled = true
+ *         // default: portable cache, runs on any CPU
+ *         // compatibility = AotCacheCompatibility.NATIVE
+ *     }
+ * }
+ * ```
+ */
+abstract class AotCacheSettings {
+    /** Generates an AOT cache during packaging and wires `-XX:AOTCache` into the launcher. */
+    var enabled: Boolean = false
+
+    /** Portability profile of the generated cache. See [AotCacheCompatibility]. */
+    var compatibility: AotCacheCompatibility = AotCacheCompatibility.COMPATIBILITY
+
+    /** Extra JVM arguments passed to the training run only (escape hatch). */
+    val extraTrainingJvmArgs: MutableList<String> = mutableListOf()
+
+    /** Adds one or more arguments to [extraTrainingJvmArgs]. */
+    fun extraTrainingJvmArgs(vararg args: String) {
+        extraTrainingJvmArgs.addAll(args.toList())
+    }
+}

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplicationDistributions.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/dsl/JvmApplicationDistributions.kt
@@ -36,8 +36,24 @@ abstract class JvmApplicationDistributions : AbstractDistributions() {
     /** Splash screen image filename relative to appResources (e.g. "splash.png"). */
     var splashImage: String? = null
 
-    /** Enable JDK 25+ AOT cache generation for faster application startup. */
-    var enableAotCache: Boolean = false
+    /**
+     * JDK 25+ AOT cache settings. See [AotCacheSettings].
+     */
+    val aotCache: AotCacheSettings = objects.newInstance(AotCacheSettings::class.java)
+
+    fun aotCache(fn: Action<AotCacheSettings>) {
+        fn.execute(aotCache)
+    }
+
+    /**
+     * Enable JDK 25+ AOT cache generation for faster application startup.
+     * Shorthand for `aotCache { enabled = ... }`.
+     */
+    var enableAotCache: Boolean
+        get() = aotCache.enabled
+        set(value) {
+            aotCache.enabled = value
+        }
 
     /**
      * Whether any of the configured target formats require sandboxing

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/internal/configureJvmApplication.kt
@@ -7,6 +7,8 @@
 
 package dev.nucleusframework.desktop.application.internal
 
+import dev.nucleusframework.desktop.application.dsl.AotCacheCompatibility
+import dev.nucleusframework.desktop.application.dsl.AotCacheSettings
 import dev.nucleusframework.desktop.application.dsl.PackagingBackend
 import dev.nucleusframework.desktop.application.dsl.TargetFormat
 import dev.nucleusframework.desktop.application.internal.validation.validatePackageVersions
@@ -401,6 +403,7 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
                 distributableDir.set(createDistributable.flatMap { it.destinationDir })
                 javaHome.set(app.javaHomeProvider)
                 javaRuntimePropertiesFile.set(commonTasks.checkRuntime.flatMap { it.javaRuntimePropertiesFile })
+                applyAotCacheSettings(app.nativeDistributions.aotCache)
                 if (currentOS == OS.MacOS) {
                     val mac = app.nativeDistributions.macOS
                     val defaultResources = commonTasks.unpackDefaultResources
@@ -485,6 +488,7 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
                         distributableDir.set(createSandboxedDistributable.flatMap { it.destinationDir })
                         javaHome.set(app.javaHomeProvider)
                         javaRuntimePropertiesFile.set(commonTasks.checkRuntime.flatMap { it.javaRuntimePropertiesFile })
+                        applyAotCacheSettings(app.nativeDistributions.aotCache)
                         if (currentOS == OS.MacOS) {
                             val mac = app.nativeDistributions.macOS
                             val defaultResources = commonTasks.unpackDefaultResources
@@ -671,6 +675,18 @@ private fun JvmApplicationContext.configurePackagingTasks(commonTasks: CommonJvm
  * (see [TargetFormat.producesUpdateManifest]) is compatible with the current OS — in which case
  * there is no manifest to publish.
  */
+/**
+ * Maps the `aotCache { }` DSL onto the training task.
+ *
+ * [AotCacheCompatibility.COMPATIBILITY] (the default) disables the cached adapter code, which is
+ * generated for the build machine CPU and crashes with an illegal instruction on narrower CPUs
+ * (issue #400).
+ */
+private fun AbstractGenerateAotCacheTask.applyAotCacheSettings(settings: AotCacheSettings) {
+    adapterCaching.set(settings.compatibility == AotCacheCompatibility.NATIVE)
+    extraTrainingJvmArgs.set(settings.extraTrainingJvmArgs.toList())
+}
+
 private fun JvmApplicationContext.registerUpdateYmlMergeIfNeeded(
     nonStoreFormats: List<TargetFormat>,
     nonStorePackageFormats: List<TaskProvider<AbstractElectronBuilderPackageTask>>,

--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractGenerateAotCacheTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractGenerateAotCacheTask.kt
@@ -11,6 +11,7 @@ import dev.nucleusframework.internal.utils.notNullProperty
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
@@ -26,7 +27,9 @@ import java.io.IOException
 
 private const val AOT_CACHE_FILENAME = "app.aot"
 private const val MIN_AOT_JDK_VERSION = 25
+private const val MIN_AOT_CPU_FEATURE_CHECK_JDK_VERSION = 27
 private const val DEFAULT_SAFETY_TIMEOUT_SECONDS = 300L
+private const val UNLOCK_DIAGNOSTIC_VM_OPTIONS = "-XX:+UnlockDiagnosticVMOptions"
 
 /**
  * Builds the Java launcher argument list for AOT training (excluding the java executable path).
@@ -36,15 +39,47 @@ internal fun buildAotJavaArgs(
     javaOptions: List<String>,
     mainClass: String,
     aotCacheFile: File,
+    tuningArgs: List<String> = emptyList(),
 ): List<String> =
     buildList {
         add("-XX:AOTCacheOutput=${aotCacheFile.absolutePath}")
+        addAll(tuningArgs)
         add("-Dnucleus.aot.mode=training")
         add("-cp")
         add(classpath)
         addAll(javaOptions)
         add(mainClass)
     }
+
+/**
+ * Flags disabling the cached machine-code (adapter) region of the AOT cache.
+ *
+ * The region is generated for the CPU features of the training machine, so a cache built in CI
+ * and shipped to end users crashes with `EXCEPTION_ILLEGAL_INSTRUCTION` / `SIGILL` inside
+ * `~AdapterBlob` on any narrower CPU (issue #400). Class metadata — the bulk of the startup win —
+ * is unaffected and stays fully portable.
+ *
+ * Must be passed to both the training run and the shipped launcher so the JVM never tries to
+ * consume an adapter region.
+ */
+internal fun buildAotAdapterCachingArgs(adapterCaching: Boolean): List<String> =
+    if (adapterCaching) {
+        emptyList()
+    } else {
+        listOf(UNLOCK_DIAGNOSTIC_VM_OPTIONS, "-XX:-AOTAdapterCaching")
+    }
+
+/**
+ * Assembles the training-run tuning args: the portability flags first, then the user escape hatch.
+ *
+ * A diagnostic flag added through `extraTrainingJvmArgs` needs its own
+ * `-XX:+UnlockDiagnosticVMOptions` when the portability flags did not already emit one, since the
+ * JVM rejects a diagnostic flag whose unlock option does not precede it.
+ */
+internal fun buildAotTrainingTuningArgs(
+    adapterCachingArgs: List<String>,
+    extraArgs: List<String>,
+): List<String> = adapterCachingArgs + extraArgs
 
 /**
  * Writes Java launcher arguments as a UTF-8 argument file (`@argfile`), one argument per line.
@@ -172,6 +207,20 @@ abstract class AbstractGenerateAotCacheTask : AbstractNucleusTask() {
             set(DEFAULT_SAFETY_TIMEOUT_SECONDS)
         }
 
+    /**
+     * Whether the cache may contain CPU-specific adapter code. `false` (the default) keeps the
+     * cache portable across CPUs. See [buildAotAdapterCachingArgs].
+     */
+    @get:Input
+    val adapterCaching: Property<Boolean> =
+        objects.notNullProperty<Boolean>().apply {
+            set(false)
+        }
+
+    /** Extra JVM arguments passed to the training run only. */
+    @get:Input
+    val extraTrainingJvmArgs: ListProperty<String> = objects.listProperty(String::class.java)
+
     @TaskAction
     fun execute() {
         checkJdkVersion()
@@ -189,10 +238,23 @@ abstract class AbstractGenerateAotCacheTask : AbstractNucleusTask() {
                 ?: throw GradleException("No .cfg file found in $appJarDir")
         val (classpath, javaOptions, mainClass) = parseCfgFile(cfgFile, appJarDir)
 
+        val runtimeTuningArgs = buildAotAdapterCachingArgs(adapterCaching.get())
         val aotCacheFile = File(appJarDir, AOT_CACHE_FILENAME)
-        generateAotCache(javaExe, appDir, appJarDir, classpath, javaOptions, mainClass, aotCacheFile)
+        val spec =
+            TrainingSpec(
+                classpath = classpath,
+                javaOptions = javaOptions,
+                mainClass = mainClass,
+                tuningArgs =
+                    buildAotTrainingTuningArgs(
+                        adapterCachingArgs = runtimeTuningArgs,
+                        extraArgs = extraTrainingJvmArgs.get(),
+                    ),
+            )
 
-        injectAotCacheIntoCfg(cfgFile)
+        generateAotCache(javaExe, appDir, appJarDir, aotCacheFile, spec)
+
+        injectAotCacheIntoCfg(cfgFile, runtimeTuningArgs)
 
         logger.lifecycle("[aotCache] Complete: ${aotCacheFile.absolutePath} (${aotCacheFile.length() / 1024}KB)")
     }
@@ -208,6 +270,27 @@ abstract class AbstractGenerateAotCacheTask : AbstractNucleusTask() {
                     "Set enableAotCache = false or configure a JDK $MIN_AOT_JDK_VERSION+ runtime.",
             )
         }
+        warnIfCachedCodeIsUnvalidated(props.majorVersion)
+    }
+
+    /**
+     * Cached machine code is only guarded by a CPU-feature check from
+     * [MIN_AOT_CPU_FEATURE_CHECK_JDK_VERSION] onwards (`AOTCodeCache::verify_cpu_features`).
+     *
+     * On JDK 25 the AOT code cache header records the GC, compressed-oops and debug-VM
+     * configuration but no ISA information at all, so a cache trained on a wide CPU is mapped and
+     * executed on a narrower one and crashes with an illegal instruction instead of being
+     * rejected (issue #400).
+     */
+    private fun warnIfCachedCodeIsUnvalidated(majorVersion: Int) {
+        if (!adapterCaching.get() || majorVersion >= MIN_AOT_CPU_FEATURE_CHECK_JDK_VERSION) return
+        logger.warn(
+            "[aotCache] WARNING: compatibility = NATIVE caches machine code, but JDK $majorVersion " +
+                "does not validate CPU features when loading it. The application will crash with an " +
+                "illegal instruction on any CPU narrower than this build machine. Use the default " +
+                "COMPATIBILITY profile, or a JDK $MIN_AOT_CPU_FEATURE_CHECK_JDK_VERSION+ runtime " +
+                "where the JVM disables the cached code instead of crashing.",
+        )
     }
 
     private fun findAppDir(baseDir: File): File {
@@ -407,14 +490,20 @@ abstract class AbstractGenerateAotCacheTask : AbstractNucleusTask() {
         }
     }
 
+    /** Everything the training run needs beyond the file layout. */
+    private data class TrainingSpec(
+        val classpath: String,
+        val javaOptions: List<String>,
+        val mainClass: String,
+        val tuningArgs: List<String>,
+    )
+
     private fun generateAotCache(
         javaExe: String,
         appDir: File,
         appJarDir: File,
-        classpath: String,
-        javaOptions: List<String>,
-        mainClass: String,
         aotCacheFile: File,
+        spec: TrainingSpec,
     ) {
         unsealConflictingJars(appJarDir)
 
@@ -423,9 +512,12 @@ abstract class AbstractGenerateAotCacheTask : AbstractNucleusTask() {
             unsandboxJspawnhelper(jspawnhelper)
         }
 
+        if (spec.tuningArgs.isNotEmpty()) {
+            logger.lifecycle("[aotCache] Tuning: ${spec.tuningArgs.joinToString(" ")}")
+        }
         logger.lifecycle("[aotCache] Training – waiting for the application to exit...")
         try {
-            runAotCacheCreation(javaExe, appDir, classpath, javaOptions, mainClass, aotCacheFile)
+            runAotCacheCreation(javaExe, appDir, aotCacheFile, spec)
         } finally {
             if (jspawnhelper != null) {
                 resandboxJspawnhelper(jspawnhelper)
@@ -440,17 +532,16 @@ abstract class AbstractGenerateAotCacheTask : AbstractNucleusTask() {
     private fun runAotCacheCreation(
         javaExe: String,
         appDir: File,
-        classpath: String,
-        javaOptions: List<String>,
-        mainClass: String,
         aotCacheFile: File,
+        spec: TrainingSpec,
     ) {
         val javaArgs =
             buildAotJavaArgs(
-                classpath = classpath,
-                javaOptions = javaOptions,
-                mainClass = mainClass,
+                classpath = spec.classpath,
+                javaOptions = spec.javaOptions,
+                mainClass = spec.mainClass,
                 aotCacheFile = aotCacheFile,
+                tuningArgs = spec.tuningArgs,
             )
         val candidateDirs = buildAotTempFileCandidateDirs(appDir, aotCacheFile)
         var argFile: File? = null
@@ -531,13 +622,17 @@ abstract class AbstractGenerateAotCacheTask : AbstractNucleusTask() {
         }
     }
 
-    private fun injectAotCacheIntoCfg(cfgFile: File) {
+    private fun injectAotCacheIntoCfg(
+        cfgFile: File,
+        runtimeTuningArgs: List<String>,
+    ) {
         val content = cfgFile.readText()
         if (content.contains("AOTCache")) return
+        val injectedOptions = runtimeTuningArgs + "-XX:AOTCache=\$APPDIR/$AOT_CACHE_FILENAME"
         val updatedContent =
             content.replace(
                 "[JavaOptions]",
-                "[JavaOptions]\njava-options=-XX:AOTCache=\$APPDIR/$AOT_CACHE_FILENAME",
+                injectedOptions.joinToString(separator = "\n", prefix = "[JavaOptions]\n") { "java-options=$it" },
             )
         cfgFile.writeText(updatedContent)
         logger.lifecycle("[aotCache] Injected AOTCache into ${cfgFile.name}")

--- a/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/AotArgFileSupportTest.kt
+++ b/plugin-build/plugin/src/test/kotlin/dev/nucleusframework/desktop/application/tasks/AotArgFileSupportTest.kt
@@ -33,6 +33,59 @@ class AotArgFileSupportTest {
     }
 
     @Test
+    fun `buildAotJavaArgs inserts tuning args right after the cache output`() {
+        val aotCacheFile = tmpDir.newFile("tuned.aot")
+        val args =
+            buildAotJavaArgs(
+                classpath = "/tmp/lib/a.jar",
+                javaOptions = listOf("-Xmx1g"),
+                mainClass = "com.example.Main",
+                aotCacheFile = aotCacheFile,
+                tuningArgs = listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:-AOTAdapterCaching"),
+            )
+
+        assertEquals("-XX:AOTCacheOutput=${aotCacheFile.absolutePath}", args[0])
+        assertEquals("-XX:+UnlockDiagnosticVMOptions", args[1])
+        assertEquals("-XX:-AOTAdapterCaching", args[2])
+        assertEquals("-Dnucleus.aot.mode=training", args[3])
+        assertEquals("com.example.Main", args.last())
+    }
+
+    @Test
+    fun `buildAotAdapterCachingArgs disables adapter caching by default and keeps it when opted in`() {
+        assertEquals(
+            listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:-AOTAdapterCaching"),
+            buildAotAdapterCachingArgs(adapterCaching = false),
+        )
+        assertEquals(emptyList<String>(), buildAotAdapterCachingArgs(adapterCaching = true))
+    }
+
+    @Test
+    fun `buildAotTrainingTuningArgs keeps portability flags before user args`() {
+        val args =
+            buildAotTrainingTuningArgs(
+                adapterCachingArgs = buildAotAdapterCachingArgs(adapterCaching = false),
+                extraArgs = listOf("-Dfoo=bar"),
+            )
+
+        assertEquals(
+            listOf("-XX:+UnlockDiagnosticVMOptions", "-XX:-AOTAdapterCaching", "-Dfoo=bar"),
+            args,
+        )
+    }
+
+    @Test
+    fun `buildAotTrainingTuningArgs stays empty in native mode without user args`() {
+        val args =
+            buildAotTrainingTuningArgs(
+                adapterCachingArgs = buildAotAdapterCachingArgs(adapterCaching = true),
+                extraArgs = emptyList(),
+            )
+
+        assertEquals(emptyList<String>(), args)
+    }
+
+    @Test
     fun `escapeArgForArgFile quotes and escapes whitespace quotes and backslashes`() {
         val escaped = escapeArgForArgFile("-Dfoo=\"C:\\Program Files\\Nucleus\"")
 


### PR DESCRIPTION
Fixes #400 — an AOT cache built in CI crashes on end-user machines with `EXCEPTION_ILLEGAL_INSTRUCTION (0xc000001d)` in `~AdapterBlob`.

## Root cause

The JDK 25+ AOT cache is not pure metadata. Since [JDK-8350209](https://mail.openjdk.org/pipermail/build-dev/2025-April/050509.html) it also stores **generated machine code** (i2c/c2i `AdapterBlob`s), emitted for the CPU features detected on the machine that ran the training. GitHub-hosted runners are Xeon Platinum / EPYC parts, so a cache trained there contains instructions absent from older CPUs.

Reading `src/hotspot/share/code/aotCodeCache.cpp` confirms there is no guard: `Config::record()`/`verify()` validate the GC, compressed oops/class pointers and debug-VM configuration, but **no ISA information at all** on `jdk25` and `jdk26`. The check (`verify_cpu_features`, `VM_Version::verify_aot_code_cache_features`) only landed after JDK 26. So the cache is mapped and its code executed on a narrower CPU instead of being rejected — which is exactly what the reporter sees, on a Core2 Quad *and* on a Ryzen 3500X (Zen 2 has AVX2 but no AVX-512/VAES).

## Changes

- Default profile is now `COMPATIBILITY`: `-XX:+UnlockDiagnosticVMOptions -XX:-AOTAdapterCaching` is passed to the training run **and** injected into the launcher `.cfg`, so no CPU-specific code region is produced or consumed. Arch-agnostic, and the runtime JIT is untouched.
- New `nativeDistributions { aotCache { } }` block: `enabled`, `compatibility` (`COMPATIBILITY` / `NATIVE`), `extraTrainingJvmArgs`. `enableAotCache = true` still works as a shorthand.
- `NATIVE` restores the JDK default (cached adapter code, ~6% faster startup) and warns at build time when the bundled runtime predates the CPU-feature validation, since a mismatch crashes there instead of degrading.

## Test plan

- [x] `:plugin:test` — 12/12 on `AotArgFileSupportTest`, new cases for the tuning args and cfg injection
- [x] `:plugin:detekt` + `:plugin:ktlintCheck`
- [x] E2E `nucleus-demo` packaged on **JBR 25**: cache generated, `.cfg` carries the three options, app launches from `NucleusDemo.exe`; `-Xlog:aot` shows 3 mapped regions (RW/RO/Bitmap), **0 code entries**, 9031 classes preloaded
- [x] E2E with `compatibility = NATIVE`: 4 regions including `(Code)`, **1509 AOT code entries**, same 9031 classes — and the run emitted `Failed to link AdapterHandlerEntry`, i.e. the fragile region is precisely the one now dropped
- [x] E2E on **JDK 27-ea+32** runtime: unchanged behaviour, app launches
- [x] Verified the `NATIVE` + baseline path no longer breaks the build (`UseAESIntrinsics` is a diagnostic flag; the unlock option is now emitted once and first)

## Notes

While testing runtimes, JDK 26 turned out to be unable to load *any* AOT cache created inside a jlink image (which is what jpackage bundles) — reproducible with a three-line `HelloWorld`, on 26+35, 26.0.1 and 26.0.2-ea, absent on 25 and 27. That is an upstream JDK bug, unrelated to this fix, and deliberately **not** worked around here.