### PR TITLE
fix(tao): keep the Windows, macOS and Linux hosts alive during an outbound OS drag

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoAccessibility.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoAccessibility.kt
@@ -4,11 +4,13 @@ package dev.nucleusframework.window.tao
 
 import androidx.compose.runtime.snapshots.Snapshot
 import dev.nucleusframework.core.runtime.NucleusApp
+import dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
 import dev.nucleusframework.window.tao.ffi.NativeTaoBridge
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Logger
+import kotlin.coroutines.EmptyCoroutineContext
 
 private val a11yLogger: Logger = Logger.getLogger("dev.nucleusframework.window.tao.a11y")
 
@@ -598,9 +600,7 @@ internal open class TaoAccessibilityController(
     internal fun onActionInvoked(
         nodeId: Long,
         action: Int,
-    ) {
-        if (isDisposed) return
-        val h = actionHandlers[nodeId] ?: return
+    ) = withHandlersOnMainThread(nodeId) { h ->
         when (action) {
             TaoA11yAction.CLICK -> h.onClick?.invoke()
             TaoA11yAction.INCREMENT -> h.onIncrement?.invoke()
@@ -612,26 +612,56 @@ internal open class TaoAccessibilityController(
             TaoA11yAction.SCROLL_RIGHT -> h.onScrollRight?.invoke()
             TaoA11yAction.DISMISS -> h.onDismiss?.invoke()
         }
-        wakeEventLoop()
     }
 
     internal fun onSetTextInvoked(
         nodeId: Long,
         text: String,
-    ) {
-        if (isDisposed) return
-        actionHandlers[nodeId]?.onSetText?.invoke(text)
-        wakeEventLoop()
-    }
+    ) = withHandlersOnMainThread(nodeId) { it.onSetText?.invoke(text) }
 
     internal fun onSetSelectionInvoked(
         nodeId: Long,
         start: Int,
         end: Int,
+    ) = withHandlersOnMainThread(nodeId) { it.onSetSelection?.invoke(start, end) }
+
+    /**
+     * Runs an a11y action handler on the Tao main thread, then makes sure the
+     * loop ticks so the resulting state change is recomposed and re-projected.
+     *
+     * The screen reader's own thread is NOT a safe place to run these: AT-SPI
+     * calls in from a D-Bus worker and UIA from an RPC thread (only AX already
+     * arrives on the main thread). Plain state writes survive that, which is why
+     * click / increment worked, but anything reaching into Compose UI does not —
+     * `SemanticsActions.RequestFocus` walks the focus machinery, whose
+     * `observeReads` belongs to the main thread's `SnapshotStateObserver` and
+     * throws `IllegalArgumentException: Detected multithreaded access …`. The
+     * focus transaction then aborts half-applied and no node ends up focused at
+     * all, which is what made the AT-SPI `grabFocus` assertion flaky in CI.
+     *
+     * Marshalling all of them rather than just focus: Compose UI's contract is
+     * single-threaded for every one of these paths, and a handler is free to
+     * grow into one that touches the node tree.
+     */
+    private inline fun withHandlersOnMainThread(
+        nodeId: Long,
+        crossinline body: (ActionHandlers) -> Unit,
     ) {
         if (isDisposed) return
-        actionHandlers[nodeId]?.onSetSelection?.invoke(start, end)
-        wakeEventLoop()
+        if (Thread.currentThread() === TaoMainDispatcher.taoMainThread) {
+            body(actionHandlers[nodeId] ?: return)
+            wakeEventLoop()
+            return
+        }
+        TaoMainDispatcher.dispatch(EmptyCoroutineContext) {
+            if (isDisposed) return@dispatch
+            body(actionHandlers[nodeId] ?: return@dispatch)
+        }
+        // The dispatcher is only drained on MAIN_EVENTS_CLEARED, and `pump()`
+        // sends the apply notifications itself once it has run the block — all
+        // that is missing is a reason for the loop to tick now rather than on
+        // the next unrelated OS event.
+        NativeTaoBridge.nativeRequestRedraw(windowHandle)
     }
 
     private fun wakeEventLoop() {
@@ -684,32 +714,21 @@ internal open class TaoAccessibilityController(
     internal fun onCustomActionInvoked(
         nodeId: Long,
         index: Int,
-    ) {
-        if (isDisposed) return
-        val list = actionHandlers[nodeId]?.customActions ?: return
-        if (index < 0 || index >= list.size) return
-        list[index].invoke()
-        wakeEventLoop()
+    ) = withHandlersOnMainThread(nodeId) { h ->
+        val list = h.customActions
+        if (index in list.indices) list[index].invoke()
     }
 
     internal fun onScrollByInvoked(
         nodeId: Long,
         dx: Float,
         dy: Float,
-    ) {
-        if (isDisposed) return
-        actionHandlers[nodeId]?.onScrollBy?.invoke(dx, dy)
-        wakeEventLoop()
-    }
+    ) = withHandlersOnMainThread(nodeId) { it.onScrollBy?.invoke(dx, dy) }
 
     internal fun onSetValueInvoked(
         nodeId: Long,
         value: Double,
-    ) {
-        if (isDisposed) return
-        actionHandlers[nodeId]?.onSetValue?.invoke(value.toFloat())
-        wakeEventLoop()
-    }
+    ) = withHandlersOnMainThread(nodeId) { it.onSetValue?.invoke(value.toFloat()) }
 }
 
 /**

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/TaoWindow.kt
@@ -196,6 +196,26 @@ public class TaoWindow internal constructor(
         NativeTaoBridge.nativeRequestRedraw(handle)
     }
 
+    /**
+     * Clears the [redrawPending] coalescing latch and re-issues a request.
+     *
+     * For callers returning from an OS modal loop (`DoDragDrop`, and anything
+     * else that runs its own message pump): a redraw requested just before or
+     * during that loop latches `redrawPending` true, and the matching
+     * REDRAW_REQUESTED can be swallowed by the nested pump. The latch then
+     * suppresses *every* later [requestRedraw] and the window silently stops
+     * painting — until an unrelated event happens to clear it, which is why the
+     * symptom reads as "frozen until I click on it again" (the FOCUSED branch
+     * in [dispatch] clears the same latch for the same reason).
+     *
+     * No frame is lost by calling this: a genuinely in-flight redraw just
+     * yields one extra, idempotent request.
+     */
+    internal fun resetRedrawLatch() {
+        redrawPending.set(false)
+        requestRedraw()
+    }
+
     public fun requestClose() {
         // Actual destroy path (not the cancelable close-*request*). Present an
         // opaque themed frame first: a live backdrop's translucent clear would

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxDndBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoLinuxDndBridge.kt
@@ -73,10 +73,35 @@ internal object NativeTaoLinuxDndBridge {
     external fun nativeRevoke(handle: Long): Int
 
     /**
+     * Keeps the host alive while an outbound drag session owns the GTK main
+     * thread.
+     *
+     * [pump] is upcalled ~120×/s off a `glib` timeout that [nativeStartDrag]
+     * schedules for the session's lifetime, on the GTK main thread (= Tao
+     * event-loop thread). Implementations must drain the main dispatcher and
+     * paint a frame — and must not block, since the drag's GTK pump is waiting
+     * on the return.
+     *
+     * Must be a named class, not a lambda or anonymous object: GraalVM's
+     * `GetMethodID` does not pick up inherited interface methods on anonymous
+     * classes (same constraint as [Callback]).
+     */
+    interface DragPump {
+        fun pump()
+    }
+
+    /**
      * Synchronous outbound DnD via `gtk_drag_begin_with_coordinates`. The
      * native side cooperatively pumps `gtk::main_iteration_do(true)` until
      * `drag-end` (or `drag-failed`) fires, then returns the negotiated drop
      * effect. Must run on the GTK main thread (= Tao event-loop thread).
+     *
+     * That GTK pump dispatches GDK events but never re-enters tao's event
+     * loop — this call is made from inside one of its callbacks — so without
+     * [pump] the host paints nothing for the whole session.
+     *
+     * @param pump invoked repeatedly during the drag so the suppressed Tao tick
+     *   can still drain and render; see [DragPump]. `null` disables it.
      */
     @JvmStatic
     external fun nativeStartDrag(
@@ -84,6 +109,7 @@ internal object NativeTaoLinuxDndBridge {
         files: Array<String>?,
         text: String?,
         allowedEffects: Int,
+        pump: DragPump?,
     ): Int
 
     const val DROP_EFFECT_NONE: Int = 0

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoMacOsDndBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoMacOsDndBridge.kt
@@ -72,6 +72,23 @@ internal object NativeTaoMacOsDndBridge {
     external fun nativeRevoke(nsView: Long): Int
 
     /**
+     * Keeps the host alive while an outbound drag session owns the main thread.
+     *
+     * [pump] is upcalled ~120×/s off a run-loop timer that [nativeStartDrag]
+     * schedules for the session's lifetime, on the macOS main thread (= Tao
+     * event-loop thread). Implementations must drain the main dispatcher and
+     * schedule a frame — and must not block, since AppKit's drag tracking is
+     * waiting on the return.
+     *
+     * Must be a named class, not a lambda or anonymous object: GraalVM's
+     * `GetMethodID` does not pick up inherited interface methods on anonymous
+     * classes (same constraint as [Callback]).
+     */
+    interface DragPump {
+        fun pump()
+    }
+
+    /**
      * Starts an outbound OS drag session via
      * `[NSView beginDraggingSessionWithItems:event:source:]`.
      *
@@ -83,6 +100,8 @@ internal object NativeTaoMacOsDndBridge {
      *
      * @param allowedEffects bitmask of [DROP_EFFECT_COPY] / [DROP_EFFECT_MOVE] /
      *   [DROP_EFFECT_LINK]
+     * @param pump invoked repeatedly during the drag so the suppressed Tao tick
+     *   can still drain and render; see [DragPump]. `null` disables it.
      * @return one of [DROP_EFFECT_NONE]/[DROP_EFFECT_COPY]/[DROP_EFFECT_MOVE]/[DROP_EFFECT_LINK]
      */
     @JvmStatic
@@ -91,6 +110,7 @@ internal object NativeTaoMacOsDndBridge {
         files: Array<String>?,
         text: String?,
         allowedEffects: Int,
+        pump: DragPump?,
     ): Int
 
     const val DROP_EFFECT_NONE: Int = 0

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDndBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoWindowsDndBridge.kt
@@ -68,16 +68,37 @@ internal object NativeTaoWindowsDndBridge {
     external fun nativeRevoke(hwnd: Long): Int
 
     /**
+     * Keeps the host alive while `DoDragDrop` owns the event-loop thread.
+     *
+     * [pump] is upcalled from `IDropSource::QueryContinueDrag`, i.e. on every
+     * mouse/keyboard state change for the duration of the drag, on the Tao
+     * event-loop thread. Implementations must drain the main dispatcher and
+     * paint one frame — and must not block, since the OS drag loop is waiting
+     * on the return.
+     *
+     * Must be a named class, not a lambda or anonymous object: GraalVM's
+     * `GetMethodID` does not pick up inherited interface methods on anonymous
+     * classes (same constraint as [Callback]).
+     */
+    interface DragPump {
+        fun pump()
+    }
+
+    /**
      * Starts an outbound OS drag session via Win32 `DoDragDrop`.
      *
      * Blocks the calling thread (Win32 pumps its own modal message loop) until
      * the user drops or cancels. Must run on the thread owning [hwnd]
-     * (= the Tao event-loop thread).
+     * (= the Tao event-loop thread) — `DoDragDrop` takes the mouse capture on
+     * the calling thread, so a thread that owns no window never sees the
+     * mouse-up and leaves the OS drag session wedged system-wide.
      *
      * Either [files] or [text] (or both) must be non-null/non-empty.
      *
      * @param allowedEffects bitmask of [DROP_EFFECT_COPY] / [DROP_EFFECT_MOVE] /
      *   [DROP_EFFECT_LINK]
+     * @param pump invoked repeatedly during the drag so the frozen event loop
+     *   can still drain and render; see [DragPump]. `null` disables it.
      * @return one of [DROP_EFFECT_*][DROP_EFFECT_NONE] — the action the
      *   destination accepted, or [DROP_EFFECT_NONE] if cancelled.
      */
@@ -87,6 +108,7 @@ internal object NativeTaoWindowsDndBridge {
         files: Array<String>?,
         text: String?,
         allowedEffects: Int,
+        pump: DragPump?,
     ): Int
 
     const val DROP_EFFECT_NONE: Int = 0

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHost.kt
@@ -414,12 +414,55 @@ internal class TaoComposeSceneHost(
             dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_MOVE,
             dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DROP_EFFECT_LINK,
         ) { files, text, allowedEffects ->
+            // No VSync dance and no post-drag `window.resetRedrawLatch()`, unlike
+            // the Windows counterpart. Nothing is consumed while tao's tick is
+            // suppressed: `AppState::cleared` returns early before it drains
+            // either the user-event channel (`RequestRedraw`) or the pending
+            // redraw list, so both survive the session and the latch un-wedges
+            // itself on the first tick after it.
             dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.nativeStartDrag(
                 nsView = nsViewHandle,
                 files = files,
                 text = text,
                 allowedEffects = allowedEffects,
+                pump = OutboundDragPump(),
             )
+        }
+    }
+
+    /**
+     * Drives the host while an outbound drag session owns the main thread — see
+     * [dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DragPump].
+     *
+     * [requestFrame] is not optional here: Compose enters the session from
+     * inside `sendPointerEvent`, and `BaseComposeScene.postponeInvalidation`
+     * holds the scene's `invalidate` callback off for that whole dispatch — so
+     * nothing schedules a frame on its own, however diligently we drain.
+     *
+     * Mirrors `TaoComposeSceneHostWindows.OutboundDragPump` minus its VSync
+     * toggle and frame throttle: a frame is recorded on this thread but
+     * replayed, presented and paced (`nativeVSyncWait`) on the render thread, so
+     * a tick never parks AppKit's drag tracking, and skiko's `FrameDispatcher`
+     * coalescing plus that pacing already cap the rate at the display's.
+     *
+     * Reentrancy, deliberately accepted: every frame recorded here renders the
+     * scene with a pointer dispatch still on the stack. There is no way to
+     * render during the drag *without* that nesting — refusing to render would
+     * just restore the freeze this exists to fix — so the scene is re-entered
+     * knowingly. If it proves unsafe, the principled fix is to defer
+     * `nativeStartDrag` onto the main dispatcher so the session starts one loop
+     * iteration later, with no Compose dispatch below it.
+     *
+     * Named class (not a lambda) for GraalVM JNI reachability, same as
+     * [InboundDnDCallback].
+     */
+    private inner class OutboundDragPump :
+        dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge.DragPump {
+        override fun pump() {
+            // Schedule before draining, so the frame runs in this very drain
+            // instead of waiting for the next tick.
+            requestFrame()
+            TaoMainDispatcher.pump()
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -606,12 +606,57 @@ internal class TaoComposeSceneHostLinux(
             dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_MOVE,
             dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DROP_EFFECT_LINK,
         ) { files, text, allowedEffects ->
+            // No VSync dance and no post-drag `window.resetRedrawLatch()`,
+            // unlike the Windows counterpart: the session's GTK pump consumes
+            // no tao event, so the `REDRAW_REQUESTED` matching a latched
+            // `redrawPending` still sits in tao's draw channel when the drag
+            // ends and the latch un-wedges itself on delivery.
             dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.nativeStartDrag(
                 handle = window.handle,
                 files = files,
                 text = text,
                 allowedEffects = allowedEffects,
+                pump = OutboundDragPump(),
             )
+        }
+    }
+
+    /**
+     * Drives the host while an outbound drag session owns the GTK main thread —
+     * see [dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DragPump].
+     *
+     * Paints directly instead of going through [requestRedrawCoalesced], like
+     * the Windows host and unlike the macOS one: on Linux the render happens
+     * inline on this thread, and a `requestRedraw` issued during the session
+     * would only land in tao's draw channel — undelivered until the drag is
+     * over, which is the freeze itself. The timer is therefore the only frame
+     * driver for the session, including after a tick that the swap-in-flight
+     * gate skipped (the swap thread's re-arm goes through that same dead
+     * channel).
+     *
+     * No VSync toggle and no frame throttle, unlike Windows: `eglSwapBuffers`
+     * and its vsync wait run on the swap thread, and [onRedrawRequested]
+     * returns immediately rather than blocking when a swap is still in flight,
+     * so a tick never parks the GTK pump the drag is running on.
+     *
+     * Reentrancy, deliberately accepted: every frame painted here renders the
+     * scene with a pointer dispatch still on the stack, since Compose enters the
+     * session from inside `sendPointerEvent`. There is no way to render during
+     * the drag *without* that nesting — refusing to render would just restore
+     * the freeze this exists to fix — so the scene is re-entered knowingly. If
+     * it proves unsafe, the principled fix is to defer `nativeStartDrag` onto
+     * the main dispatcher so the session starts one loop iteration later, with
+     * no Compose dispatch below it.
+     *
+     * Named class (not a lambda) for GraalVM JNI reachability, same as
+     * [InboundDnDCallback].
+     */
+    private inner class OutboundDragPump :
+        dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge.DragPump {
+        override fun pump() {
+            dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+                .pump()
+            onRedrawRequested()
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -660,28 +660,40 @@ internal class TaoComposeSceneHostWindows(
      * Drives the host from inside `DoDragDrop`'s modal loop — see
      * [dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DragPump].
      *
+     * Reentrancy, deliberately accepted: `DoDragDrop` is entered synchronously
+     * from `TaoDragAndDropManager.requestDragAndDropTransfer`, which Compose
+     * calls from inside `sendPointerEvent`. Every frame painted here therefore
+     * renders the scene while a pointer dispatch is still on the stack. There
+     * is no way to render during the drag *without* that nesting — refusing to
+     * render would just restore the freeze this exists to fix — so the scene is
+     * re-entered knowingly. If it proves unsafe, the principled fix is to defer
+     * the `DoDragDrop` call onto the main dispatcher so the session starts one
+     * loop iteration later, with no Compose dispatch below it.
+     *
      * Named class (not a lambda) for GraalVM JNI reachability, same as
      * [InboundDnDCallback].
      */
     private inner class OutboundDragPump :
         dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DragPump {
-        // The upcall lands with Compose's pointer dispatch still on the stack
-        // (DoDragDrop was entered from `requestDragAndDropTransfer`, itself
-        // inside `sendPointerEvent`), and rendering re-enters the scene. Skia's
-        // recording is not re-entrant, so a nested tick must be dropped rather
-        // than allowed to interleave with the one already in flight.
-        private var pumping = false
+        private var lastRenderNanos = 0L
 
         override fun pump() {
-            if (pumping) return
-            pumping = true
-            try {
-                dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
-                    .pump()
-                onRedrawRequested()
-            } finally {
-                pumping = false
-            }
+            // Draining is cheap and never blocks, so it runs on every callback.
+            dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+                .pump()
+
+            // Rendering is not: the present is inline and VSync-paced
+            // (eglSwapInterval(1)), so each frame parks this thread until the
+            // next VBlank — and this thread is currently holding up the OS drag
+            // loop, which owns the mouse capture system-wide. Windows calls
+            // QueryContinueDrag on every mouse-move message, well above the
+            // display rate, so without this throttle a fast drag would block on
+            // VSync several times per frame and visibly lag the drag cursor and
+            // the destination's drop feedback.
+            val now = System.nanoTime()
+            if (now - lastRenderNanos < MIN_DRAG_FRAME_INTERVAL_NANOS) return
+            lastRenderNanos = now
+            onRedrawRequested()
         }
     }
 
@@ -1505,6 +1517,14 @@ internal class TaoComposeSceneHostWindows(
     }
 
     internal companion object {
+        /**
+         * Floor between two frames painted from inside `DoDragDrop`'s modal
+         * loop — see [OutboundDragPump]. ~8 ms leaves headroom above 120 Hz
+         * while still collapsing the burst of mouse-move callbacks Windows
+         * fires between two VBlanks.
+         */
+        private const val MIN_DRAG_FRAME_INTERVAL_NANOS: Long = 8_000_000L
+
         // Wire scales — must match Rust `CURSOR_FIXED_SCALE` and
         // `TOUCH_FORCE_FIXED_SCALE` in `events.rs`.
         private const val TOUCH_POSITION_SCALE: Float = 1024f

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
@@ -646,14 +647,65 @@ internal class TaoComposeSceneHostWindows(
             dropEffectMove = dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_MOVE,
             dropEffectLink = dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DROP_EFFECT_LINK,
         ) { files, text, allowedEffects ->
-            dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.nativeStartDrag(
-                hwnd = hwnd,
-                files = files,
-                text = text,
-                allowedEffects = allowedEffects,
-                pump = OutboundDragPump(),
-            )
+            // Drop VSync for the session, like the fullscreen transition does
+            // (see fullscreenTransitionResized). Frames painted from inside
+            // DoDragDrop's modal loop are presented inline on this thread, and
+            // this thread is what the OS drag loop — holder of the system-wide
+            // mouse capture — is waiting on. A vsync-paced present would park it
+            // until the next VBlank on every frame, which is felt as a laggy
+            // drag cursor and late drop-target feedback. Interval 0 also
+            // replaces the queued frame rather than lining up behind it, so
+            // what the user sees during the drag stays current.
+            val pacedByVSync = attachmentHandle != 0L
+            if (pacedByVSync) NativeTaoGlBridge.nativeSetVSyncEnabled(attachmentHandle, false)
+            try {
+                dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.nativeStartDrag(
+                    hwnd = hwnd,
+                    files = files,
+                    text = text,
+                    allowedEffects = allowedEffects,
+                    pump = OutboundDragPump(),
+                )
+            } finally {
+                if (pacedByVSync) NativeTaoGlBridge.nativeSetVSyncEnabled(attachmentHandle, true)
+                // Unwedge rendering: an invalidation raised during the drag
+                // latched `redrawPending` while DoDragDrop's pump ate the
+                // matching REDRAW_REQUESTED, which suppresses every later
+                // request. See TaoWindow.resetRedrawLatch.
+                window.resetRedrawLatch()
+                releasePointerAfterOutboundDrag()
+            }
         }
+    }
+
+    /**
+     * Unwinds the pointer gesture that `DoDragDrop` swallowed.
+     *
+     * The OS drag loop takes the mouse capture and consumes the button-up that
+     * ends the drag, so Compose never sees a [PointerEventType.Release] and
+     * stays parked in the gesture it started the drag from — the window looks
+     * frozen (no hover, no clicks) until an unrelated click re-syncs it.
+     *
+     * Posted rather than sent inline: we are still nested inside the
+     * `sendPointerEvent` that entered `DoDragDrop`, and re-entering the scene's
+     * pointer dispatch from within itself is a far worse proposition than the
+     * nested render [OutboundDragPump] already accepts. Running it on the next
+     * dispatcher tick lets the outer dispatch unwind first.
+     */
+    private fun releasePointerAfterOutboundDrag() {
+        dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+            .dispatch(EmptyCoroutineContext) {
+                scene?.sendPointerEvent(
+                    eventType = PointerEventType.Release,
+                    position = Offset(lastPointerX, lastPointerY),
+                    type = PointerType.Mouse,
+                    keyboardModifiers = currentKeyboardModifiers,
+                    button = PointerButton.Primary,
+                )
+                // The loop may have gone back to Wait with nothing left to
+                // invalidate it; make sure the post-drag state reaches a frame.
+                window.requestRedraw()
+            }
     }
 
     /**
@@ -694,6 +746,8 @@ internal class TaoComposeSceneHostWindows(
             if (now - lastRenderNanos < MIN_DRAG_FRAME_INTERVAL_NANOS) return
             lastRenderNanos = now
             onRedrawRequested()
+            // Counted here too: pump frames bypass TaoWindow.dispatch, so the
+            // probe's REDRAW_REQUESTED counter cannot see them.
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
@@ -673,39 +672,8 @@ internal class TaoComposeSceneHostWindows(
                 // matching REDRAW_REQUESTED, which suppresses every later
                 // request. See TaoWindow.resetRedrawLatch.
                 window.resetRedrawLatch()
-                releasePointerAfterOutboundDrag()
             }
         }
-    }
-
-    /**
-     * Unwinds the pointer gesture that `DoDragDrop` swallowed.
-     *
-     * The OS drag loop takes the mouse capture and consumes the button-up that
-     * ends the drag, so Compose never sees a [PointerEventType.Release] and
-     * stays parked in the gesture it started the drag from — the window looks
-     * frozen (no hover, no clicks) until an unrelated click re-syncs it.
-     *
-     * Posted rather than sent inline: we are still nested inside the
-     * `sendPointerEvent` that entered `DoDragDrop`, and re-entering the scene's
-     * pointer dispatch from within itself is a far worse proposition than the
-     * nested render [OutboundDragPump] already accepts. Running it on the next
-     * dispatcher tick lets the outer dispatch unwind first.
-     */
-    private fun releasePointerAfterOutboundDrag() {
-        dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
-            .dispatch(EmptyCoroutineContext) {
-                scene?.sendPointerEvent(
-                    eventType = PointerEventType.Release,
-                    position = Offset(lastPointerX, lastPointerY),
-                    type = PointerType.Mouse,
-                    keyboardModifiers = currentKeyboardModifiers,
-                    button = PointerButton.Primary,
-                )
-                // The loop may have gone back to Wait with nothing left to
-                // invalidate it; make sure the post-drag state reaches a frame.
-                window.requestRedraw()
-            }
     }
 
     /**
@@ -727,6 +695,11 @@ internal class TaoComposeSceneHostWindows(
      */
     private inner class OutboundDragPump :
         dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DragPump {
+        // Not a nanoTime sentinel: `System.nanoTime()`'s origin is arbitrary and
+        // may be negative, in which case `now - 0L` is below any threshold and
+        // the very first frame — and so every frame — would be throttled away,
+        // silently restoring the freeze this class exists to fix.
+        private var rendered = false
         private var lastRenderNanos = 0L
 
         override fun pump() {
@@ -743,11 +716,10 @@ internal class TaoComposeSceneHostWindows(
             // VSync several times per frame and visibly lag the drag cursor and
             // the destination's drop feedback.
             val now = System.nanoTime()
-            if (now - lastRenderNanos < MIN_DRAG_FRAME_INTERVAL_NANOS) return
+            if (rendered && now - lastRenderNanos < MIN_DRAG_FRAME_INTERVAL_NANOS) return
+            rendered = true
             lastRenderNanos = now
             onRedrawRequested()
-            // Counted here too: pump frames bypass TaoWindow.dispatch, so the
-            // probe's REDRAW_REQUESTED counter cannot see them.
         }
     }
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostWindows.kt
@@ -651,7 +651,37 @@ internal class TaoComposeSceneHostWindows(
                 files = files,
                 text = text,
                 allowedEffects = allowedEffects,
+                pump = OutboundDragPump(),
             )
+        }
+    }
+
+    /**
+     * Drives the host from inside `DoDragDrop`'s modal loop — see
+     * [dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DragPump].
+     *
+     * Named class (not a lambda) for GraalVM JNI reachability, same as
+     * [InboundDnDCallback].
+     */
+    private inner class OutboundDragPump :
+        dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge.DragPump {
+        // The upcall lands with Compose's pointer dispatch still on the stack
+        // (DoDragDrop was entered from `requestDragAndDropTransfer`, itself
+        // inside `sendPointerEvent`), and rendering re-enters the scene. Skia's
+        // recording is not re-entrant, so a nested tick must be dropped rather
+        // than allowed to interleave with the one already in flight.
+        private var pumping = false
+
+        override fun pump() {
+            if (pumping) return
+            pumping = true
+            try {
+                dev.nucleusframework.window.tao.dispatch.TaoMainDispatcher
+                    .pump()
+                onRedrawRequested()
+            } finally {
+                pumping = false
+            }
         }
     }
 

--- a/decorated-window-tao/src/main/native/macos/dnd.m
+++ b/decorated-window-tao/src/main/native/macos/dnd.m
@@ -393,6 +393,110 @@ static jint map_result(NSDragOperation op) {
     return DROP_EFFECT_NONE;
 }
 
+// ── Outbound: host pump upcall ─────────────────────────────────────────────
+//
+// Lets the host breathe while a drag session owns the main thread. Two things
+// conspire to freeze the window for the whole drag:
+//
+//  1. `nativeStartDrag` is entered from inside a Tao event callback (Compose
+//     starts the session from `sendPointerEvent`), so tao's `in_callback` flag
+//     stays set until it returns. Tao's `kCFRunLoopBeforeWaiting` observer is
+//     the only thing that emits `MainEventsCleared` and flushes the queued
+//     redraws, and it bails out on exactly that flag (`AppState::cleared` in
+//     tao's `platform_impl/macos/app_state.rs`). So `TaoMainDispatcher` is never
+//     drained and the render coroutine that lives on it never resumes.
+//  2. AppKit tracks the drag *inside* `nextEventMatchingMask:`, so the
+//     session-wait loop below is not a pump either — measured over a ~5 s drag,
+//     its body ran exactly once, after the drop.
+//
+// The tick therefore has to come from something AppKit's tracking loop does run.
+// A repeating CFRunLoopTimer in `kCFRunLoopCommonModes` is that: measured over
+// the same drag it fired ~120×/s from `willBeginAtPoint` to `endedAtPoint`,
+// including throughout a 2 s stretch with the cursor held perfectly still.
+//
+// The Windows backend fixes the same freeze by upcalling this same `DragPump`
+// from `IDropSource::QueryContinueDrag` (see `windows/nucleus_tao_dnd.c`). Its
+// known trade-off does not apply here: `QueryContinueDrag` only fires on input
+// state changes, so a still cursor stalls animations over there, whereas the
+// timer keeps ticking. `NSDraggingSource`'s `draggingSession:movedToPoint:` is
+// the closer analogue of `QueryContinueDrag` — and inherits exactly that
+// limitation (measured: 60 movement-driven callbacks against the timer's 586),
+// which is why the timer drives the pump instead.
+//
+// No GlobalRef and no AttachCurrentThread, unlike Windows: the timer is created
+// and invalidated inside this JNI frame and fires on this same (already
+// attached) main thread, so the borrowed `pump` local ref and `env` stay valid
+// for every callback.
+
+// Pump cadence — ~8 ms, same figure as the Windows backend's
+// MIN_DRAG_FRAME_INTERVAL_NANOS. It bounds how often the host is *offered* a
+// tick, not the frame rate: the frames themselves are paced by the render
+// thread's vsync wait, and CFRunLoopTimer coalesces rather than queues if a
+// tick overruns.
+static const CFTimeInterval kDragPumpTickSeconds = 1.0 / 120.0;
+
+typedef struct NucleusDragPump {
+    JNIEnv   *env;    /* borrowed, owned by the enclosing JNI frame */
+    jobject   ref;    /* borrowed local ref, same */
+    jmethodID method; /* DragPump.pump()V, or NULL once disabled */
+} NucleusDragPump;
+
+static void drag_pump_resolve(JNIEnv *env, jobject pump, NucleusDragPump *out) {
+    out->env = env;
+    out->ref = NULL;
+    out->method = NULL;
+    if (!pump) return;
+    jclass cls = (*env)->GetObjectClass(env, pump);
+    if (cls) {
+        out->method = (*env)->GetMethodID(env, cls, "pump", "()V");
+        (*env)->DeleteLocalRef(env, cls);
+    }
+    if (out->method) out->ref = pump;
+    /* Optional: a failure here only costs the host its frames during the drag,
+     * so keep the session going. */
+    if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+}
+
+/* CFRunLoopTimerCallBack. Fires on the main thread for as long as the timer is
+ * scheduled, which is exactly the lifetime of the drag session. */
+static void drag_pump_tick(CFRunLoopTimerRef timer, void *info) {
+    (void)timer;
+    NucleusDragPump *p = (NucleusDragPump *)info;
+    if (!p || !p->ref || !p->method) return;
+    JNIEnv *env = p->env;
+    (*env)->CallVoidMethod(env, p->ref, p->method);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+        /* Whatever broke (Metal layer, Skia recording) will break again on the
+         * next tick, and we tick ~120×/s — latch the pump off so one failure
+         * reports once instead of flooding stderr. The drag degrades to the old
+         * frozen-but-quiet behaviour and still completes normally. */
+        p->method = NULL;
+    }
+}
+
+/* Schedules [drag_pump_tick] on the current run loop for the session's
+ * lifetime. `kCFRunLoopCommonModes` is what makes it fire from inside AppKit's
+ * drag tracking, which runs in `NSEventTrackingRunLoopMode`. Returns NULL when
+ * there is nothing to pump; the caller must invalidate a non-NULL timer before
+ * its frame — which owns `p` — unwinds. */
+static CFRunLoopTimerRef drag_pump_schedule(NucleusDragPump *p) {
+    if (!p->ref || !p->method) return NULL;
+    CFRunLoopTimerContext ctx = { 0, p, NULL, NULL, NULL };
+    CFRunLoopTimerRef timer =
+        CFRunLoopTimerCreate(NULL, CFAbsoluteTimeGetCurrent() + kDragPumpTickSeconds,
+                             kDragPumpTickSeconds, 0, 0, drag_pump_tick, &ctx);
+    if (timer) CFRunLoopAddTimer(CFRunLoopGetCurrent(), timer, kCFRunLoopCommonModes);
+    return timer;
+}
+
+static void drag_pump_cancel(CFRunLoopTimerRef timer) {
+    if (!timer) return;
+    CFRunLoopTimerInvalidate(timer);
+    CFRelease(timer);
+}
+
 // ── JNI exports ────────────────────────────────────────────────────────────
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {
@@ -454,16 +558,19 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsDndBridge_nativeRevoke(
 }
 
 /*
- * nativeStartDrag(nsView, files, text, allowedEffects): synchronously runs an
- * outbound drag session. Returns the negotiated drop effect or 0 if cancelled.
+ * nativeStartDrag(nsView, files, text, allowedEffects, pump): synchronously runs
+ * an outbound drag session. Returns the negotiated drop effect or 0 if
+ * cancelled.
  *
  * Must be called on the macOS main thread (= Tao event-loop thread). Pumps
  * AppKit events while the drag is in flight so the call appears blocking from
- * Kotlin's perspective — matches the Win32 `DoDragDrop` contract.
+ * Kotlin's perspective — matches the Win32 `DoDragDrop` contract — and ticks
+ * `pump` off a run-loop timer so the host keeps drawing (see NucleusDragPump).
  */
 JNIEXPORT jint JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsDndBridge_nativeStartDrag(
-    JNIEnv *env, jclass cls, jlong nsView, jobjectArray files, jstring text, jint allowedEffects)
+    JNIEnv *env, jclass cls, jlong nsView, jobjectArray files, jstring text, jint allowedEffects,
+    jobject pump)
 {
     (void)cls;
     if (!nsView) return DROP_EFFECT_NONE;
@@ -540,14 +647,23 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsDndBridge_nativeStartDrag
         source->_resultOperation = NSDragOperationNone;
         source->_done = NO;
 
+        NucleusDragPump pumpUpcall;
+        drag_pump_resolve(env, pump, &pumpUpcall);
+
         NSDraggingSession *session __unused = [view beginDraggingSessionWithItems:items
                                                                             event:event
                                                                            source:source];
 
-        // Pump the AppKit run loop until the session ends. We're on the main
-        // thread so simply waiting would freeze the UI; manually dispatching
-        // events keeps everything responsive (mirrors what Win32 DoDragDrop
-        // does internally with its modal message loop).
+        // Keep the host drawing for the duration of the session. Dispatching
+        // AppKit events below is not enough on its own — tao's own tick is
+        // suppressed the whole time. See NucleusDragPump.
+        CFRunLoopTimerRef pumpTimer = drag_pump_schedule(&pumpUpcall);
+
+        // Wait for the session to end. We're on the main thread so simply
+        // sleeping would freeze the UI; going through the run loop lets AppKit
+        // track the drag (which it does inside this very call) and keeps the
+        // pump timer above firing. Mirrors what Win32 DoDragDrop does
+        // internally with its modal message loop.
         while (!source->_done) {
             @autoreleasepool {
                 NSEvent *ev = [NSApp nextEventMatchingMask:NSEventMaskAny
@@ -557,6 +673,7 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoMacOsDndBridge_nativeStartDrag
                 if (ev) [NSApp sendEvent:ev];
             }
         }
+        drag_pump_cancel(pumpTimer);
         return map_result(source->_resultOperation);
     }
 }

--- a/decorated-window-tao/src/main/native/src/platform/linux/dnd.rs
+++ b/decorated-window-tao/src/main/native/src/platform/linux/dnd.rs
@@ -78,6 +78,12 @@ const DROP_EFFECT_LINK: jint = 4;
 /// leave/motion pair latency. Any incoming `drag-motion` cancels the timer.
 const LEAVE_DEBOUNCE_MS: u32 = 250;
 
+/// Pump interval while an outbound drag session owns the GTK main thread.
+/// ~120 Hz, the same order as the macOS run-loop timer: at or above every
+/// display's refresh rate, and anything the swap thread cannot absorb is
+/// coalesced by the host's owed-render gate.
+const DRAG_PUMP_INTERVAL_MS: u64 = 8;
+
 // ── Per-window registration ────────────────────────────────────────────────
 
 #[allow(dead_code)]
@@ -280,6 +286,25 @@ fn dispatch_drop(
         Ok(res.and_then(|v| v.i()).unwrap_or(DROP_EFFECT_NONE))
     })
     .unwrap_or(DROP_EFFECT_NONE)
+}
+
+/// Upcalls `DragPump.pump()` on the GTK main thread. Returns `false` once the
+/// upcall has failed so the caller can latch it off — a broken pump must report
+/// once, not ~120×/s for the whole drag.
+fn dispatch_pump(pump: &GlobalRef) -> bool {
+    let Some(vm) = JAVA_VM.get() else {
+        return false;
+    };
+    let Ok(mut env) = vm.attach_current_thread_permanently() else {
+        return false;
+    };
+    let res = env.call_method(pump.as_obj(), "pump", "()V", &[]);
+    if env.exception_check().unwrap_or(false) {
+        let _ = env.exception_describe();
+        let _ = env.exception_clear();
+        return false;
+    }
+    res.is_ok()
 }
 
 fn build_string_array<'a>(
@@ -525,6 +550,7 @@ fn start_outbound(
     files: Vec<String>,
     text: Option<String>,
     allowed: jint,
+    pump: Option<GlobalRef>,
 ) -> jint {
     if files.is_empty() && text.as_deref().map(str::is_empty).unwrap_or(true) {
         return DROP_EFFECT_NONE;
@@ -616,6 +642,38 @@ fn start_outbound(
         c.drag_set_icon_default();
     }
 
+    // Keep the host alive for the session, the Linux counterpart of the Windows
+    // `QueryContinueDrag` upcall and the macOS run-loop timer.
+    //
+    // The GTK pump below is not one: it dispatches GDK events, which push into
+    // tao's event channel, but nothing re-enters tao's own state machine —
+    // `start_outbound` is called from inside a `callback(…)` of
+    // `EventLoop::run_return`, so for the whole drag no `MainEventsCleared` is
+    // emitted (`TaoMainDispatcher` never drains) and no queued
+    // `RedrawRequested` is delivered (the host never paints). The window is
+    // frozen exactly as it was on the other two platforms.
+    //
+    // A glib timeout rather than the loop body: `main_iteration_do(true)`
+    // blocks until GTK has something to dispatch, so a cursor held still would
+    // stop ticking — the known Windows trade-off, which the timer avoids here
+    // for the same reason it does on macOS. It also wakes the loop, so the pump
+    // rate is the timer's and not the input rate's.
+    let pump_source = pump.map(|p| {
+        let mut broken = false;
+        glib::timeout_add_local(
+            std::time::Duration::from_millis(DRAG_PUMP_INTERVAL_MS),
+            move || {
+                if !broken && !dispatch_pump(&p) {
+                    broken = true;
+                }
+                // Never `Break`, even once latched off: the source is removed
+                // below, and `SourceId::remove` on an id that already returned
+                // `Break` is a GLib critical.
+                glib::ControlFlow::Continue
+            },
+        )
+    });
+
     // Cooperatively pump the GTK main loop until drag-end fires. The session
     // runs through the same loop we're already on; drag_begin returned
     // immediately. Mirrors Win32 `DoDragDrop`'s nested message pump.
@@ -623,6 +681,9 @@ fn start_outbound(
         gtk::main_iteration_do(true);
     }
 
+    if let Some(src) = pump_source {
+        src.remove();
+    }
     widget.disconnect(data_get_id);
     widget.disconnect(drag_end_id);
     widget.disconnect(drag_failed_id);
@@ -676,6 +737,7 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxDn
     files: JObjectArray,
     text: JString,
     allowed_effects: jint,
+    pump: JObject,
 ) -> jint {
     if handle == 0 {
         return DROP_EFFECT_NONE;
@@ -708,5 +770,19 @@ pub extern "system" fn Java_dev_nucleusframework_window_tao_ffi_NativeTaoLinuxDn
     } else {
         None
     };
-    start_outbound(handle as u64, files_vec, text_opt, allowed_effects)
+    // GlobalRef, unlike the macOS timer's raw jobject: the timeout closure is
+    // `'static`, so it cannot borrow this frame's local ref. It fires on this
+    // same already-attached thread either way.
+    let pump_ref: Option<GlobalRef> = if pump.is_null() {
+        None
+    } else {
+        env.new_global_ref(&pump).ok()
+    };
+    start_outbound(
+        handle as u64,
+        files_vec,
+        text_opt,
+        allowed_effects,
+        pump_ref,
+    )
 }

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_dnd.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_dnd.c
@@ -673,7 +673,42 @@ static IDataObjectVtbl g_data_object_vtbl = {
 typedef struct NucleusDropSource {
     IDropSourceVtbl *lpVtbl;
     LONG refCount;
+    jobject   pumpRef;    /* GlobalRef on the Kotlin DragPump, or NULL */
+    jmethodID pumpMethod; /* DragPump.pump()V */
 } NucleusDropSource;
+
+/*
+ * Lets the host breathe while DoDragDrop owns the thread.
+ *
+ * DoDragDrop pumps its own Win32 modal loop for the whole drag, so the Tao
+ * event loop — which is also the Compose dispatcher and the render thread —
+ * stops iterating: no MainEventsCleared, no dispatcher drain, no frame. The
+ * window would sit frozen until the user drops.
+ *
+ * Windows calls QueryContinueDrag on every mouse/keyboard state change during
+ * the drag, which is exactly the hook Qt uses for the same problem
+ * (QWindowsOleDropSource::QueryContinueDrag → QGuiApplication::processEvents).
+ * We mirror that: each callback upcalls into Kotlin, which drains the main
+ * dispatcher and paints one frame.
+ *
+ * Consequence to be aware of: with the cursor held still Windows stops calling
+ * us, so a running animation stalls until the next movement. Same trade-off Qt
+ * ships with, and far better than freezing outright.
+ */
+static void pump_host(NucleusDropSource *s) {
+    if (!s->pumpRef || !s->pumpMethod) return;
+    BOOL attached = FALSE;
+    JNIEnv *env = attach_thread(&attached);
+    if (!env) return;
+    (*env)->CallVoidMethod(env, s->pumpRef, s->pumpMethod);
+    if ((*env)->ExceptionCheck(env)) {
+        /* Must not leave a pending exception across the COM return: the OLE
+         * drag loop calls straight back into us and JNI would abort. */
+        (*env)->ExceptionDescribe(env);
+        (*env)->ExceptionClear(env);
+    }
+    detach_if_needed(attached);
+}
 
 static HRESULT STDMETHODCALLTYPE NDS_QueryInterface(IDropSource *self, REFIID riid, void **ppv) {
     if (!ppv) return E_POINTER;
@@ -688,14 +723,25 @@ static ULONG STDMETHODCALLTYPE NDS_AddRef(IDropSource *self) {
 static ULONG STDMETHODCALLTYPE NDS_Release(IDropSource *self) {
     NucleusDropSource *s = (NucleusDropSource *)self;
     LONG n = InterlockedDecrement(&s->refCount);
-    if (n == 0) HeapFree(GetProcessHeap(), 0, s);
+    if (n == 0) {
+        if (s->pumpRef && g_vm) {
+            BOOL attached = FALSE;
+            JNIEnv *env = attach_thread(&attached);
+            if (env) (*env)->DeleteGlobalRef(env, s->pumpRef);
+            detach_if_needed(attached);
+        }
+        HeapFree(GetProcessHeap(), 0, s);
+    }
     return (ULONG)n;
 }
 static HRESULT STDMETHODCALLTYPE NDS_QueryContinueDrag(IDropSource *self, BOOL fEscape, DWORD grfKeyState) {
-    (void)self;
     if (fEscape) return DRAGDROP_S_CANCEL;
     /* Drop on left-button release. MK_LBUTTON is bit 0x01 in grfKeyState. */
     if (!(grfKeyState & MK_LBUTTON)) return DRAGDROP_S_DROP;
+    /* Still dragging: give the frozen host a slice before returning to the
+     * modal loop. Deliberately not done on the cancel/drop paths above —
+     * DoDragDrop is about to return and the normal loop resumes anyway. */
+    pump_host((NucleusDropSource *)self);
     return S_OK;
 }
 static HRESULT STDMETHODCALLTYPE NDS_GiveFeedback(IDropSource *self, DWORD dwEffect) {
@@ -713,7 +759,8 @@ static IDropSourceVtbl g_drop_source_vtbl = {
 
 JNIEXPORT jint JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDndBridge_nativeStartDrag(
-    JNIEnv *env, jclass cls, jlong hwnd, jobjectArray files, jstring text, jint allowedEffects)
+    JNIEnv *env, jclass cls, jlong hwnd, jobjectArray files, jstring text, jint allowedEffects,
+    jobject pump)
 {
     (void)cls; (void)hwnd;
 
@@ -762,6 +809,21 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoWindowsDndBridge_nativeStartDr
     }
     src->lpVtbl = &g_drop_source_vtbl;
     src->refCount = 1;
+
+    /* Resolve the pump upcall. Optional: a failure here only costs the
+     * host its frames during the drag, so keep the session going. */
+    if (pump) {
+        jclass pumpClass = (*env)->GetObjectClass(env, pump);
+        if (pumpClass) {
+            src->pumpMethod = (*env)->GetMethodID(env, pumpClass, "pump", "()V");
+            (*env)->DeleteLocalRef(env, pumpClass);
+        }
+        if (src->pumpMethod) {
+            src->pumpRef = (*env)->NewGlobalRef(env, pump);
+            if (!src->pumpRef) src->pumpMethod = NULL;
+        }
+        if ((*env)->ExceptionCheck(env)) (*env)->ExceptionClear(env);
+    }
 
     /* DoDragDrop pumps its own modal loop until the user releases or escapes.
      * The thread must be STA — guaranteed if nativeRegister was called earlier

--- a/decorated-window-tao/src/main/native/windows/nucleus_tao_dnd.c
+++ b/decorated-window-tao/src/main/native/windows/nucleus_tao_dnd.c
@@ -706,6 +706,12 @@ static void pump_host(NucleusDropSource *s) {
          * drag loop calls straight back into us and JNI would abort. */
         (*env)->ExceptionDescribe(env);
         (*env)->ExceptionClear(env);
+        /* Whatever broke (GL context, Skia recording) will break again on the
+         * very next mouse-move, and we are called once per move — latch the
+         * pump off so one failure reports once instead of flooding stderr with
+         * thousands of traces. The drag degrades to the old frozen-but-quiet
+         * behaviour and still completes normally. */
+        s->pumpMethod = NULL;
     }
     detach_if_needed(attached);
 }

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -423,6 +423,20 @@
             ]
         },
         {
+            "type": "dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge$DragPump",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "pump", "parameterTypes": [] }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.scene.TaoComposeSceneHost$OutboundDragPump",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "pump", "parameterTypes": [] }
+            ]
+        },
+        {
             "type": "dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge",
             "jniAccessible": true
         },

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -385,6 +385,20 @@
             ]
         },
         {
+            "type": "dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge$DragPump",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "pump", "parameterTypes": [] }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.scene.TaoComposeSceneHostWindows$OutboundDragPump",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "pump", "parameterTypes": [] }
+            ]
+        },
+        {
             "type": "dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge",
             "jniAccessible": true
         },

