### PR TITLE
fix(proguard): survive obfuscation for all JNI bridges and coroutines

### DIFF
--- a/media-control/build.gradle.kts
+++ b/media-control/build.gradle.kts
@@ -88,7 +88,7 @@ val buildNativeWindows by tasks.registering(Exec::class) {
     inputs.dir(nativeDir)
     outputs.dir(nativeResourceDir)
     workingDir(nativeDir)
-    commandLine("cmd", "/c", "build.bat")
+    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
 }
 
 tasks.processResources {

--- a/plugin-build/plugin/src/main/resources/nucleus-default-compose-desktop-rules.pro
+++ b/plugin-build/plugin/src/main/resources/nucleus-default-compose-desktop-rules.pro
@@ -147,134 +147,32 @@
 -dontwarn dev.nucleusframework.**
 -dontnote dev.nucleusframework.**
 
-# Nucleus decorated-window JNI
--keep class dev.nucleusframework.window.utils.macos.NativeMacBridge {
-    native <methods>;
-}
--keep class dev.nucleusframework.window.** { *; }
+# ── Nucleus JNI bridges ─────────────────────────────────────────────
+# Native entry points are resolved by symbol name (Java_<pkg>_<class>_<method>),
+# so renaming a class or a method that declares `native` breaks the lookup at the
+# first call — an UnsatisfiedLinkError deep inside composition at runtime, never a
+# build failure. The rules below are deliberately generic: enumerating bridges
+# module by module is what left autolaunch, launcher-linux, notification-linux,
+# notification-macos, service-management-macos, system-info, taskbar-progress and
+# graalvm-runtime's locale bridge unprotected, and every new native module would
+# have to remember to add itself here.
 
-# Nucleus darkmode-detector JNI (macOS)
-# NativeDarkModeBridge is looked up by name from native code (FindClass + GetStaticMethodID)
--keep class dev.nucleusframework.darkmodedetector.mac.NativeDarkModeBridge {
-    native <methods>;
-    static void onThemeChanged(boolean);
-}
-
-# Nucleus darkmode-detector JNI (Linux)
-# NativeLinuxBridge is looked up by name from native code (FindClass + GetStaticMethodID)
--keep class dev.nucleusframework.darkmodedetector.linux.NativeLinuxBridge {
-    native <methods>;
-    static void onThemeChanged(boolean);
-}
-
-# Nucleus darkmode-detector JNI (Windows)
--keep class dev.nucleusframework.darkmodedetector.windows.NativeWindowsBridge {
-    native <methods>;
-}
--keep class dev.nucleusframework.darkmodedetector.** { *; }
-
-# Nucleus fs-watcher JNI
-# NativeFsWatcherBridge is looked up by name from native code (FindClass + GetStaticMethodID)
--keep class dev.nucleusframework.fswatcher.NativeFsWatcherBridge {
-    native <methods>;
-    static void onNativeEvent(long, long, java.lang.Long, int, java.lang.String, java.lang.String, boolean, int);
-    static void onNativeError(long, long, java.lang.Long, java.lang.String, boolean, java.lang.String);
-}
-
-# Nucleus native-ssl JNI (macOS)
--keep class dev.nucleusframework.nativessl.mac.NativeSslBridge {
+# Any Nucleus class declaring native methods keeps its own name and the names of
+# those methods. Unused classes can still be shrunk away.
+-keepclasseswithmembernames,includedescriptorclasses class dev.nucleusframework.** {
     native <methods>;
 }
 
-# Nucleus native-ssl JNI (Windows)
--keep class dev.nucleusframework.nativessl.windows.WindowsSslBridge {
-    native <methods>;
-}
+# Bridge objects are additionally looked up from native code via FindClass +
+# GetStaticMethodID for callbacks (onThemeChanged, onHotKey, onToastActivated,
+# onMenuItemClicked, …). Those callbacks are ordinary JVM methods with no
+# reachable caller, so ProGuard cannot see them — bridges are kept whole. They
+# are thin JNI shims, so the size cost is negligible.
+-keep class dev.nucleusframework.**Bridge { *; }
+-keep class dev.nucleusframework.**Jni { *; }
 
-# Nucleus system-color JNI (macOS)
-# NativeMacSystemColorBridge is looked up by name from native code (FindClass + GetStaticMethodID)
--keep class dev.nucleusframework.systemcolor.mac.NativeMacSystemColorBridge {
-    native <methods>;
-    static void onAccentColorChanged(float, float, float);
-    static void onAccentColorCleared();
-    static void onContrastChanged(boolean);
-}
-
-# Nucleus system-color JNI (Linux)
-# NativeLinuxSystemColorBridge is looked up by name from native code (FindClass + GetStaticMethodID)
--keep class dev.nucleusframework.systemcolor.linux.NativeLinuxSystemColorBridge {
-    native <methods>;
-    static void onAccentColorChanged(float, float, float);
-    static void onHighContrastChanged(boolean);
-}
-
-# Nucleus system-color JNI (Windows)
-# NativeWindowsSystemColorBridge is looked up by name from native code (FindClass + GetStaticMethodID)
--keep class dev.nucleusframework.systemcolor.windows.NativeWindowsSystemColorBridge {
-    native <methods>;
-    static void onAccentColorChanged(int, int, int);
-    static void onHighContrastChanged(boolean);
-}
--keep class dev.nucleusframework.systemcolor.** { *; }
-
-# Nucleus energy-manager JNI (macOS)
--keep class dev.nucleusframework.energymanager.macos.NativeMacOsEnergyBridge {
-    native <methods>;
-}
-
-# Nucleus energy-manager JNI (Linux)
--keep class dev.nucleusframework.energymanager.linux.NativeLinuxEnergyBridge {
-    native <methods>;
-}
-
-# Nucleus energy-manager JNI (Windows)
--keep class dev.nucleusframework.energymanager.windows.NativeWindowsEnergyBridge {
-    native <methods>;
-}
--keep class dev.nucleusframework.energymanager.** { *; }
-
-# Nucleus linux-hidpi JNI
--keep class dev.nucleusframework.hidpi.HiDpiLinuxBridge {
-    native <methods>;
-}
-
-# Nucleus notification-windows JNI — static callbacks invoked from native via FindClass/GetStaticMethodID
--keep class dev.nucleusframework.notification.windows.NativeWindowsNotificationBridge {
-    native <methods>;
-    static void onToastActivated(java.lang.String, java.lang.String, java.lang.String, java.lang.String[], java.lang.String[]);
-    static void onToastDismissed(java.lang.String, java.lang.String, int);
-    static void onToastFailed(java.lang.String, java.lang.String, int);
-    static void onToastShown(long, java.lang.String);
-    static void onToastUpdated(long, java.lang.String);
-    static void onHistoryResult(long, java.lang.String[], java.lang.String[], java.lang.String);
-}
--keep class dev.nucleusframework.notification.windows.** { *; }
--keep class dev.nucleusframework.notification.common.** { *; }
-
-# Nucleus media-control JNI — native code uses FindClass(BRIDGE_CLASS) + static callbacks
--keep class dev.nucleusframework.media.control.** { *; }
-
-# Nucleus scheduler JNI
--keep class dev.nucleusframework.scheduler.** { *; }
-
-# Nucleus global-hotkey JNI — onHotKey is invoked from native code via JNI
--keep class dev.nucleusframework.globalhotkey.windows.NativeWindowsHotKeyBridge {
-    native <methods>;
-    static void onHotKey(long, int, int);
-}
--keep class dev.nucleusframework.globalhotkey.macos.NativeMacOsHotKeyBridge {
-    native <methods>;
-    static void onHotKey(long, int, int);
-}
--keep class dev.nucleusframework.globalhotkey.linux.NativeLinuxHotKeyBridge {
-    native <methods>;
-    static void onHotKey(long, int, int);
-}
-
-# Nucleus launcher-windows JNI — ThumbBarClickListener.onThumbButtonClick is invoked from native
--keep class dev.nucleusframework.launcher.windows.NativeWindowsBadgeBridge { native <methods>; }
--keep class dev.nucleusframework.launcher.windows.NativeWindowsJumpListBridge { native <methods>; }
--keep class dev.nucleusframework.launcher.windows.NativeWindowsTaskbarBridge { native <methods>; }
+# Callback interfaces implemented by application code: native code invokes the
+# interface method on instances whose construction ProGuard never observes.
 -keep interface dev.nucleusframework.launcher.windows.ThumbBarClickListener {
     void onThumbButtonClick(int);
 }
@@ -282,27 +180,15 @@
     void onThumbButtonClick(int);
 }
 
-# Nucleus menu-macos JNI — NativeNsMenuBridge is looked up by name from native
-# code (FindClass + GetStaticMethodID). The menu action/delegate callbacks fire
-# from AppKit into these @JvmStatic methods, so both the class name and the
-# method names must survive shrinking/obfuscation.
--keep class dev.nucleusframework.menu.macos.NativeNsMenuBridge {
-    native <methods>;
-    static void onMenuItemAction(long);
-    static void onMenuWillOpen(long);
-    static void onMenuDidClose(long);
-    static void onMenuNeedsUpdate(long);
-    static void onMenuWillHighlightItem(long, long);
-    static int onNumberOfItemsInMenu(long);
-}
-
-# Nucleus launcher-macos JNI — NativeMacOsDockMenuBridge is looked up by name
-# from native code (FindClass + GetStaticMethodID); onMenuItemClicked is the
-# dock-menu action callback invoked from AppKit.
--keep class dev.nucleusframework.launcher.macos.NativeMacOsDockMenuBridge {
-    native <methods>;
-    static void onMenuItemClicked(int);
-}
+# API surfaces whose types cross the JNI boundary or are resolved reflectively
+# beyond the bridge objects themselves.
+-keep class dev.nucleusframework.window.** { *; }
+-keep class dev.nucleusframework.darkmodedetector.** { *; }
+-keep class dev.nucleusframework.systemcolor.** { *; }
+-keep class dev.nucleusframework.energymanager.** { *; }
+-keep class dev.nucleusframework.notification.** { *; }
+-keep class dev.nucleusframework.media.control.** { *; }
+-keep class dev.nucleusframework.scheduler.** { *; }
 
 -dontwarn sun.misc.Unsafe
 -dontwarn sun.awt.**

--- a/plugin-build/plugin/src/main/resources/nucleus-obfuscation-safety-rules.pro
+++ b/plugin-build/plugin/src/main/resources/nucleus-obfuscation-safety-rules.pro
@@ -7,8 +7,10 @@
 # open-source and carry no IP to protect, so their *names* are preserved while everything the
 # application declares (its own packages) is still obfuscated.
 #
-# `allowshrinking,allowoptimization` keeps ProGuard's shrinking and optimization passes fully
-# active on these classes (dead Compose code is still stripped, methods still optimized) — only
-# the renaming pass is held back.
--keep,allowshrinking,allowoptimization class androidx.** { *; }
--keep,allowshrinking,allowoptimization class kotlinx.** { *; }
+# `allowshrinking` keeps the shrinking pass fully active on these classes (dead Compose code
+# is still stripped) — renaming AND optimization are held back. Optimization must stay off for
+# kept-by-name framework classes: ProGuard's method specialization/class merging rewrites
+# signatures inside kotlinx.coroutines inconsistently with their call sites, producing
+# `VerifyError: Bad type on operand stack` in ChannelsKt.trySendBlocking at runtime.
+-keep,allowshrinking class androidx.** { *; }
+-keep,allowshrinking class kotlinx.** { *; }

--- a/system-color/build.gradle.kts
+++ b/system-color/build.gradle.kts
@@ -84,7 +84,7 @@ val buildNativeWindows by tasks.registering(Exec::class) {
     inputs.dir(nativeDir)
     outputs.dir(nativeResourceDir)
     workingDir(nativeDir)
-    commandLine("cmd.exe", "/c", "build.bat")
+    commandLine("cmd", "/c", nativeDir.file("build.bat").asFile.absolutePath)
 }
 
 tasks.processResources {


### PR DESCRIPTION
## Summary
- Release builds with `proguard { obfuscate = true }` (enabled in v2.1.6) crashed at runtime with `UnsatisfiedLinkError`: the JNI keep rules enumerated bridges module by module, leaving autolaunch, launcher-linux, notification-linux/macos, service-management-macos, system-info, taskbar-progress and graalvm-runtime's locale bridge unprotected, so their classes were renamed and the `Java_<pkg>_<class>_<method>` symbol lookup broke.
- Replace the enumeration with generic rules: `-keepclasseswithmembernames` for any `dev.nucleusframework` class declaring `native` methods, plus keep `*Bridge`/`*Jni` objects whole (native code resolves them via `FindClass` + `GetStaticMethodID` for callbacks). New native modules are covered automatically.
- Fix a second crash, `VerifyError: Bad type on operand stack` in `ChannelsKt.trySendBlocking`: `allowoptimization` on kept-by-name `kotlinx.**`/`androidx.**` let ProGuard's optimizer specialize method signatures inconsistently with their call sites. Dropped from the obfuscation-safety rules; shrinking stays fully active.
- Fix `system-color`/`media-control` native build tasks to invoke `build.bat` by absolute path like every other module — the bare name fails on machines hardened with `NoDefaultCurrentDirectoryInExePath=1`.

## Test plan
- [x] `proguardReleaseJars` succeeds; obfuscated jars keep bridge class names (`NativeAutoLaunchBridge`, `NativeWindowsNotificationBridge`, scheduler `*Jni`, …) while other app classes remain obfuscated
- [x] NSIS release install of nucleus-demo launches and runs without `UnsatisfiedLinkError` / `VerifyError`
- [ ] CI pre-merge