### PR TITLE
fix(proguard): resolve the JDK library jars on JMOD-less JDKs

### DIFF
--- a/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractProguardTask.kt
+++ b/plugin-build/plugin/src/main/kotlin/dev/nucleusframework/desktop/application/tasks/AbstractProguardTask.kt
@@ -95,13 +95,7 @@ abstract class AbstractProguardTask : AbstractNucleusTask() {
         val destinationDir = destinationDir.ioFile.absoluteFile
 
         // todo: can be cached for a jdk
-        val jmods =
-            javaHome
-                .resolve("jmods")
-                .walk()
-                .filter {
-                    it.isFile && it.path.endsWith("jmod", ignoreCase = true)
-                }.toList()
+        val libraryJarsConfig = jdkLibraryJarsConfig(javaHome)
 
         val inputToOutputJars = LinkedHashMap<File, File>()
         // avoid mangling mainJar
@@ -126,8 +120,8 @@ abstract class AbstractProguardTask : AbstractNucleusTask() {
                 writer.writeLn("-outjars '${mainJarInDestinationDir.ioFile.normalizedPath()}'")
             }
 
-            for (jmod in jmods) {
-                writer.writeLn("-libraryjars '${jmod.normalizedPath()}'(!**.jar;!module-info.class)")
+            for (libraryJar in libraryJarsConfig) {
+                writer.writeLn(libraryJar)
             }
         }
 
@@ -178,6 +172,46 @@ abstract class AbstractProguardTask : AbstractNucleusTask() {
             environment = emptyMap(),
             logToConsole = ExternalToolRunner.LogToConsole.Always,
         ).assertNormalExitValue()
+    }
+
+    /**
+     * `-libraryjars` lines covering the JDK's own classes.
+     *
+     * Modular JDKs ship them as jmod files under `jmods`, but distributions built with run-time image linking
+     * (JEP 493, JDK 25+) drop that directory entirely — Temurin 25 is one of them. With no library
+     * jars ProGuard cannot resolve even `java.lang.Object` and aborts after several hundred thousand
+     * "can't find referenced class" warnings, so fall back to extracting the run-time image with
+     * `jimage` and hand ProGuard one class root per module.
+     */
+    private fun jdkLibraryJarsConfig(javaHome: File): List<String> {
+        val jmodsDir = javaHome.resolve("jmods")
+        val jmods =
+            jmodsDir
+                .walk()
+                .filter {
+                    it.isFile && it.path.endsWith("jmod", ignoreCase = true)
+                }.toList()
+        if (jmods.isNotEmpty()) {
+            return jmods.map { "-libraryjars '${it.normalizedPath()}'(!**.jar;!module-info.class)" }
+        }
+
+        val runtimeImage = javaHome.resolve("lib").resolve("modules")
+        check(runtimeImage.isFile) {
+            "Cannot resolve the JDK classes required by ProGuard: neither '$jmodsDir' nor " +
+                "'$runtimeImage' exists. Point the application's javaHome at a JDK."
+        }
+
+        val modulesDir = workingDir.ioFile.resolve("jdk-modules")
+        runExternalTool(
+            tool = jvmToolFile(toolName = "jimage", javaHome = javaHome),
+            args = listOf("extract", "--dir", modulesDir.normalizedPath(), runtimeImage.normalizedPath()),
+        ).assertNormalExitValue()
+
+        val moduleDirs = modulesDir.listFiles().orEmpty().filter { it.isDirectory }
+        check(moduleDirs.isNotEmpty()) {
+            "Extracting '$runtimeImage' produced no modules in '$modulesDir'."
+        }
+        return moduleDirs.map { "-libraryjars '${it.normalizedPath()}'(!module-info.class,**.class)" }
     }
 
     private fun Writer.writeLn(s: String) {


### PR DESCRIPTION
## Summary

Release builds fail in `proguardReleaseJars` on every non-Windows runner since the CI JDK moved from the JBR SDK to Temurin ([failing run](https://github.com/NucleusFramework/Nucleus/actions/runs/30199137918/job/89786155531)): 698 730 `can't find referenced class java.lang.Object` warnings, then `IOException: Please correct the above warnings first` — a 97 MB job log and no packages produced.

- `AbstractProguardTask` derived every `-libraryjars` entry from `$JAVA_HOME/jmods`. JDKs built with run-time image linking (JEP 493, JDK 25+) drop that directory entirely — Temurin 25 is one of them (`bin conf include legal lib man release`), while the JBR SDK and the Microsoft Build of OpenJDK still ship it, which is why the Windows jobs stayed green.
- With `jmods` missing the generated config carried no library jars at all, so ProGuard could not resolve a single JDK class — and failed with warning spam rather than a usable error.
- Fall back to extracting the run-time image with `jimage extract` and pass one class root per module (69 roots, ~0.4 s, 204 MB under the task's `@LocalState` dir — build-time only, never packaged).
- JDKs that still ship `jmods` keep the exact previous behaviour; a JDK offering neither now fails through the existing `jvmToolFile` check with a one-line diagnostic.

`jmods` had no other consumer in the repo: `jlink`, `jpackage`, `jdeps`/`suggestModules`, the AOT cache and GraalVM never touched it.

## Test plan

Verified locally on Linux x64 with Temurin 25.0.3+9 (no `jmods`) and the system OpenJDK 25 (with `jmods`):

- [x] Repro before the fix on Temurin: same 698 730 unresolved references as CI
- [x] After the fix on Temurin: `proguardReleaseJars` succeeds, **0** unresolved references, 69 module roots in `jars-config.pro`
- [x] Full `packageReleaseDistributionForCurrentOS` on Temurin: deb, rpm, AppImage, snap, flatpak, pacman, 7z, tar.gz, zip — including `checkRuntime` + `createRuntimeImage` (jlink via run-time image linking)
- [x] No regression on a JDK with `jmods`: `--rerun-tasks` still emits the 69 `-libraryjars '….jmod'` entries, build green
- [x] `jlink` from a cacerts-patched JMOD-less JDK still works (relevant to the CA-patching task)
- [x] `ktlintCheck` + `detekt` clean on the changed file