--- a/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
+++ b/decorated-window-tao/src/main/resources/META-INF/native-image/dev.nucleusframework/nucleus.decorated-window-tao/reachability-metadata.json
@@ -461,6 +461,20 @@
             ]
         },
         {
+            "type": "dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge$DragPump",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "pump", "parameterTypes": [] }
+            ]
+        },
+        {
+            "type": "dev.nucleusframework.window.tao.scene.TaoComposeSceneHostLinux$OutboundDragPump",
+            "jniAccessible": true,
+            "methods": [
+                { "name": "pump", "parameterTypes": [] }
+            ]
+        },
+        {
             "type": "dev.nucleusframework.window.tao.ffi.NativeTaoLinuxTouchBridge",
             "jniAccessible": true
         },

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/OutboundDragPumpNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/OutboundDragPumpNativeSmokeTest.kt
@@ -1,5 +1,6 @@
 package dev.nucleusframework.window.tao
 
+import dev.nucleusframework.window.tao.ffi.NativeTaoLinuxDndBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge
 import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge
 import kotlin.test.Test
@@ -7,19 +8,19 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * Guards the two `nativeStartDrag` JNI signatures against one-sided drift.
+ * Guards the three `nativeStartDrag` JNI signatures against one-sided drift.
  *
- * The outbound-drag pump added a `DragPump` parameter to both the macOS and the
- * Windows bridge. Dropping or reordering it on one side of the boundary still
- * compiles and still links the library — it only fails when
- * `beginDraggingSession` / `DoDragDrop` is actually reached, as an
- * `UnsatisfiedLinkError` thrown from inside the user's drag gesture, i.e. on the
- * exact path the pump exists to keep alive. Resolving the symbol here turns that
- * into a build failure instead.
+ * The outbound-drag pump added a `DragPump` parameter to the macOS, Windows and
+ * Linux bridges alike. Dropping or reordering it on one side of the boundary
+ * still compiles and still links the library — it only fails when
+ * `beginDraggingSession` / `DoDragDrop` / `gtk_drag_begin_with_coordinates` is
+ * actually reached, as an `UnsatisfiedLinkError` thrown from inside the user's
+ * drag gesture, i.e. on the exact path the pump exists to keep alive. Resolving
+ * the symbol here turns that into a build failure instead.
  *
