### PR TITLE
feat(notification): implement platform notifications DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Each module is published independently to Maven Central — use them together or
 | `nucleus.decorated-window-jewel` | Jewel (IntelliJ theme) integration |
 | `nucleus.decorated-window-material2` | Material 2 integration |
 | `nucleus.decorated-window-material3` | Material 3 integration |
+| `nucleus.notification-common` | Cross-platform notification DSL with per-platform (`linux`/`macos`/`windows`) option blocks |
 | `nucleus.notification-macos` | macOS User Notifications |
 | `nucleus.notification-windows` | Windows Toast Notifications |
 | `nucleus.notification-linux` | Freedesktop Desktop Notifications |

--- a/examples/nucleus-demo/src/main/kotlin/com/example/demo/CommonNotificationsScreen.kt
+++ b/examples/nucleus-demo/src/main/kotlin/com/example/demo/CommonNotificationsScreen.kt
@@ -31,10 +31,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import dev.nucleusframework.notification.InterruptionLevel
 import dev.nucleusframework.notification.common.NotificationHandle
 import dev.nucleusframework.notification.common.NotificationManager
 import dev.nucleusframework.notification.common.NotificationResult
 import dev.nucleusframework.notification.common.notification
+import dev.nucleusframework.notification.linux.Urgency
+import dev.nucleusframework.notification.windows.ToastScenario
 
 private const val EVENT_LOG_MAX = 20
 
@@ -139,6 +142,52 @@ fun CommonNotificationsScreen() {
                         enabled = lastHandle != null,
                     ) {
                         Text("Dismiss Last")
+                    }
+                }
+            }
+
+            // -- Platform-specific options --
+            SectionCard("Platform-Specific Options") {
+                Text(
+                    text =
+                        "The common fields are shared across platforms. Behavior that differs per OS " +
+                            "(urgency, expiry, history) is set in linux { } / macos { } / windows { } blocks, " +
+                            "each honored only on that platform.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = {
+                        val result =
+                            notification(
+                                title = "Critical Alert",
+                                message = "Something needs your attention now",
+                            ) {
+                                linux { urgency = Urgency.CRITICAL; category = "device.error" }
+                                macos { interruptionLevel = InterruptionLevel.TIME_SENSITIVE }
+                                windows { scenario = ToastScenario.URGENT }
+                            }.send()
+                        logResult("Critical", result, events = events, onHandle = { lastHandle = it })
+                    }) {
+                        Text("Critical (all platforms)")
+                    }
+
+                    Button(onClick = {
+                        val result =
+                            notification(
+                                title = "Transient",
+                                message = "Shown but not kept in history (Linux)",
+                            ) {
+                                linux {
+                                    transient = true
+                                    category = "im.received"
+                                    expireTimeout = 3000
+                                }
+                            }.send()
+                        logResult("Transient", result, events = events, onHandle = { lastHandle = it })
+                    }) {
+                        Text("Linux: transient + 3s expire")
                     }
                 }
             }

--- a/examples/nucleus-demo/src/main/kotlin/com/example/demo/CommonNotificationsScreen.kt
+++ b/examples/nucleus-demo/src/main/kotlin/com/example/demo/CommonNotificationsScreen.kt
@@ -164,7 +164,10 @@ fun CommonNotificationsScreen() {
                                 title = "Critical Alert",
                                 message = "Something needs your attention now",
                             ) {
-                                linux { urgency = Urgency.CRITICAL; category = "device.error" }
+                                linux {
+                                    urgency = Urgency.CRITICAL
+                                    category = "device.error"
+                                }
                                 macos { interruptionLevel = InterruptionLevel.TIME_SENSITIVE }
                                 windows { scenario = ToastScenario.URGENT }
                             }.send()

