### PR TITLE
ci: use Microsoft JDK on Windows, Temurin elsewhere

### DIFF
--- a/.github/actions/setup-nucleus/action.yml
+++ b/.github/actions/setup-nucleus/action.yml
@@ -1,13 +1,13 @@
 name: Setup Nucleus
-description: Setup JBR, packaging tools, Gradle, and Node.js for Nucleus builds
+description: Setup the JDK, packaging tools, Gradle, and Node.js for Nucleus builds
 
 inputs:
   java-version:
-    description: 'JBR (JetBrains Runtime) version used to run Gradle and bundled by jpackage in JVM packaging builds. A bare LTS major like "25" resolves to the latest JBR build; setup-java handles every CI OS/arch, including windows-aarch64 where Temurin 25 is EA-only.'
+    description: 'JDK version used to run Gradle and bundled by jpackage in JVM packaging builds. A bare LTS major like "25" resolves to the latest build of the per-OS distribution (Microsoft Build of OpenJDK on Windows, Temurin elsewhere).'
     required: false
     default: '25'
   java-package:
-    description: 'JBR package variant (jdk, jre, jdk+jcef, jre+jcef, jdk+ft, jre+ft). Defaults to the full JDK so jpackage/jlink can build a custom runtime.'
+    description: 'JDK package variant (jdk, jre). Defaults to the full JDK so jpackage/jlink can build a custom runtime.'
     required: false
     default: 'jdk'
   packaging-tools:
@@ -49,25 +49,25 @@ inputs:
 
 outputs:
   java-home:
-    description: 'Path to the JBR installation'
+    description: 'Path to the JDK installation'
     value: ${{ steps.set-java-home.outputs.java-home }}
 
 runs:
   using: composite
   steps:
-    # ── JDK (JetBrains Runtime) ────────────────────────────────────────
-    # JBR is the single JDK for every job. setup-java's jetbrains distribution
-    # resolves the latest JBR build for the given LTS major and covers every CI
-    # OS/arch — including windows-aarch64, where Temurin 25 is only published as
-    # an EA beta. jpackage bundles this JDK into the distributed app, and
-    # decorated-window-jbr needs the JBR API at runtime. In GraalVM mode the
-    # native image is built entirely by the plugin-provisioned GraalVM, so the
-    # Gradle JDK contributes nothing to that output — JBR is used uniformly for
-    # simplicity.
-    - name: Set up JDK (JBR)
+    # ── JDK ─────────────────────────────────────────────────────────────
+    # Windows (x64 and aarch64) uses the Microsoft Build of OpenJDK: it is the
+    # only mainstream distribution with GA windows-aarch64 builds for current
+    # LTS majors (Temurin still ships that arch as EA). Every other OS/arch uses
+    # Temurin, matching the rest of the workflows. jpackage bundles this JDK into
+    # the distributed app. In GraalVM mode the native image is built entirely by
+    # the plugin-provisioned GraalVM, so the Gradle JDK contributes nothing to
+    # that output. decorated-window-jbr needs no JBR here — the JBR API comes
+    # from the org.jetbrains.runtime:jbr-api Maven artifact.
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        distribution: 'jetbrains'
+        distribution: ${{ runner.os == 'Windows' && 'microsoft' || 'temurin' }}
         java-version: ${{ inputs.java-version }}
         java-package: ${{ inputs.java-package }}
       env:


### PR DESCRIPTION
## Summary
- `setup-nucleus` no longer installs JBR. Windows (x64 and aarch64) now uses the Microsoft Build of OpenJDK — the only mainstream distribution with GA `windows-aarch64` builds for current LTS majors (Temurin is still EA there, which was the original reason for JBR). All other OS/arch combinations use Temurin, matching every other workflow in the repo.
- `decorated-window-jbr` needs no JBR at build time: the JBR API is consumed from the `org.jetbrains.runtime:jbr-api` Maven artifact.
- Updated the action's inputs/comments accordingly (`java-package` variants are now plain `jdk`/`jre`).

## Test plan
- [ ] CI: all `Build` matrix jobs (windows-latest, windows-11-arm, ubuntu, macOS) resolve their JDK and package successfully