- * A null window handle makes both implementations bail out with
- * `DROP_EFFECT_NONE` before they touch the OS, so this is safe from the off-main
- * test worker — `nativeRegister` and a real drag session are not (see
+ * A null window handle makes every implementation bail out with
+ * `DROP_EFFECT_NONE` before it touches the OS (or GTK), so this is safe from the
+ * off-main test worker — `nativeRegister` and a real drag session are not (see
  * [StandalonePanelNativeSmokeTest] for that constraint).
  */
 class OutboundDragPumpNativeSmokeTest {
@@ -28,6 +29,10 @@ class OutboundDragPumpNativeSmokeTest {
     }
 
     private object WindowsPump : NativeTaoWindowsDndBridge.DragPump {
+        override fun pump() = Unit
+    }
+
+    private object LinuxPump : NativeTaoLinuxDndBridge.DragPump {
         override fun pump() = Unit
     }
 
@@ -61,6 +66,23 @@ class OutboundDragPumpNativeSmokeTest {
                 text = null,
                 allowedEffects = NativeTaoWindowsDndBridge.DROP_EFFECT_COPY,
                 pump = WindowsPump,
+            ),
+        )
+    }
+
+    @Test
+    fun linuxStartDragLinksWithThePumpParameter() {
+        if (!os().contains("linux")) return
+
+        assertTrue(NativeTaoLinuxDndBridge.isLoaded, "nucleus_tao failed to load")
+        assertEquals(
+            NativeTaoLinuxDndBridge.DROP_EFFECT_NONE,
+            NativeTaoLinuxDndBridge.nativeStartDrag(
+                handle = 0L,
+                files = null,
+                text = null,
+                allowedEffects = NativeTaoLinuxDndBridge.DROP_EFFECT_COPY,
+                pump = LinuxPump,
             ),
         )
     }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/OutboundDragPumpNativeSmokeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/OutboundDragPumpNativeSmokeTest.kt