--- a/notification-common/README.md
+++ b/notification-common/README.md
@@ -1,0 +1,130 @@
+# notification-common
+
+Cross-platform desktop notification API for JVM applications. Write one notification and it is
+delivered through the native backend of whichever OS the app is running on — Freedesktop
+Desktop Notifications on Linux, User Notifications on macOS, and Toast Notifications on Windows.
+
+The shared surface is deliberately limited to what behaves the same everywhere (title, body,
+image, action buttons, lifecycle callbacks). Behavior that genuinely differs between platforms —
+urgency, expiry, history, interruption level — is opted into through per-platform `linux { }` /
+`macos { }` / `windows { }` blocks, so the common abstraction never silently means different
+things on different systems.
+
+## Features
+
+- One `notification { }` DSL that dispatches to the native backend at runtime
+- Up to five action buttons, plus body-click / dismiss / failure callbacks
+- `NotificationResult` with a handle you can use to dismiss the notification later
+- Per-platform option blocks for platform-specific behavior, each a no-op off its OS
+- No platform `when` branching required — the correct backend is selected automatically
+
+## Setup
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation(project(":notification-common"))
+}
+```
+
+`notification-common` pulls in the `notification-linux`, `notification-windows`, and
+`notification-macos` backends. Only the one matching the host OS activates its native library at
+runtime; the others are inert.
+
+## Quick start
+
+```kotlin
+import dev.nucleusframework.notification.common.NotificationManager
+import dev.nucleusframework.notification.common.NotificationResult
+import dev.nucleusframework.notification.common.notification
+
+if (NotificationManager.isAvailable()) {
+    val result =
+        notification(
+            title = "Download complete",
+            message = "report.pdf has been saved",
+            onActivated = { openFile() },
+            onDismissed = { reason -> log("dismissed: $reason") },
+            onFailed = { log("failed to display") },
+        ) {
+            button("Open") { openFile() }
+            button("Show in Folder") { showInFolder() }
+        }.send()
+
+    when (result) {
+        is NotificationResult.Success -> lastHandle = result.handle // handle.dismiss() to close it
+        is NotificationResult.Failure -> log("not sent: ${result.reason}")
+    }
+}
+```
+
+Lifecycle callbacks are not guaranteed to run on a UI thread.
+
+## Platform-specific options
+
+Add a `linux { }`, `macos { }`, and/or `windows { }` block to configure behavior that only makes
+sense on that platform. Each block is applied **only** when the notification is delivered on that
+OS and ignored everywhere else, so a single call site can carry full-fidelity settings for all
+three platforms:
+
+```kotlin
+import dev.nucleusframework.notification.InterruptionLevel
+import dev.nucleusframework.notification.common.notification
+import dev.nucleusframework.notification.linux.Urgency
+import dev.nucleusframework.notification.windows.ToastDuration
+import dev.nucleusframework.notification.windows.ToastScenario
+
+notification(title = "Build failed", message = "Disk usage is above 95%") {
+    linux {
+        urgency = Urgency.CRITICAL      // shown prominently; on most servers breaks through DnD
+        category = "device.error"
+        transient = true                // don't keep it in the notification history
+        expireTimeout = 0               // 0 = never auto-expires (ms otherwise)
+    }
+    macos {
+        interruptionLevel = InterruptionLevel.TIME_SENSITIVE
+        relevanceScore = 0.9
+    }
+    windows {
+        scenario = ToastScenario.URGENT // Windows 11+: breaks through Focus Assist
+        duration = ToastDuration.LONG
+    }
+}.send()
+```
+
+### What each block supports
+
+| `linux { }` (`LinuxNotificationScope`) | Description |
+|---|---|
+| `urgency` | Freedesktop urgency: `LOW`, `NORMAL`, `CRITICAL` |
+| `category` | Type category, e.g. `"im.received"`, `"email.arrived"` |
+| `transient` | Bypass the notification log/history |
+| `resident` | Keep the notification after an action is invoked |
+| `expireTimeout` | Auto-dismiss (ms): `-1`/unset = server default, `0` = never, `>0` = explicit |
+
+| `macos { }` (`MacNotificationScope`) | Description |
+|---|---|
+| `interruptionLevel` | `PASSIVE` / `ACTIVE` / `TIME_SENSITIVE` / `CRITICAL` (the last two need an Apple entitlement; without it macOS falls back to `ACTIVE`) |
+| `relevanceScore` | `0.0..1.0`, used to sort the app's notifications |
+| `subtitle` | Line shown between the title and body |
+
+| `windows { }` (`WindowsNotificationScope`) | Description |
+|---|---|
+| `scenario` | `DEFAULT` / `REMINDER` / `ALARM` / `INCOMING_CALL` / `URGENT` (`URGENT` requires Windows 11) |
+| `duration` | `DEFAULT` / `SHORT` / `LONG` on-screen time |
+
+> **Why not a single common `urgency`?** The levels don't map cleanly: `CRITICAL` breaks through
+> Do Not Disturb on Linux and Windows, but on macOS that requires an entitlement most apps lack,
+> so it can only reach `timeSensitive` (which merely re-prioritizes). Rather than expose a shared
+> knob that behaves differently per OS, the divergent settings live in the platform blocks where
+> the semantics are unambiguous.
+
+## Backend modules
+
+| Module | Backend |
+|--------|---------|
+| `nucleus.notification-linux` | Freedesktop Desktop Notifications (D-Bus `org.freedesktop.Notifications`) |
+| `nucleus.notification-macos` | macOS User Notifications (`UNUserNotificationCenter`) |
+| `nucleus.notification-windows` | Windows Toast Notifications (WinRT) |
+
+Each backend can also be used directly for the full native API of a single platform.

--- a/notification-common/build.gradle.kts
+++ b/notification-common/build.gradle.kts
@@ -14,9 +14,11 @@ val publishVersion =
 
 dependencies {
     implementation(project(":core-runtime"))
-    implementation(project(":notification-linux"))
-    implementation(project(":notification-windows"))
-    implementation(project(":notification-macos"))
+    // api (not implementation): the per-platform DSL blocks expose these modules' public types
+    // (Urgency, InterruptionLevel, ToastScenario, ...) so consumers can name them.
+    api(project(":notification-linux"))
+    api(project(":notification-windows"))
+    api(project(":notification-macos"))
     implementation(project(":freedesktop-icons"))
     testImplementation(kotlin("test"))
 }

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/Notification.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/Notification.kt
@@ -17,6 +17,9 @@ class Notification internal constructor(
     val onActivated: (() -> Unit)?,
     val onDismissed: ((DismissReason) -> Unit)?,
     val onFailed: (() -> Unit)?,
+    internal val linux: LinuxNotificationScope?,
+    internal val macos: MacNotificationScope?,
+    internal val windows: WindowsNotificationScope?,
 ) {
     /** Sends this notification to the OS notification system. */
     fun send(): NotificationResult = NotificationManager.send(this)
@@ -32,10 +35,20 @@ data class NotificationButton internal constructor(
 @DslMarker
 annotation class NotificationDsl
 
-/** Builder for notification action buttons. */
+/**
+ * Builder for a cross-platform notification.
+ *
+ * Add up to [MAX_BUTTONS] action [button]s, and optionally attach platform-specific behavior
+ * via the [linux], [macos], and [windows] blocks. Each platform block is applied only when the
+ * notification is delivered on that OS — the semantics that differ between platforms (urgency,
+ * expiry, history, etc.) live there rather than in a lossy shared abstraction.
+ */
 @NotificationDsl
-class NotificationButtonBuilder internal constructor() {
+class NotificationBuilder internal constructor() {
     internal val buttons = mutableListOf<NotificationButton>()
+    internal var linuxScope: LinuxNotificationScope? = null
+    internal var macScope: MacNotificationScope? = null
+    internal var windowsScope: WindowsNotificationScope? = null
 
     /** Adds a button with the given [title] and [onClick] handler. Max $MAX_BUTTONS buttons. */
     fun button(
@@ -45,7 +58,26 @@ class NotificationButtonBuilder internal constructor() {
         require(buttons.size < MAX_BUTTONS) { "Maximum $MAX_BUTTONS buttons allowed" }
         buttons.add(NotificationButton(title, onClick))
     }
+
+    /** Configures Linux-specific options (see [LinuxNotificationScope]); a no-op on other platforms. */
+    fun linux(block: LinuxNotificationScope.() -> Unit) {
+        linuxScope = (linuxScope ?: LinuxNotificationScope()).apply(block)
+    }
+
+    /** Configures macOS-specific options (see [MacNotificationScope]); a no-op on other platforms. */
+    fun macos(block: MacNotificationScope.() -> Unit) {
+        macScope = (macScope ?: MacNotificationScope()).apply(block)
+    }
+
+    /** Configures Windows-specific options (see [WindowsNotificationScope]); a no-op on other platforms. */
+    fun windows(block: WindowsNotificationScope.() -> Unit) {
+        windowsScope = (windowsScope ?: WindowsNotificationScope()).apply(block)
+    }
 }
+
+/** Former name of [NotificationBuilder], kept for source compatibility. */
+@Deprecated("Renamed to NotificationBuilder", ReplaceWith("NotificationBuilder"))
+typealias NotificationButtonBuilder = NotificationBuilder
 
 /**
  * Creates a cross-platform notification.
@@ -60,6 +92,11 @@ class NotificationButtonBuilder internal constructor() {
  * ) {
  *     button("Open") { openFile() }
  *     button("Show in Folder") { showInFolder() }
+ *
+ *     // Platform-specific behavior, honored only on the matching OS:
+ *     linux { urgency = Urgency.CRITICAL; transient = true; category = "device.error" }
+ *     macos { interruptionLevel = InterruptionLevel.TIME_SENSITIVE }
+ *     windows { scenario = ToastScenario.URGENT }
  * }
  * n.send()
  * ```