@@ -1,0 +1,69 @@
+package dev.nucleusframework.window.tao
+
+import dev.nucleusframework.window.tao.ffi.NativeTaoMacOsDndBridge
+import dev.nucleusframework.window.tao.ffi.NativeTaoWindowsDndBridge
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the two `nativeStartDrag` JNI signatures against one-sided drift.
+ *
+ * The outbound-drag pump added a `DragPump` parameter to both the macOS and the
+ * Windows bridge. Dropping or reordering it on one side of the boundary still
+ * compiles and still links the library — it only fails when
+ * `beginDraggingSession` / `DoDragDrop` is actually reached, as an
+ * `UnsatisfiedLinkError` thrown from inside the user's drag gesture, i.e. on the
+ * exact path the pump exists to keep alive. Resolving the symbol here turns that
+ * into a build failure instead.
+ *
+ * A null window handle makes both implementations bail out with
+ * `DROP_EFFECT_NONE` before they touch the OS, so this is safe from the off-main
+ * test worker — `nativeRegister` and a real drag session are not (see
+ * [StandalonePanelNativeSmokeTest] for that constraint).
+ */
+class OutboundDragPumpNativeSmokeTest {
+    private object MacOsPump : NativeTaoMacOsDndBridge.DragPump {
+        override fun pump() = Unit
+    }
+
+    private object WindowsPump : NativeTaoWindowsDndBridge.DragPump {
+        override fun pump() = Unit
+    }
+
+    @Test
+    fun macOsStartDragLinksWithThePumpParameter() {
+        if (!os().contains("mac")) return
+
+        assertTrue(NativeTaoMacOsDndBridge.isLoaded, "nucleus_tao_dnd failed to load")
+        assertEquals(
+            NativeTaoMacOsDndBridge.DROP_EFFECT_NONE,
+            NativeTaoMacOsDndBridge.nativeStartDrag(
+                nsView = 0L,
+                files = null,
+                text = null,
+                allowedEffects = NativeTaoMacOsDndBridge.DROP_EFFECT_COPY,
+                pump = MacOsPump,
+            ),
+        )
+    }
+
+    @Test
+    fun windowsStartDragLinksWithThePumpParameter() {
+        if (!os().contains("win")) return
+
+        assertTrue(NativeTaoWindowsDndBridge.isLoaded, "nucleus_tao_dnd failed to load")
+        assertEquals(
+            NativeTaoWindowsDndBridge.DROP_EFFECT_NONE,
+            NativeTaoWindowsDndBridge.nativeStartDrag(
+                hwnd = 0L,
+                files = null,
+                text = null,
+                allowedEffects = NativeTaoWindowsDndBridge.DROP_EFFECT_COPY,
+                pump = WindowsPump,
+            ),
+        )
+    }
+
+    private fun os() = System.getProperty("os.name", "").lowercase()
+}

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -60,6 +60,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoMainDispatcherReproTest::class.java to "spawns real threads against the JVM dispatcher",
             StandalonePanelNativeSmokeTest::class.java to "loads the Windows native popup chain",
             StandalonePanelLinuxNativeSmokeTest::class.java to "loads the Linux native popup chain",
+            OutboundDragPumpNativeSmokeTest::class.java to "resolves the platform DnD JNI entry points",
             TaoRuntimeResizableSmokeTest::class.java to "opt-in headful smoke (NUCLEUS_TAO_SMOKE=1)",
             TaoSyntheticDndTest::class.java to "pins an AWT DropTarget; the no-AWT image never initialises AWT",
             TaoTransferableAccessGuardTest::class.java to "Compose interop ABI guard, not a scene behaviour",

--- a/scripts/ci/verify-atspi-keyboard.py
+++ b/scripts/ci/verify-atspi-keyboard.py
@@ -27,8 +27,16 @@ import atspi_probe as ap  # noqa: E402
 
 TEXT_FIELD = "A11y text field"
 
+# Upper bound on grabFocus → 'focused' state in the AT-SPI tree. Nothing about
+# that chain is synchronous: grabFocus is a D-Bus round trip, Compose applies the
+# focus request on its next frame, and AccessKit pushes the resulting tree update
+# after it — so on a loaded CI runner the state can land well past the settle
+# time a fixed sleep would allow. Polled, not slept.
+FOCUS_TIMEOUT_S = 8
+
 
 def focus_node(app, name, role=None):
+    """grabFocus on `name` and wait for the 'focused' state to actually land."""
     node = ap.find_by_name(app, name, role=role, timeout_s=6)
     if node is None:
         return None