@@ -71,7 +108,7 @@ class NotificationButtonBuilder internal constructor() {
  * @param onActivated Called when the user clicks the notification body.
  * @param onDismissed Called when the notification is dismissed, with the [DismissReason].
  * @param onFailed Called if the notification fails to display.
- * @param buttons Optional DSL block to add up to 5 action buttons.
+ * @param block Optional DSL block to add action buttons and per-platform options.
  */
 fun notification(
     title: String,
@@ -81,13 +118,20 @@ fun notification(
     onActivated: (() -> Unit)? = null,
     onDismissed: ((DismissReason) -> Unit)? = null,
     onFailed: (() -> Unit)? = null,
-    buttons: (NotificationButtonBuilder.() -> Unit)? = null,
+    block: (NotificationBuilder.() -> Unit)? = null,
 ): Notification {
-    val buttonList =
-        if (buttons != null) {
-            NotificationButtonBuilder().apply(buttons).buttons.toList()
-        } else {
-            emptyList()
-        }
-    return Notification(title, message, largeImage, smallIcon, buttonList, onActivated, onDismissed, onFailed)
+    val builder = block?.let { NotificationBuilder().apply(it) }
+    return Notification(
+        title = title,
+        message = message,
+        largeImage = largeImage,
+        smallIcon = smallIcon,
+        buttons = builder?.buttons?.toList() ?: emptyList(),
+        onActivated = onActivated,
+        onDismissed = onDismissed,
+        onFailed = onFailed,
+        linux = builder?.linuxScope,
+        macos = builder?.macScope,
+        windows = builder?.windowsScope,
+    )
 }

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/PlatformScopes.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/PlatformScopes.kt
@@ -1,0 +1,62 @@
+package dev.nucleusframework.notification.common
+
+import dev.nucleusframework.notification.InterruptionLevel
+import dev.nucleusframework.notification.linux.Urgency
+import dev.nucleusframework.notification.windows.ToastDuration
+import dev.nucleusframework.notification.windows.ToastScenario
+
+/**
+ * Linux-specific notification options, configured via the `linux { }` block of the
+ * [notification] DSL. These are applied only when the notification is delivered on Linux;
+ * on any other platform the block is ignored.
+ *
+ * The cross-platform [notification] fields (title, message, image, buttons, callbacks) are
+ * always used as the base — these options only add Linux-specific behavior on top.
+ *
+ * @property urgency freedesktop urgency hint. `CRITICAL` is shown prominently and, on most
+ *   servers, breaks through Do Not Disturb and never auto-expires.
+ * @property category Notification type category, e.g. `"email.arrived"` or `"im.received"`.
+ * @property transient If `true`, the notification bypasses the notification log/history.
+ * @property resident If `true`, the notification is not removed when one of its actions is invoked.
+ * @property expireTimeout Auto-dismiss timeout in milliseconds: `null`/`-1` = server default,
+ *   `0` = never expires, positive = auto-close after that many milliseconds.
+ */
+@NotificationDsl
+class LinuxNotificationScope internal constructor() {
+    var urgency: Urgency? = null
+    var category: String? = null
+    var transient: Boolean? = null
+    var resident: Boolean? = null
+    var expireTimeout: Int? = null
+}
+
+/**
+ * macOS-specific notification options, configured via the `macos { }` block of the
+ * [notification] DSL. Applied only when the notification is delivered on macOS.
+ *
+ * @property interruptionLevel `UNNotificationInterruptionLevel` (macOS 12+). `TIME_SENSITIVE`
+ *   and `CRITICAL` require the corresponding Apple entitlement; without it the system falls
+ *   back to `ACTIVE`.
+ * @property relevanceScore Score in `0.0..1.0` used to sort the app's notifications in a group.
+ * @property subtitle Subtitle shown between the title and the body.
+ */
+@NotificationDsl
+class MacNotificationScope internal constructor() {
+    var interruptionLevel: InterruptionLevel? = null
+    var relevanceScore: Double? = null
+    var subtitle: String? = null
+}
+
+/**
+ * Windows-specific notification options, configured via the `windows { }` block of the
+ * [notification] DSL. Applied only when the notification is delivered on Windows.
+ *
+ * @property scenario Toast scenario. `URGENT` (Windows 11+) breaks through Focus Assist;
+ *   `REMINDER`/`ALARM` keep the toast on screen until dismissed.
+ * @property duration How long the toast stays on screen before moving to the Action Center.
+ */
+@NotificationDsl
+class WindowsNotificationScope internal constructor() {
+    var scenario: ToastScenario? = null
+    var duration: ToastDuration? = null
+}

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/LinuxDispatcher.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/LinuxDispatcher.kt
@@ -89,9 +89,14 @@ internal class LinuxDispatcher private constructor() : PlatformDispatcher {
             buttonCallbacks[key] = button.onClick
         }
 
+        val opts = notification.linux
         val hints =
             NotificationHints(
+                urgency = opts?.urgency,
+                category = opts?.category,
                 imagePath = notification.largeImage?.let { FreedesktopIcon.Custom(it) },
+                resident = opts?.resident,
+                transient = opts?.transient,
             )
 
         val linuxNotification =
@@ -101,6 +106,7 @@ internal class LinuxDispatcher private constructor() : PlatformDispatcher {
                 appIcon = notification.smallIcon?.let { FreedesktopIcon.Custom(it) },
                 actions = actions,
                 hints = hints,
+                expireTimeout = opts?.expireTimeout ?: SERVER_DEFAULT_EXPIRE_TIMEOUT,
             )
 
         val id = LinuxNotificationCenter.notify(linuxNotification)
@@ -139,6 +145,9 @@ internal class LinuxDispatcher private constructor() : PlatformDispatcher {
         }
     }
 }
+
+/** freedesktop `expire_timeout` sentinel meaning "let the server decide". */
+private const val SERVER_DEFAULT_EXPIRE_TIMEOUT = -1
 
 private fun CloseReason.toCommon(): DismissReason =
     when (this) {

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/MacOsDispatcher.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/MacOsDispatcher.kt
@@ -3,6 +3,7 @@ package dev.nucleusframework.notification.common.internal
 import dev.nucleusframework.notification.ActionOption
 import dev.nucleusframework.notification.CategoryOption
 import dev.nucleusframework.notification.DeliveredNotification
+import dev.nucleusframework.notification.InterruptionLevel
 import dev.nucleusframework.notification.NotificationAction
 import dev.nucleusframework.notification.NotificationAttachment
 import dev.nucleusframework.notification.NotificationCategory
@@ -104,12 +105,16 @@ internal class MacOsDispatcher private constructor() : PlatformDispatcher {
                 emptyList()
             }
 
+        val opts = notification.macos
         val content =
             NotificationContent(
                 title = notification.title,
+                subtitle = opts?.subtitle ?: "",
                 body = notification.message,
                 categoryIdentifier = categoryId,
                 attachments = attachments,
+                interruptionLevel = opts?.interruptionLevel ?: InterruptionLevel.ACTIVE,
+                relevanceScore = opts?.relevanceScore ?: 0.0,
             )
 
         val request =

--- a/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/WindowsDispatcher.kt
+++ b/notification-common/src/main/kotlin/dev/nucleusframework/notification/common/internal/WindowsDispatcher.kt
@@ -111,8 +111,12 @@ internal class WindowsDispatcher private constructor() : PlatformDispatcher {
         val tag = generateTag()
         val platformId = toPlatformId(tag, GROUP)
 
+        val opts = notification.windows
         val toastContent =
             toast {
+                opts?.scenario?.let { scenario = it }
+                opts?.duration?.let { duration = it }
+
                 visual {
                     text(notification.title)
                     if (notification.message.isNotEmpty()) {

--- a/notification-common/src/test/kotlin/dev/nucleusframework/notification/common/NotificationDslTest.kt
+++ b/notification-common/src/test/kotlin/dev/nucleusframework/notification/common/NotificationDslTest.kt
@@ -1,0 +1,89 @@
+package dev.nucleusframework.notification.common
+
+import dev.nucleusframework.notification.InterruptionLevel
+import dev.nucleusframework.notification.linux.Urgency
+import dev.nucleusframework.notification.windows.ToastDuration
+import dev.nucleusframework.notification.windows.ToastScenario
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NotificationDslTest {
+    @Test
+    fun `no block leaves all platform scopes unset`() {
+        val n = notification(title = "Hi", message = "there")
+
+        assertEquals("Hi", n.title)
+        assertNull(n.linux)
+        assertNull(n.macos)
+        assertNull(n.windows)
+    }
+
+    @Test
+    fun `buttons DSL still works (backward compatible)`() {
+        val n =
+            notification(title = "Choose") {
+                button("Yes") {}
+                button("No") {}
+            }
+
+        assertEquals(listOf("Yes", "No"), n.buttons.map { it.title })
+        assertNull(n.linux)
+    }
+
+    @Test
+    fun `platform blocks populate only their own scope`() {
+        val n =
+            notification(title = "Build failed", message = "see logs") {
+                button("Open") {}
+                linux {
+                    urgency = Urgency.CRITICAL
+                    transient = true
+                    resident = true
+                    category = "device.error"
+                    expireTimeout = 0
+                }
+                macos {
+                    interruptionLevel = InterruptionLevel.TIME_SENSITIVE
+                    relevanceScore = 0.9
+                    subtitle = "CI"
+                }
+                windows {
+                    scenario = ToastScenario.URGENT
+                    duration = ToastDuration.LONG
+                }
+            }
+
+        assertEquals(1, n.buttons.size)
+
+        val linux = requireNotNull(n.linux)
+        assertEquals(Urgency.CRITICAL, linux.urgency)
+        assertEquals(true, linux.transient)
+        assertEquals(true, linux.resident)
+        assertEquals("device.error", linux.category)
+        assertEquals(0, linux.expireTimeout)
+
+        val macos = requireNotNull(n.macos)
+        assertEquals(InterruptionLevel.TIME_SENSITIVE, macos.interruptionLevel)
+        assertEquals(0.9, macos.relevanceScore)
+        assertEquals("CI", macos.subtitle)
+
+        val windows = requireNotNull(n.windows)
+        assertEquals(ToastScenario.URGENT, windows.scenario)
+        assertEquals(ToastDuration.LONG, windows.duration)
+    }
+
+    @Test
+    fun `repeated platform block merges into the same scope`() {
+        val n =
+            notification(title = "x") {
+                linux { urgency = Urgency.LOW }
+                linux { transient = true }
+            }
+
+        val linux = requireNotNull(n.linux)
+        assertEquals(Urgency.LOW, linux.urgency)
+        assertTrue(linux.transient == true)
+    }
+}

--- a/notification-windows/build.gradle.kts
+++ b/notification-windows/build.gradle.kts
@@ -15,6 +15,7 @@ val publishVersion =
 
 dependencies {
     implementation(project(":core-runtime"))
+    testImplementation(kotlin("test"))
 }
 
 java {

--- a/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/Enums.kt
+++ b/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/Enums.kt
@@ -46,6 +46,27 @@ enum class ToastScenario(
 
     /** Pre-expanded in special call format, audio loops with ringtone. */
     INCOMING_CALL("incomingCall"),
+
+    /**
+     * High-priority toast that can break through Focus Assist / Do Not Disturb.
+     *
+     * Requires Windows 11 (build 22000+); ignored on older versions.
+     */
+    URGENT("urgent"),
+}
+
+/** How long a toast stays on screen before moving to the Action Center. */
+enum class ToastDuration(
+    val xmlValue: String,
+) {
+    /** System default (roughly 7 seconds). */
+    DEFAULT(""),
+
+    /** Short duration (roughly 7 seconds). */
+    SHORT("short"),
+
+    /** Long duration (roughly 25 seconds). */
+    LONG("long"),
 }
 
 // -- Dismissal --

--- a/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/Model.kt
+++ b/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/Model.kt
@@ -18,6 +18,7 @@ package dev.nucleusframework.notification.windows
  * @param launch App-defined launch arguments when the toast body is clicked.
  * @param activationType How the app is activated on click.
  * @param scenario Pre-defined display/audio behavior.
+ * @param duration How long the toast stays on screen before moving to the Action Center.
  * @param displayTimestamp Custom timestamp override (ISO 8601 string).
  */
 data class ToastContent(
@@ -28,6 +29,7 @@ data class ToastContent(
     val launch: String = "",
     val activationType: ActivationType = ActivationType.FOREGROUND,
     val scenario: ToastScenario = ToastScenario.DEFAULT,
+    val duration: ToastDuration = ToastDuration.DEFAULT,
     val displayTimestamp: String? = null,
 )
 

--- a/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/ToastContentDsl.kt
+++ b/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/ToastContentDsl.kt
@@ -60,6 +60,7 @@ class ToastContentBuilder {
     var launch: String = ""
     var activationType: ActivationType = ActivationType.FOREGROUND
     var scenario: ToastScenario = ToastScenario.DEFAULT
+    var duration: ToastDuration = ToastDuration.DEFAULT
     var displayTimestamp: String? = null
 
     private var visual: ToastVisual? = null
@@ -107,6 +108,7 @@ class ToastContentBuilder {
             launch = launch,
             activationType = activationType,
             scenario = scenario,
+            duration = duration,
             displayTimestamp = displayTimestamp,
         )
     }

--- a/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/ToastXmlBuilder.kt
+++ b/notification-windows/src/main/kotlin/dev/nucleusframework/notification/windows/ToastXmlBuilder.kt
@@ -18,6 +18,9 @@ internal object ToastXmlBuilder {
         if (toast.scenario != ToastScenario.DEFAULT) {
             sb.attr("scenario", toast.scenario.xmlValue)
         }
+        if (toast.duration != ToastDuration.DEFAULT) {
+            sb.attr("duration", toast.duration.xmlValue)
+        }
         toast.displayTimestamp?.let { sb.attr("displayTimestamp", it) }
         sb.append(">")
 

--- a/notification-windows/src/test/kotlin/dev/nucleusframework/notification/windows/ToastXmlBuilderTest.kt
+++ b/notification-windows/src/test/kotlin/dev/nucleusframework/notification/windows/ToastXmlBuilderTest.kt
@@ -1,0 +1,37 @@
+package dev.nucleusframework.notification.windows
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ToastXmlBuilderTest {
+    private fun xmlOf(
+        scenario: ToastScenario = ToastScenario.DEFAULT,
+        duration: ToastDuration = ToastDuration.DEFAULT,
+    ): String =
+        ToastXmlBuilder.buildXml(
+            toast {
+                this.scenario = scenario
+                this.duration = duration
+                visual { text("Title") }
+            },
+        )
+
+    @Test
+    fun `omits scenario and duration attributes by default`() {
+        val xml = xmlOf()
+        assertFalse(xml.contains("scenario="), xml)
+        assertFalse(xml.contains("duration="), xml)
+    }
+
+    @Test
+    fun `emits urgent scenario`() {
+        assertTrue(xmlOf(scenario = ToastScenario.URGENT).contains("scenario=\"urgent\""))
+    }
+
+    @Test
+    fun `emits short and long duration`() {
+        assertTrue(xmlOf(duration = ToastDuration.SHORT).contains("duration=\"short\""))
+        assertTrue(xmlOf(duration = ToastDuration.LONG).contains("duration=\"long\""))
+    }
+}


### PR DESCRIPTION
## 🚀 Description

Adds first-class **per-platform option blocks** to the cross-platform notification DSL. The common `notification { }` builder now accepts `linux { }`, `macos { }`, and `windows { }` blocks, each applied only when the notification is delivered on that OS:

```kotlin
notification(title = "Build failed", message = "see logs") {
    button("Open") { openLogs() }

    // Behavior that differs per OS lives where the semantics are unambiguous:
    linux   { urgency = Urgency.CRITICAL; transient = true; category = "device.error" }
    macos   { interruptionLevel = InterruptionLevel.TIME_SENSITIVE; relevanceScore = 0.9 }
    windows { scenario = ToastScenario.URGENT; duration = ToastDuration.LONG }
}
```

The common fields (title, message, image, buttons, callbacks) remain the shared, genuinely-uniform base; anything whose behavior diverges between platforms is set in the matching block and is a no-op elsewhere.

Highlights:
- New `LinuxNotificationScope` / `MacNotificationScope` / `WindowsNotificationScope`, typed with the existing platform enums.
- `notification-common`'s platform dependencies are now `api` (were `implementation`) so consumers can name `Urgency` / `InterruptionLevel` / `ToastScenario` directly in the blocks.
- `notification-windows` gains `ToastScenario.URGENT`, a `ToastDuration` enum, and `duration` toast support (used by the `windows { }` block).

Resolves #397

## 📄 Motivation and Context

#397 asked for notification urgency and per-OS hints (transient, resident, category, expire-timeout) in the API. The first cut mapped a common `urgency`/`priority` enum onto each platform, but that abstraction is dishonest: `CRITICAL` breaks through Do Not Disturb on Linux and Windows, whereas on macOS that requires an Apple entitlement most apps don't have, so it can only reach `timeSensitive` — which merely re-prioritizes. There is no uniform 3-level ladder to map to (Windows toasts don't even have a graded "low").

Following the discussion on the issue, this PR takes the opposite approach: **don't fake a shared abstraction for behavior that isn't shared.** The common surface stays limited to the truly-portable structural fields, and platform-specific behavior is expressed through explicit per-platform blocks the caller opts into. This is also the ergonomic answer for a single-codebase multiplatform desktop app — the OS is a runtime dimension of one JVM artifact (not a compile target, so `expect/actual` can't express it), and the blocks let you configure all three platforms in one call site with full fidelity instead of hand-rolling `when (Platform.Current)`.

## 🧪 How Has This Been Tested?

Environment: Fedora Linux, KDE Plasma 6 (Wayland), JDK 21 (Temurin).

- **Unit tests** — `NotificationDslTest` (blocks populate only their own scope, buttons still work, repeated blocks merge) and `ToastXmlBuilderTest` (`scenario="urgent"` and `duration="short"/"long"` emitted correctly, omitted by default).
- **Static checks** — `ktlintCheck` and `detekt` pass on the changed modules.
- **Linux end-to-end, on the wire** — ran the real common API → `LinuxDispatcher` → JNI → D-Bus against a mock `org.freedesktop.Notifications` server on an isolated `dbus-run-session` bus, and asserted the captured hints: `linux { urgency = CRITICAL }` → `urgency=2`, `LOW` → `0`, and `transient/resident/category="im.received"/expireTimeout=3000` all land correctly. A no-block notification emits identical output to the previous API (empty hints, `expire_timeout=-1`), confirming backward compatibility.
- **macOS / Windows** — verified at compile + unit level (no macOS/Windows hosts available); the `windows { }` path is covered by the XML builder test, and the `macos { }` mapping sets `interruptionLevel`/`relevanceScore`/`subtitle` on `NotificationContent`, which is already wired to native.
- `examples/nucleus-demo` compiles with a new "Platform-Specific Options" section demonstrating the blocks.

Backward-compatibility note: this is source-compatible — the `notification(...)` parameters are unchanged, `button()` still works, the trailing-lambda receiver was renamed (`NotificationButtonBuilder` → `NotificationBuilder`, with a `@Deprecated typealias` kept), and the trailing-lambda parameter was renamed (`buttons` → `block`); no in-repo caller referenced either name. It is not binary-compatible (the lambda receiver type changed), so downstream code should be recompiled.

## 📦 Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.