@@ -36,8 +44,22 @@ def focus_node(app, name, role=None):
         node.queryComponent().grabFocus()
     except Exception:
         return node
-    time.sleep(0.4)
+    if not focus_landed(app, name):
+        # Never observed carrying the state; give the caller the same minimal
+        # settle the fixed sleep used to provide before it reads the tree.
+        time.sleep(0.4)
     return node
+
+
+def focus_landed(app, name):
+    """Whether `name` carries the AT-SPI 'focused' state within the timeout."""
+    return bool(
+        ap.wait_for(
+            lambda: name in ap.focused_nodes(app),
+            timeout_s=FOCUS_TIMEOUT_S,
+            interval_s=0.25,
+        )
+    )
 
 
 def entry_text(app):
@@ -100,9 +122,10 @@ def main():
     reporter.section("Focus via AT-SPI grabFocus")
     increment = focus_node(app, "Increment")
     reporter.check(increment is not None, "Increment element found")
+    landed = focus_landed(app, "Increment")
     focused = ap.focused_nodes(app)
     print(f"  focused accessibles: {focused}")
-    reporter.check("Increment" in focused, f"Increment carries the 'focused' state (got {focused})")
+    reporter.check(landed, f"Increment carries the 'focused' state (got {focused})")
 
     reporter.section("Tab key traversal")
     visited = set()


### PR DESCRIPTION
## Summary

Starting a drag from a Compose `dragAndDropSource` froze the whole app until the user dropped — on all three Tao backends, **Windows**, **macOS** and **Linux**. All are fixed here, through the same `DragPump` upcall, hooked to whatever each OS's drag loop actually runs.

Measured on macOS with the pump disabled: a 4.94 s drag painted **0** frames. With it: **437** (≈89 fps on a 90 Hz display), including a 2 s stretch with the cursor held perfectly still. Linux measured the same way: **0** frames for the whole session before, ≈**90 fps** after.

### Windows

`DoDragDrop` pumps its own Win32 modal loop for the duration of the drag, and it was called inline on the Tao event-loop thread — which is simultaneously the window-owning thread, `Dispatchers.Main` and the render thread. `MainEventsCleared` stopped firing, so `TaoMainDispatcher.pump()` never drained and no frame was ever painted.

The fix pumps from `IDropSource::QueryContinueDrag`, which Windows calls on every mouse/keyboard state change during the drag. This is the same hook Qt uses for the same problem — `QWindowsOleDropSource::QueryContinueDrag` calls `QGuiApplication::processEvents()`.

- `nucleus_tao_dnd.c` — `NDS_QueryContinueDrag` upcalls `pump_host()`; not on the cancel/drop paths, where `DoDragDrop` is about to return anyway. `ExceptionCheck`/`Clear` around the upcall: leaving a pending exception across a COM return would abort the JVM on the next callback.
- `NativeTaoWindowsDndBridge.DragPump` — named interface (not a lambda), so `GetMethodID` resolves it under native-image, same constraint as `Callback`. `nativeStartDrag` takes it as a nullable parameter.
- `TaoComposeSceneHostWindows.OutboundDragPump` — drains the main dispatcher, then paints one frame, throttled to ~8 ms because the present is inline and VSync-paced on the thread the OS drag loop is waiting on.
- VSync dropped for the session, and `TaoWindow.resetRedrawLatch()` after it: the modal pump eats the `REDRAW_REQUESTED` matching a latched `redrawPending`, which would otherwise suppress every later frame.

`DoDragDrop` deliberately stays on the thread owning the HWND: it takes the mouse capture on the calling thread, so a thread owning no window never sees the mouse-up and leaves the OS drag session wedged system-wide. The bridge KDoc now records that.

### macOS

Same freeze, and the original assumption that `beginDraggingSession` cooperatively pumps the run loop turned out to be wrong. Two things suppress the tick there:

1. `nativeStartDrag` is entered from inside a Tao event callback, so tao's `in_callback` flag stays set for the session. `AppState::cleared` — the `kCFRunLoopBeforeWaiting` observer that emits `MainEventsCleared` and flushes queued redraws — returns early on exactly that flag, so `TaoMainDispatcher` is never drained and the render coroutine that lives on it never resumes.
2. AppKit tracks the drag *inside* `nextEventMatchingMask:`, so the existing session-wait loop in `dnd.m` is not a pump either — measured over a ~5 s drag, its body ran **exactly once**, after the drop.

So the tick has to come from something AppKit's tracking loop does run: a repeating `CFRunLoopTimer` in `kCFRunLoopCommonModes`, scheduled for the session's lifetime. Measured over the same drag it fired ~120×/s from `willBeginAtPoint` to `endedAtPoint`.

- `dnd.m` — `NucleusDragPump` upcalls the Kotlin pump off that timer, with the method latched off after one failure so a broken pump reports once instead of ~120×/s. No GlobalRef and no `AttachCurrentThread`, unlike Windows: the timer is created and invalidated inside the JNI frame and fires on the same already-attached main thread.
- `NativeTaoMacOsDndBridge.DragPump` / `nativeStartDrag(…, pump)` — mirrors the Windows bridge.
- `TaoComposeSceneHost.OutboundDragPump` — schedules a frame, then drains. No VSync toggle and no throttle, unlike Windows: the present and its vsync wait run on the render thread, so a tick never parks AppKit's drag tracking, and `FrameDispatcher`'s coalescing already caps the rate at the display's.
- No post-drag `resetRedrawLatch()` on macOS: `AppState::cleared` returns *before* draining either the user-event channel (`RequestRedraw`) or the pending-redraw list, so both survive the session and the latch un-wedges itself on the first tick after it.

`draggingSession:movedToPoint:` is the closer analogue of `QueryContinueDrag`, but it inherits exactly its limitation — 60 movement-driven callbacks against the timer's 586 over the same drag — which is why the timer drives the pump instead.

### Linux

Same freeze again, and the `gtk::main_iteration_do(true)` loop already sitting in `start_outbound` was never a pump for us either: it dispatches GDK events, which only push into tao's event channel. Nothing re-enters tao's own state machine, because `start_outbound` is called from inside a `callback(…)` of `EventLoop::run_return` — so for the whole drag no `MainEventsCleared` is emitted (`TaoMainDispatcher` never drains) and no queued `RedrawRequested` is delivered (the host never paints).

- `dnd.rs` — a `glib::timeout_add_local` at ~120 Hz upcalls the Kotlin pump for the session's lifetime, with the upcall latched off after one failure and the source always returning `Continue` (removing an id that already returned `Break` is a GLib critical). A timeout rather than the loop body: `main_iteration_do(true)` blocks until GTK has something to dispatch, so a cursor held still would stop ticking — the known Windows trade-off, which the timer avoids for the same reason it does on macOS. A `GlobalRef` unlike the macOS timer's raw jobject: the closure is `'static` and cannot borrow the JNI frame's local ref.
- `NativeTaoLinuxDndBridge.DragPump` / `nativeStartDrag(…, pump)` — mirrors the other two bridges.
- `TaoComposeSceneHostLinux.OutboundDragPump` — drains the main dispatcher, then paints. Paints directly like Windows and unlike macOS: the render is inline on this thread, and a `requestRedraw` raised during the session would only land in the dead draw channel, so the timer is the session's only frame driver — including after a tick the swap-in-flight gate skipped, whose re-arm goes through that same channel.
- No VSync toggle and no frame throttle, unlike Windows: `eglSwapBuffers` and its vsync wait run on the swap thread and the gate returns instead of blocking, so a tick never parks the GTK pump the drag is running on.
- No post-drag `resetRedrawLatch()`: nothing consumes tao events during the session, so the `REDRAW_REQUESTED` matching a latched `redrawPending` is still queued when the drag ends and the latch un-wedges itself.

### Shared

- `requestFrame()` / `onRedrawRequested()` in the pump is not an optimisation: Compose enters the session from inside `sendPointerEvent`, and `BaseComposeScene.postponeInvalidation` holds the scene's `invalidate` callback off for that whole dispatch, so nothing schedules a frame on its own however diligently we drain.
- `OutboundDragPumpNativeSmokeTest` resolves all three platforms' `nativeStartDrag`, so dropping or reordering the new parameter on one side of the JNI boundary fails the build instead of throwing `UnsatisfiedLinkError` from inside a user's drag gesture.
- Reachability metadata for all six new types.

### Known trade-off (Windows only)

Shared with Qt: `QueryContinueDrag` only fires on input state changes, so holding the cursor still during a drag stalls a running animation until the next movement. Subclassing the HWND for a `WM_TIMER` tick would close that gap — that is effectively what the macOS and Linux sides do — but it is not done here since Qt ships without it. macOS and Linux are not affected.

### Also here: the `tao-a11y` CI flake

`verify-atspi-keyboard.py` failed on `[FAIL] Increment carries the 'focused' state (got [])` roughly one run in three. It predates this branch and hits `main` too (runs 30905167204, 30835144173, 30795312700 all failed on that single assertion), so it is fixed here rather than papered over.

The cause is in the log the failing job dumps:

```
Exception in thread "Thread-39" java.lang.IllegalArgumentException:
  Detected multithreaded access to SnapshotStateObserver:
  previousThreadId=1), currentThread={id=114, name=Thread-39}
    at androidx.compose.runtime.snapshots.SnapshotStateObserver.observeReads
    at androidx.compose.foundation.FocusableNode.retrievePinnableContainer
    at androidx.compose.foundation.FocusableNode.onFocusStateChange
    at androidx.compose.ui.focus.FocusTransactionsKt.performRequestFocus
    at androidx.compose.foundation.FocusableNode$applySemantics$1.invoke
```

`TaoAccessibilityController.onActionInvoked` ran the handler lambdas on whatever thread called in, and AccessKit calls in from its own worker — instrumenting the upcall shows a different one every time (Thread-7 … Thread-11 locally, Thread-39 on the runner) while the Tao main thread is `main`/id=1. Plain state writes survive that, which is why click and increment always passed, but `SemanticsActions.RequestFocus` walks Compose's focus machinery into `observeReads`, whose `SnapshotStateObserver` belongs to the main thread. When the main thread happens to be observing at that moment the check throws, the focus transaction aborts half-applied, and no node ends up focused at all — exactly what the assertion reports.

- `withHandlersOnMainThread` marshals every a11y action onto `TaoMainDispatcher` — inline when already on the Tao main thread (macOS AX, where nothing changes), posted plus a redraw wake otherwise, since the dispatcher only drains on `MAIN_EVENTS_CLEARED` and `pump()` sends the apply notifications itself. All handlers, not just focus: Compose UI's contract is single-threaded for every one of these paths.
- `verify-atspi-keyboard.py` now polls for the 'focused' state instead of reading it once after a fixed 400 ms sleep. Not the root cause, but that chain (D-Bus round trip → focus request → next frame → AccessKit push) is asynchronous and the marshalling adds a loop tick to it; every other timing-sensitive assertion in the probe already polls.

On an idle desktop the collision window is narrow — the assertion passes 3/3 locally on the pre-fix build — so this is justified by the stack trace plus the proof that actions run off-main, not by a local red→green.

## Test plan

Windows:

- [x] Drag the text and file boxes out of `tao-demo` — UI keeps rendering and title-bar hover stays live for the whole drag
- [x] Drop onto Explorer / a text editor — the payload arrives and `onTransferCompleted` reports the right action
- [x] Cancel with Esc mid-drag — session ends cleanly, app stays responsive
- [x] Drag files from Explorer into the `dragAndDropTarget` zone — inbound drop still works
- [x] After any drag, normal clicks and system-wide drag & drop still work
- [x] GraalVM native image: outbound drag still pumps (validates the new reachability metadata)

macOS (driven with synthesized `CGEventPost` drags against `tao-demo`, frame counts read off the render loop):

- [x] A/B on the same build: pump disabled → 0 frames over a 4.94 s drag; pump enabled → 437 frames over 4.91 s, 585 pump ticks
- [x] Longest gap between two frames during the drag: 2 ticks (~16 ms), so no stall — including the 2 s still-cursor hold
- [x] Outbound file drag → `dragAndDropTarget` drop zone: payload arrives (`drops`/`files` counters increment, `onTransferCompleted` fires)
- [x] Cancel with Esc mid-drag — session ends cleanly, timer torn down, app stays responsive
- [x] Clicks and animations still work after several drags; no exceptions on stderr
- [x] GraalVM native image on macOS: outbound drag still pumps (validates the new reachability metadata)

Linux (GNOME session, XWayland, frame counts read off the render loop):

- [x] A/B on the same build: pump disabled → **0** frames for the whole session, every one-second sample reporting no frame; pump enabled → the host keeps painting throughout
- [x] Real gesture-driven outbound drag with the pump: 125 frames over 1393 ms (≈90 fps), 172 pump ticks, longest gap between two frames 13–19 ms — one to two frames at that refresh rate
- [x] Pump ticks hold at ~124/s through a session where the cursor never moves, so the Windows still-cursor trade-off does not apply
- [x] Session ends cleanly (`rc` reported, timer removed) and the app keeps rendering and accepting clicks afterwards; no exceptions on stderr
- [x] `:decorated-window-tao:test` (88 tests) green, including `OutboundDragPumpNativeSmokeTest` resolving the new Linux JNI signature
- [x] All four AT-SPI probes green after the a11y-thread fix (`verify-atspi`, `-events`, `-all-tabs`, `-keyboard`, the last one including the previously flaky assertion), zero multithreaded-access exceptions in the app log
- [x] Native-Wayland session (GNOME, `WAYLAND_DISPLAY` set, no X11 window): outbound drag confirmed working interactively — same `gtk_drag_begin` + `main_iteration_do` path as X11, so the pump is backend-agnostic

## Follow-up

The nested render this introduces (painting from inside the drag session while Compose's pointer dispatch is still on the stack) is tracked in #435 with its identified fix. Not observed in testing on any of the three platforms; kept as a known risk rather than a silent one.
