### PR TITLE
fix(tao): wayland window resize content jumping fix

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
@@ -147,6 +147,21 @@ internal object NativeTaoEglBridge {
         commitNow: Boolean,
     )
 
+    /**
+     * The EGL window surface's **actual** size, packed `(width shl 32) or height`,
+     * or 0 if unavailable. Wayland only in practice.
+     *
+     * Deliberately not the size last passed to [nativeResize]:
+     * `wl_egl_window_resize` records a *pending* size and the buffer behind the
+     * GL default framebuffer is only reallocated on the next `eglSwapBuffers`.
+     * Between those two points this reports the OLD size, while our own state
+     * has already moved to the new one — and anything that wraps `fbId = 0`
+     * (i.e. `BackendRenderTarget.makeGL`) is wrapping a framebuffer of that old
+     * size. See `docs/linux-wayland-resize-latency.md`.
+     */
+    @JvmStatic
+    external fun nativeSurfaceSize(handle: Long): Long
+
     /** Pumps the back-buffer to screen via `eglSwapBuffers`. */
     @JvmStatic
     external fun nativePresent(handle: Long)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
@@ -136,14 +136,23 @@ internal object NativeTaoEglBridge {
      * safe from the event-loop thread **while no swap is in flight** — the swap
      * thread commits the same surface. Callers must hold that gate themselves.
      *
-     * No-op on X11, on compositors without `wp_viewporter`, and when the
-     * destination is unchanged and [commitNow] is false.
+     * [srcW]/[srcH] crop the window rect out of the buffer, which is
+     * over-allocated on a coarse grid so a drag rarely reallocates it. **They
+     * must not exceed the buffer currently in flight** — a source rectangle
+     * running past the buffer is a fatal `wp_viewport` protocol error — so the
+     * caller clamps them to the size reported by [nativeSurfaceSize]. Pass 0 to
+     * fall back to the destination size.
+     *
+     * No-op on X11, on compositors without `wp_viewporter`, and when nothing
+     * changed and [commitNow] is false.
      */
     @JvmStatic
     external fun nativeSetViewportDestination(
         handle: Long,
         logicalW: Int,
         logicalH: Int,
+        srcW: Int,
+        srcH: Int,
         commitNow: Boolean,
     )
 

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
@@ -121,6 +121,32 @@ internal object NativeTaoEglBridge {
         yLogical: Int,
     )
 
+    /**
+     * Wayland only: sets the content surface's `wp_viewport` destination —
+     * the size the surface occupies in surface (logical) units, independent of
+     * the buffer's size. The compositor scales the buffer to fit.
+     *
+     * This decouples "how big the window is" from "how big the buffer we last
+     * finished rendering is". Those are ~30 ms apart during a resize drag, and
+     * that gap is the resize artifact (see
+     * `docs/linux-wayland-resize-latency.md`).
+     *
+     * [commitNow] makes the change land immediately instead of waiting for the
+     * next `eglSwapBuffers`. It issues a `wl_surface.commit`, so it is only
+     * safe from the event-loop thread **while no swap is in flight** — the swap
+     * thread commits the same surface. Callers must hold that gate themselves.
+     *
+     * No-op on X11, on compositors without `wp_viewporter`, and when the
+     * destination is unchanged and [commitNow] is false.
+     */
+    @JvmStatic
+    external fun nativeSetViewportDestination(
+        handle: Long,
+        logicalW: Int,
+        logicalH: Int,
+        commitNow: Boolean,
+    )
+
     /** Pumps the back-buffer to screen via `eglSwapBuffers`. */
     @JvmStatic
     external fun nativePresent(handle: Long)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -222,6 +222,10 @@ internal class TaoComposeSceneHostLinux(
      */
     private var swapThread: SwapThread? = null
 
+    /** Real framebuffer size the cached Skia surface was built for. */
+    private var lastFbWidthPx: Int = 0
+    private var lastFbHeightPx: Int = 0
+
     private var widthPx: Int = 0
     private var heightPx: Int = 0
     private var scale: Float = 1f
@@ -1008,6 +1012,33 @@ internal class TaoComposeSceneHostLinux(
     }
 
     /**
+     * Size to render at, from the EGL surface size packed by
+     * `nativeSurfaceSize`.
+     *
+     * The framebuffer lags the requested size in **either** direction: smaller
+     * while the window grows, larger while it shrinks. An earlier version of
+     * this guard required `w <= widthPx`, which silently disabled the whole fix
+     * for shrinking — and matched the report exactly ("almost gone when making
+     * the window larger, still very visible when making it smaller"). The bound
+     * is therefore symmetric.
+     *
+     * Its only job is to reject a *degenerate* report: before the first
+     * configure is applied the EGL surface can return something tiny, and laying
+     * the scene out into that leaves the window unmapped. A real resize step is
+     * a handful of pixels, so a factor-of-two window either way never rejects a
+     * legitimate value.
+     */
+    private fun resolveFramebufferSize(packed: Long): IntSize {
+        if (packed == 0L) return IntSize(widthPx, heightPx)
+        val w = (packed ushr 32).toInt()
+        val h = (packed and 0xFFFFFFFFL).toInt()
+        val sane =
+            w in (widthPx / 2)..(widthPx * 2) &&
+                h in (heightPx / 2)..(heightPx * 2)
+        return if (sane) IntSize(w, h) else IntSize(widthPx, heightPx)
+    }
+
+    /**
      * Pushes the *current* window size to the content surface's `wp_viewport`
      * destination, so the surface occupies the window rect regardless of how
      * stale the buffer we last rendered is.
@@ -1188,12 +1219,44 @@ internal class TaoComposeSceneHostLinux(
         // is current — applyPendingNativeResize closes the stale Skia cache.
         applyPendingNativeResize()
 
+        // Render at the framebuffer's REAL size, not the size we requested.
+        //
+        // `wl_egl_window_resize` only records a pending size; the buffer behind
+        // the GL default framebuffer is not reallocated until the next
+        // `eglSwapBuffers`. `BackendRenderTarget.makeGL(fbId = 0)` wraps that
+        // same framebuffer, so passing the requested size tells Skia the drawable
+        // is taller than it is — and with `SurfaceOrigin.BOTTOM_LEFT` Skia maps
+        // y=0 to GL row `height - 1`, off the top of the real drawable. The whole
+        // frame is displaced by the difference, leaving a band of clear colour at
+        // the top of the window, `delta-height` tall, flickering for the whole
+        // drag. Measured: the framebuffer is exactly one resize step behind on
+        // every resizing frame. See docs/linux-wayland-resize-latency.md.
+        //
+        // Drawing smaller than the window is safe: the `wp_viewport` destination
+        // already maps whatever we render onto the current window rect.
+        val packedFb = NativeTaoEglBridge.nativeSurfaceSize(attachmentHandle)
+        val fbSize = resolveFramebufferSize(packedFb)
+        val fbW = fbSize.width
+        val fbH = fbSize.height
+        if (fbW != lastFbWidthPx || fbH != lastFbHeightPx) {
+            cachedSurface?.close()
+            cachedSurface = null
+            cachedRt?.close()
+            cachedRt = null
+            lastFbWidthPx = fbW
+            lastFbHeightPx = fbH
+        }
+        if (scene?.size != IntSize(fbW, fbH)) {
+            scene?.size = IntSize(fbW, fbH)
+            updateWindowInfoSize()
+        }
+
         var surface = cachedSurface
         if (surface == null) {
             val rt =
                 BackendRenderTarget.makeGL(
-                    width = widthPx,
-                    height = heightPx,
+                    width = fbW,
+                    height = fbH,
                     sampleCnt = 0,
                     stencilBits = 8,
                     fbId = 0,

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -591,6 +591,9 @@ internal class TaoComposeSceneHostLinux(
         // The redraw gate may have latched while hidden (invalidations with no
         // draw ever arriving); clear it so the re-arm below goes through.
         redrawPending.set(false)
+        // The swap in flight during the last configure has finished by now, so a
+        // destination whose commit had to be skipped can land here.
+        pushViewportDestination(allowCommit = true)
         requestRedrawCoalesced()
     }
 
@@ -979,6 +982,10 @@ internal class TaoComposeSceneHostLinux(
             updateWindowInfoSize()
             lastSceneSizeUpdateNs = now
         }
+        // Track the window immediately, without waiting to render at the new
+        // size: this is the configure -> surface-size path that previously had
+        // to run through the whole render pipeline. See [pushViewportDestination].
+        pushViewportDestination(allowCommit = true)
         requestRedrawCoalesced()
     }
 
@@ -998,6 +1005,44 @@ internal class TaoComposeSceneHostLinux(
         val xLogical = (packed shr 32).toInt()
         val yLogical = packed.toInt()
         NativeTaoEglBridge.nativeSetContentOffset(attachmentHandle, xLogical, yLogical)
+    }
+
+    /**
+     * Pushes the *current* window size to the content surface's `wp_viewport`
+     * destination, so the surface occupies the window rect regardless of how
+     * stale the buffer we last rendered is.
+     *
+     * This is the resize fix. Without it the surface size is `buffer_px /
+     * buffer_scale`, which only advances when a new buffer finishes rendering —
+     * ~37 ms after the configure on a large window, against the ~7 ms GTK takes
+     * to commit the matching window geometry. That ~30 ms difference is the
+     * artifact: the content sits visibly offset from the dragged edge, leaving a
+     * gap or overhanging it (never scaled — see the notes doc). Driving the
+     * destination from [widthPx]/[heightPx], which track the newest configure,
+     * makes the surface follow the window immediately and leaves the compositor
+     * to scale the stale buffer for a frame or two.
+     *
+     * Exact at rest, which matters more than the resize behaviour: once the drag
+     * stops, `widthPx == lastAppliedWidthPx` and the divisor is the same integer
+     * buffer scale handed to `nativeAttachWayland`, so the destination equals
+     * the buffer-derived size and the compositor does no filtering at all.
+     * Getting that wrong would blur the window permanently — a far worse bug
+     * than the one being fixed.
+     *
+     * [allowCommit] commits the surface immediately instead of letting the
+     * change ride the next `eglSwapBuffers`. That is the whole point — it lets
+     * the destination advance *between* our frames — but it is only safe while
+     * the swap thread is not itself committing this surface, hence the
+     * [SwapThread.isSwapIdle] gate. Event-loop thread only.
+     */
+    private fun pushViewportDestination(allowCommit: Boolean) {
+        if (attachmentHandle == 0L) return
+        if (widthPx <= 0 || heightPx <= 0) return
+        val bufferScale = scale.roundToInt().coerceAtLeast(1)
+        val w = (widthPx / bufferScale).coerceAtLeast(1)
+        val h = (heightPx / bufferScale).coerceAtLeast(1)
+        val commit = allowCommit && (swapThread?.isSwapIdle() ?: true)
+        NativeTaoEglBridge.nativeSetViewportDestination(attachmentHandle, w, h, commit)
     }
 
     /**
@@ -1180,6 +1225,10 @@ internal class TaoComposeSceneHostLinux(
         applyFrameDecoration(surface.canvas)
         surface.flushAndSubmit(syncCpu = false)
         NativeTaoEglBridge.nativeReleaseCurrent(attachmentHandle)
+        // Queued, not committed: this one rides the swap's own commit and only
+        // guarantees the destination is never staler than the buffer it ships
+        // with. The two commits above are what close the latency gap.
+        pushViewportDestination(allowCommit = false)
         swapThread?.requestSwap()
 
         // Re-align the content subsurface with GTK's content area AFTER the
@@ -1945,6 +1994,19 @@ internal class TaoComposeSceneHostLinux(
                     true
                 }
             }
+
+        /**
+         * True when no swap is queued or running, i.e. nothing else is
+         * currently committing the content `wl_surface`. Unlike
+         * [tryBeginRenderOrMarkOwed] this does not mark a render owed — it is a
+         * plain gate for [pushViewportDestination], which commits the surface
+         * directly.
+         *
+         * Only meaningful when called from the event-loop thread: that thread
+         * is the sole caller of [requestSwap], so a `true` answer cannot go
+         * stale underneath it.
+         */
+        fun isSwapIdle(): Boolean = lock.withLock { !swapPending && !swapping }
 
         fun shutdownAndJoin() {
             lock.withLock {

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -1072,8 +1072,24 @@ internal class TaoComposeSceneHostLinux(
         val bufferScale = scale.roundToInt().coerceAtLeast(1)
         val w = (widthPx / bufferScale).coerceAtLeast(1)
         val h = (heightPx / bufferScale).coerceAtLeast(1)
+        // Crop exactly the window rect out of the over-allocated buffer, so the
+        // presented image is 1:1 and nothing is scaled. Clamped to the buffer
+        // actually in flight: while the window grows past a grid boundary the
+        // buffer is briefly smaller, and a source rect past its edge is a fatal
+        // protocol error. In that one frame the crop is short and the compositor
+        // scales it — the same transient this change removes everywhere else.
+        val packed = NativeTaoEglBridge.nativeSurfaceSize(attachmentHandle)
+        val srcW: Int
+        val srcH: Int
+        if (packed != 0L) {
+            srcW = minOf(w, ((packed ushr 32).toInt() / bufferScale).coerceAtLeast(1))
+            srcH = minOf(h, ((packed and 0xFFFFFFFFL).toInt() / bufferScale).coerceAtLeast(1))
+        } else {
+            srcW = 0
+            srcH = 0
+        }
         val commit = allowCommit && (swapThread?.isSwapIdle() ?: true)
-        NativeTaoEglBridge.nativeSetViewportDestination(attachmentHandle, w, h, commit)
+        NativeTaoEglBridge.nativeSetViewportDestination(attachmentHandle, w, h, srcW, srcH, commit)
     }
 
     /**
@@ -1246,8 +1262,13 @@ internal class TaoComposeSceneHostLinux(
             lastFbWidthPx = fbW
             lastFbHeightPx = fbH
         }
-        if (scene?.size != IntSize(fbW, fbH)) {
-            scene?.size = IntSize(fbW, fbH)
+        // Lay out at the *window* size, not the buffer's. The buffer is
+        // over-allocated on a coarse grid so a drag rarely reallocates it;
+        // wp_viewport.set_source crops the window rect back out, so the extra
+        // is never presented. Skia is still told the buffer's real size below —
+        // that is what keeps the BOTTOM_LEFT origin flip correct.
+        if (scene?.size != IntSize(widthPx, heightPx)) {
+            scene?.size = IntSize(widthPx, heightPx)
             updateWindowInfoSize()
         }
 

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
@@ -367,6 +367,27 @@ static void *g_libwlclient = NULL;
 static int g_libs_loaded = 0;
 
 static PFN_wl_egl_window_create  p_wl_egl_window_create  = NULL;
+
+/* Round an axis up to EGL_ALLOC_GRID, plus one whole grid of headroom.
+ *
+ * The grid alone stops the buffer being reallocated every frame, but on the
+ * frame the window first crosses a boundary the buffer is still the old size,
+ * so that frame crops short and is scaled. The headroom means the buffer is
+ * always at least a grid larger than the window, so growth has somewhere to go
+ * and the window only outruns it if it gains a full grid within one frame.
+ *
+ * It also matters most where it is cheapest. The scale error at a crossing is
+ * one frame of drag motion over the window size, so it is far more visible on a
+ * small window (~3% at 1024 px) than a large one (~1% at 3800 px) — which is
+ * exactly when the absolute cost of the extra headroom is smallest.
+ */
+#define EGL_ALLOC_GRID 128
+static inline int egl_bucket(int px) {
+    if (px < 1) px = 1;
+    return ((px + EGL_ALLOC_GRID - 1) / EGL_ALLOC_GRID) * EGL_ALLOC_GRID
+           + EGL_ALLOC_GRID;
+}
+
 static PFN_wl_egl_window_destroy p_wl_egl_window_destroy = NULL;
 static PFN_wl_egl_window_resize  p_wl_egl_window_resize  = NULL;
 
@@ -682,6 +703,8 @@ typedef struct {
     wl_proxy       *wl_viewport;
     int             viewport_w;         /* last destination sent, -1 = unset */
     int             viewport_h;
+    int             viewport_src_w;     /* last source rect sent, -1 = unset */
+    int             viewport_src_h;
     wl_egl_window  *wl_window;
     /* Content-area origin inside the parent surface, logical px. (0,0) for a
      * plain undecorated toplevel; the GTK theme's shadow margins when the
@@ -1336,7 +1359,11 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeAttachWayland(
     }
 
     /* Wrap our owned child wl_surface — NOT GTK's — into a wl_egl_window. */
-    wl_egl_window *wlwin = p_wl_egl_window_create((wl_surface *) child_surface, phys_w, phys_h);
+    /* Bucketed from the start: creating at the exact size leaves the first
+     * drag with no headroom, which is why it stretched while later drags did
+     * not. */
+    wl_egl_window *wlwin = p_wl_egl_window_create(
+        (wl_surface *) child_surface, egl_bucket(phys_w), egl_bucket(phys_h));
     if (!wlwin) {
         DBG("wl_egl_window_create returned NULL\n");
         p_eglDestroyContext(edpy, ctx);
@@ -1402,6 +1429,8 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeAttachWayland(
     att->wl_viewporter    = bind_state.viewporter;
     att->viewport_w       = -1;
     att->viewport_h       = -1;
+    att->viewport_src_w   = -1;
+    att->viewport_src_h   = -1;
     /* One viewport per content surface, created up front so the per-frame path
      * is a single `set_destination`. Left NULL (and simply unused) when the
      * compositor did not advertise wp_viewporter. */
@@ -1525,6 +1554,7 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeReleaseCurrent
     p_eglMakeCurrent(att->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 }
 
+
 JNIEXPORT void JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeResize(
     JNIEnv *env, jclass clazz, jlong handle, jint widthPx, jint heightPx, jfloat scale)
@@ -1549,8 +1579,19 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeResize(
      * eglSwapBuffers. Without this the buffer stays at its original
      * dimensions and the compositor scales it up, blurring the result. */
     if (att->wl_window && p_wl_egl_window_resize) {
+        /* Allocate on a coarse grid rather than at the exact window size.
+         *
+         * The buffer behind the GL default framebuffer is only reallocated by
+         * `eglSwapBuffers`, so at the exact size it is always one resize step
+         * behind during a drag — and presenting it means either a gap at the
+         * growing edge or scaling it to fit. Rounding up means the allocation
+         * usually does not change at all while dragging, so every frame can be
+         * rendered at the true window size and `wp_viewport.set_source` crops
+         * the exact window rect back out. Costs at most one grid step of unused
+         * buffer per axis. */
         p_wl_egl_window_resize(att->wl_window,
-                               att->widthPx, att->heightPx, 0, 0);
+                               egl_bucket(att->widthPx), egl_bucket(att->heightPx),
+                               0, 0);
         /* Track DPI changes: re-assert the integer buffer scale so the new
          * buffer is still read as `logical` surface units. Queued state, lands
          * with the next eglSwapBuffers commit. */
@@ -1623,21 +1664,42 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetContentOffs
 JNIEXPORT void JNICALL
 Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetViewportDestination(
     JNIEnv *env, jclass clazz, jlong handle,
-    jint logicalW, jint logicalH, jboolean commitNow)
+    jint logicalW, jint logicalH, jint srcW, jint srcH, jboolean commitNow)
 {
     (void) env; (void) clazz;
     EglAttachment *att = (EglAttachment *) (uintptr_t) handle;
     if (!att || !att->wl_viewport || !p_wl_proxy_marshal_flags) return;
     if (logicalW <= 0 || logicalH <= 0) return;
-    if (att->viewport_w == logicalW && att->viewport_h == logicalH && !commitNow) return;
 
-    if (att->viewport_w != logicalW || att->viewport_h != logicalH) {
+    /* Crop the window rect out of the (over-allocated) buffer, then present it
+     * 1:1. Source is wl_fixed_t — 24.8 fixed point — and MUST lie inside the
+     * buffer: a source rectangle that runs past it is a fatal protocol error,
+     * which is why the caller clamps it to the buffer actually in flight. */
+    int src_w = srcW > 0 ? srcW : logicalW;
+    int src_h = srcH > 0 ? srcH : logicalH;
+    /* Never crop to a degenerate rect. Before the first configure is applied the
+     * surface can read back far smaller than the window, and stretching a
+     * handful of pixels across it would flash. Anything under half the
+     * destination means "no useful crop": fall back to the whole surface, which
+     * is just the pre-crop behaviour for that frame. */
+    if (src_w * 2 < logicalW || src_h * 2 < logicalH) {
+        src_w = logicalW;
+        src_h = logicalH;
+    }
+    if (att->viewport_w != logicalW || att->viewport_h != logicalH ||
+        att->viewport_src_w != src_w || att->viewport_src_h != src_h) {
+        p_wl_proxy_marshal_flags(
+            att->wl_viewport, WP_VIEWPORT_SET_SOURCE, NULL,
+            p_wl_proxy_get_version(att->wl_viewport), 0,
+            0, 0, src_w << 8, src_h << 8);
         p_wl_proxy_marshal_flags(
             att->wl_viewport, WP_VIEWPORT_SET_DESTINATION, NULL,
             p_wl_proxy_get_version(att->wl_viewport), 0,
             logicalW, logicalH);
         att->viewport_w = logicalW;
         att->viewport_h = logicalH;
+        att->viewport_src_w = src_w;
+        att->viewport_src_h = src_h;
     } else if (!commitNow) {
         return;
     }

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
@@ -92,6 +92,9 @@ typedef unsigned long  EGLNativeWindowType;   /* X11 Window XID on Xlib */
 #define EGL_NO_CONTEXT                 ((EGLContext) 0)
 #define EGL_NO_SURFACE                 ((EGLSurface) 0)
 #define EGL_NONE                       0x3038
+/* Queryable surface attributes (egl.h) — declared locally like the rest. */
+#define EGL_HEIGHT                     0x3056
+#define EGL_WIDTH                      0x3057
 #define EGL_RED_SIZE                   0x3024
 #define EGL_GREEN_SIZE                 0x3023
 #define EGL_BLUE_SIZE                  0x3022
@@ -217,6 +220,7 @@ typedef EGLBoolean (*PFN_eglDestroySurface)(EGLDisplay, EGLSurface);
 typedef EGLBoolean (*PFN_eglMakeCurrent)(EGLDisplay, EGLSurface, EGLSurface, EGLContext);
 typedef EGLBoolean (*PFN_eglSwapBuffers)(EGLDisplay, EGLSurface);
 typedef EGLBoolean (*PFN_eglSwapInterval)(EGLDisplay, EGLint);
+typedef EGLBoolean (*PFN_eglQuerySurface)(EGLDisplay, EGLSurface, EGLint, EGLint *);
 typedef EGLint     (*PFN_eglGetError)(void);
 typedef void      *(*PFN_eglGetProcAddress)(const char *);
 typedef const char *(*PFN_eglQueryString)(EGLDisplay, EGLint);
@@ -338,6 +342,7 @@ static PFN_eglDestroySurface     p_eglDestroySurface     = NULL;
 static PFN_eglMakeCurrent        p_eglMakeCurrent        = NULL;
 static PFN_eglSwapBuffers        p_eglSwapBuffers        = NULL;
 static PFN_eglSwapInterval       p_eglSwapInterval       = NULL;
+static PFN_eglQuerySurface       p_eglQuerySurface       = NULL;
 static PFN_eglGetError           p_eglGetError           = NULL;
 static PFN_eglGetProcAddress     p_eglGetProcAddress     = NULL;
 static PFN_eglQueryString        p_eglQueryString        = NULL;
@@ -498,6 +503,7 @@ static int load_libs(void) {
     LOAD(g_libegl, eglMakeCurrent);
     LOAD(g_libegl, eglSwapBuffers);
     LOAD(g_libegl, eglSwapInterval);
+    LOAD(g_libegl, eglQuerySurface);
     LOAD(g_libegl, eglGetError);
     LOAD(g_libegl, eglGetProcAddress);
     LOAD(g_libegl, eglQueryString);
@@ -1643,6 +1649,37 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetViewportDes
             p_wl_display_flush(att->wl_display_conn);
         }
     }
+}
+
+/**
+ * Returns the EGL window surface's **actual** current size, packed as
+ * `(width << 32) | height`, or 0 if unavailable.
+ *
+ * This is not the size we last asked for. `wl_egl_window_resize` only records a
+ * pending size; the buffer behind the GL default framebuffer is not reallocated
+ * until the next `eglSwapBuffers`. So between a resize and the swap that applies
+ * it, `eglQuerySurface` still reports the OLD size while our Kotlin state has
+ * moved on.
+ *
+ * That gap matters because `BackendRenderTarget.makeGL(..., fbId = 0)` wraps
+ * that same default framebuffer, and Skia is told the size we *requested*. With
+ * `SurfaceOrigin.BOTTOM_LEFT` Skia maps y=0 to GL row `height - 1`, so if the
+ * two disagree by N the whole frame is displaced by N — which is the measured
+ * artifact (a band exactly `delta-height` tall at the top of the window during a
+ * resize drag). See docs/linux-wayland-resize-latency.md.
+ */
+JNIEXPORT jlong JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSurfaceSize(
+    JNIEnv *env, jclass clazz, jlong handle)
+{
+    (void) env; (void) clazz;
+    EglAttachment *att = (EglAttachment *) (uintptr_t) handle;
+    if (!att || !p_eglQuerySurface || att->surface == EGL_NO_SURFACE) return 0;
+    EGLint w = 0, h = 0;
+    if (!p_eglQuerySurface(att->display, att->surface, EGL_WIDTH, &w)) return 0;
+    if (!p_eglQuerySurface(att->display, att->surface, EGL_HEIGHT, &h)) return 0;
+    if (w <= 0 || h <= 0) return 0;
+    return ((jlong) w << 32) | (jlong) (h & 0xFFFFFFFFL);
 }
 
 JNIEXPORT void JNICALL

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
@@ -294,6 +294,11 @@ typedef int             (*PFN_wl_display_flush)(wl_display *);
 #define WL_SURFACE_SET_INPUT_REGION        5
 #define WL_SURFACE_COMMIT                  6
 #define WL_SURFACE_SET_BUFFER_SCALE        8
+#define WP_VIEWPORTER_DESTROY              0
+#define WP_VIEWPORTER_GET_VIEWPORT         1
+#define WP_VIEWPORT_DESTROY                0
+#define WP_VIEWPORT_SET_SOURCE             1
+#define WP_VIEWPORT_SET_DESTINATION        2
 
 /* ── Xlib function pointer types ────────────────────────────────────────── */
 
@@ -381,6 +386,63 @@ static const struct wl_interface *g_wl_subsurface_interface   = NULL;
 static const struct wl_interface *g_wl_surface_interface      = NULL;
 static const struct wl_interface *g_wl_region_interface       = NULL;
 static const struct wl_interface *g_wl_callback_interface     = NULL;
+/* ── wp_viewporter introspection tables (hand-authored) ─────────────────────
+ *
+ * Every interface above is fetched with `dlsym` from libwayland-client.so.0,
+ * but that only works for **core** protocol. `wp_viewporter` is an extension:
+ * `wayland-scanner` generates its `wl_interface` tables into each client, and
+ * GTK links its copies privately, so there is no symbol to look up. They have
+ * to be built by hand, matching the `wl_message` / `wl_interface` layouts
+ * declared near the top of this file.
+ *
+ * Why we want it: the surface's size is normally derived from the buffer
+ * (`buffer_px / buffer_scale`), which means it inherits our full render
+ * latency. A viewport lets us state the surface size *independently* of the
+ * buffer — so a buffer that is a couple of frames stale is scaled to exactly
+ * fill the current window rect instead of leaving a gap or overhanging it.
+ * See docs/linux-wayland-resize-latency.md.
+ *
+ * Both interfaces are version 1 and have been stable since 2014. Neither has
+ * events, so no listener plumbing is needed.
+ */
+static struct wl_interface g_wp_viewporter_iface;
+static struct wl_interface g_wp_viewport_iface;
+
+/* Per-argument interface types. Only get_viewport has non-NULL entries, and
+ * they are filled at load time because one of them comes from `dlsym`. */
+static const struct wl_interface *g_wp_no_types[4]                = { NULL, NULL, NULL, NULL };
+static const struct wl_interface *g_wp_get_viewport_types[2]      = { NULL, NULL };
+
+static const struct wl_message g_wp_viewporter_requests[] = {
+    { "destroy",         "",     g_wp_no_types },
+    { "get_viewport",    "no",   g_wp_get_viewport_types },
+};
+static const struct wl_message g_wp_viewport_requests[] = {
+    { "destroy",         "",     g_wp_no_types },
+    { "set_source",      "ffff", g_wp_no_types },
+    { "set_destination", "ii",   g_wp_no_types },
+};
+
+/** Populates the hand-authored tables. Safe to call more than once. */
+static void wl_init_viewport_interfaces(void) {
+    g_wp_get_viewport_types[0] = &g_wp_viewport_iface;
+    g_wp_get_viewport_types[1] = g_wl_surface_interface;
+
+    g_wp_viewport_iface.name         = "wp_viewport";
+    g_wp_viewport_iface.version      = 1;
+    g_wp_viewport_iface.method_count = 3;
+    g_wp_viewport_iface.methods      = g_wp_viewport_requests;
+    g_wp_viewport_iface.event_count  = 0;
+    g_wp_viewport_iface.events       = NULL;
+
+    g_wp_viewporter_iface.name         = "wp_viewporter";
+    g_wp_viewporter_iface.version      = 1;
+    g_wp_viewporter_iface.method_count = 2;
+    g_wp_viewporter_iface.methods      = g_wp_viewporter_requests;
+    g_wp_viewporter_iface.event_count  = 0;
+    g_wp_viewporter_iface.events       = NULL;
+}
+
 
 static int load_libs(void) {
     if (g_libs_loaded) return 1;
@@ -501,6 +563,8 @@ static int load_libs(void) {
             (const struct wl_interface *) dlsym(g_libwlclient, "wl_region_interface");
         g_wl_callback_interface =
             (const struct wl_interface *) dlsym(g_libwlclient, "wl_callback_interface");
+        /* Extensions have no symbols to load — build their tables by hand. */
+        wl_init_viewport_interfaces();
     }
 #undef LOAD
 
@@ -603,6 +667,15 @@ typedef struct {
     wl_proxy       *wl_parent_surface; /* GTK's wl_surface — not owned, not destroyed. */
     wl_proxy       *wl_child_surface;
     wl_proxy       *wl_subsurface;
+    /* wp_viewporter: lets the content surface state its size independently of
+     * the buffer, so a stale buffer is scaled to fill the current window rect
+     * rather than leaving a gap / overhang at the dragged edge. Both NULL when
+     * the compositor has no wp_viewporter — the surface then sizes itself from
+     * the buffer, exactly as before. */
+    wl_proxy       *wl_viewporter;
+    wl_proxy       *wl_viewport;
+    int             viewport_w;         /* last destination sent, -1 = unset */
+    int             viewport_h;
     wl_egl_window  *wl_window;
     /* Content-area origin inside the parent surface, logical px. (0,0) for a
      * plain undecorated toplevel; the GTK theme's shadow margins when the
@@ -924,6 +997,7 @@ typedef struct {
     wl_proxy *registry;
     wl_proxy *compositor;
     wl_proxy *subcompositor;
+    wl_proxy *viewporter;
 } WlBindState;
 
 static void wl_registry_global(
@@ -945,6 +1019,13 @@ static void wl_registry_global(
         st->subcompositor = p_wl_proxy_marshal_flags(
             registry, WL_REGISTRY_BIND, g_wl_subcompositor_interface, v, 0,
             name, "wl_subcompositor", v, NULL);
+    } else if (!st->viewporter && strcmp(interface, "wp_viewporter") == 0) {
+        /* Optional: absent on very old compositors, in which case the surface
+         * keeps deriving its size from the buffer exactly as before. */
+        uint32_t v = version < 1 ? version : 1;
+        st->viewporter = p_wl_proxy_marshal_flags(
+            registry, WL_REGISTRY_BIND, &g_wp_viewporter_iface, v, 0,
+            name, "wp_viewporter", v, NULL);
     }
 }
 
@@ -1312,6 +1393,22 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeAttachWayland(
     att->wl_parent_surface = wparent;
     att->wl_child_surface = child_surface;
     att->wl_subsurface    = subsurface;
+    att->wl_viewporter    = bind_state.viewporter;
+    att->viewport_w       = -1;
+    att->viewport_h       = -1;
+    /* One viewport per content surface, created up front so the per-frame path
+     * is a single `set_destination`. Left NULL (and simply unused) when the
+     * compositor did not advertise wp_viewporter. */
+    if (att->wl_viewporter) {
+        att->wl_viewport = p_wl_proxy_marshal_flags(
+            att->wl_viewporter, WP_VIEWPORTER_GET_VIEWPORT,
+            &g_wp_viewport_iface,
+            p_wl_proxy_get_version(att->wl_viewporter), 0,
+            NULL, child_surface);
+        if (att->wl_viewport && p_wl_proxy_set_queue) {
+            p_wl_proxy_set_queue(att->wl_viewport, queue);
+        }
+    }
     att->wl_window        = wlwin;
     att->widthPx          = phys_w;
     att->heightPx         = phys_h;
@@ -1364,6 +1461,19 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeDetach(
      * Inverting any pair triggers a `Bad object` protocol error from Mutter. */
     if (att->wl_window && p_wl_egl_window_destroy) {
         p_wl_egl_window_destroy(att->wl_window);
+    }
+    /* Viewport before its wl_surface — it holds a reference to it. */
+    if (att->wl_viewport && p_wl_proxy_marshal_flags) {
+        p_wl_proxy_marshal_flags(att->wl_viewport, WP_VIEWPORT_DESTROY,
+            NULL, p_wl_proxy_get_version(att->wl_viewport),
+            WL_MARSHAL_FLAG_DESTROY);
+        att->wl_viewport = NULL;
+    }
+    if (att->wl_viewporter && p_wl_proxy_marshal_flags) {
+        p_wl_proxy_marshal_flags(att->wl_viewporter, WP_VIEWPORTER_DESTROY,
+            NULL, p_wl_proxy_get_version(att->wl_viewporter),
+            WL_MARSHAL_FLAG_DESTROY);
+        att->wl_viewporter = NULL;
     }
     if (att->wl_subsurface && p_wl_proxy_marshal_flags) {
         p_wl_proxy_marshal_flags(att->wl_subsurface, WL_SUBSURFACE_DESTROY,
@@ -1480,6 +1590,59 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetContentOffs
             NULL, p_wl_proxy_get_version(att->wl_parent_surface), 0);
     }
     if (p_wl_display_flush && att->wl_display_conn) p_wl_display_flush(att->wl_display_conn);
+}
+
+/**
+ * Sets the content surface's `wp_viewport` destination — the size the surface
+ * occupies, in surface (logical) units — decoupled from the buffer's own size.
+ *
+ * This is the resize fix. Normally the surface size is `buffer_px /
+ * buffer_scale`, so it only changes when a newly rendered buffer arrives, which
+ * on a large window is ~37 ms after the compositor asked for the new size.
+ * Meanwhile GTK commits the new *window geometry* within ~7 ms, and the ~30 ms
+ * difference is what the user sees as the content jumping relative to the
+ * dragged edge. Feeding the newest configure straight to the viewport lets the
+ * surface track the window immediately; the stale buffer is scaled to fit,
+ * which is a sub-1% error for one or two frames and is what GTK and Qt do
+ * during a resize anyway.
+ *
+ * [commitNow] issues a `wl_surface.commit` so the destination lands without
+ * waiting for the next `eglSwapBuffers`. **Only pass 1 from the event-loop
+ * thread while no swap is in flight** — `eglSwapBuffers` commits this same
+ * surface from the swap thread, and two committers would race for surface
+ * state ordering. The caller owns that gate (see `SwapThread.isSwapIdle`).
+ *
+ * No-op without wp_viewporter, leaving the buffer-derived sizing in place.
+ */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetViewportDestination(
+    JNIEnv *env, jclass clazz, jlong handle,
+    jint logicalW, jint logicalH, jboolean commitNow)
+{
+    (void) env; (void) clazz;
+    EglAttachment *att = (EglAttachment *) (uintptr_t) handle;
+    if (!att || !att->wl_viewport || !p_wl_proxy_marshal_flags) return;
+    if (logicalW <= 0 || logicalH <= 0) return;
+    if (att->viewport_w == logicalW && att->viewport_h == logicalH && !commitNow) return;
+
+    if (att->viewport_w != logicalW || att->viewport_h != logicalH) {
+        p_wl_proxy_marshal_flags(
+            att->wl_viewport, WP_VIEWPORT_SET_DESTINATION, NULL,
+            p_wl_proxy_get_version(att->wl_viewport), 0,
+            logicalW, logicalH);
+        att->viewport_w = logicalW;
+        att->viewport_h = logicalH;
+    } else if (!commitNow) {
+        return;
+    }
+    if (commitNow) {
+        p_wl_proxy_marshal_flags(
+            att->wl_child_surface, WL_SURFACE_COMMIT, NULL,
+            p_wl_proxy_get_version(att->wl_child_surface), 0);
+        if (p_wl_display_flush && att->wl_display_conn) {
+            p_wl_display_flush(att->wl_display_conn);
+        }
+    }
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description

Fixes the Tao/Wayland resize artifact in three steps, one commit each.

**1. Size the Compose subsurface with `wp_viewport`, not its buffer.**
Bind `wp_viewporter` and drive `wp_viewport.set_destination` from the newest
`configure`, instead of letting the surface size follow whatever buffer we last
rendered. The surface then tracks the window immediately. `wp_viewporter` is an
extension, so its `wl_interface` tables are not exported by libwayland-client
and cannot be `dlsym`-ed like the core ones — they are hand-authored against the
layouts already declared in `nucleus_tao_egl.c`.

**2. Render at the EGL surface's real size, not the requested one.**
Query the surface with `eglQuerySurface` and build the render target, Skia
surface and scene size from that. Skia and GL then always agree, so the
`SurfaceOrigin.BOTTOM_LEFT` y-flip is correct and nothing is displaced.

The sanity bound on the queried size must be **symmetric** — the framebuffer
lags in both directions (smaller while growing, larger while shrinking), and an
asymmetric bound silently disables the fix for shrinking.

**3. Over-allocate the EGL buffer and crop it with `wp_viewport.set_source`.**
Allocate the `wl_egl_window` on a 128 px grid *plus a whole grid of headroom*,
so the allocation does not change while dragging. Every frame is then rendered
at the true window size and the window rect is cropped back out, presented 1:1.
The initial allocation in `nativeAttachWayland` is bucketed too — creating at
the exact size left the *first* drag with no headroom, which is where the error
is most visible, since the scale error at a boundary crossing is one frame of
drag motion over the window size (~3 % at 1024 px, ~1 % at 3800 px).

The source rectangle is clamped to the buffer actually in flight: a source rect
running past the buffer is a fatal protocol error. A source under half the
destination is discarded rather than cropped — before the first `configure` is
applied the surface can read back as 1×1, and stretching that across the window
would flash.

Degrades cleanly on compositors without `wp_viewporter` (falls back to
buffer-derived sizing) and is a no-op on X11.

## 📄 Motivation and Context

Fixes #444 .

Each commit addresses a distinct defect; they are ordered as discovered and each
builds on the previous one. Notably, (2) is invisible to every surface-geometry
metric — the surface size is correct throughout, and the error lives entirely
inside the rendered buffer. It was found by frame-by-frame analysis of a screen
capture, after protocol tracing repeatedly failed to see it.

## 🧪 How Has This Been Tested?

Environment: Fedora 44, KWin 6.7.3 native Wayland, 3 × 4K at fractional scale
1.3, AMD Navi 48 / radv, Temurin 21, Compose 1.11.1.

Measured on the reporting machine with `WAYLAND_DEBUG` traces of a resize drag
on a 2842×1840 window:

| | before | after (1) |
| --- | --- | --- |
| time content size ≠ window geometry | 94.6 % | ~26 % |
| \|mismatch\| p50 | 27 px | 0 px |
| \|mismatch\| p90 | 35 px | 9 px |
| share of drag exactly correct | 5 % | 74 % |

For (2), a frame-content probe over a resize drag — frames whose top band
collapsed to under 20 px: **108 of 257 → 0**; over a combined grow+shrink drag,
**1 of 434**.

For (3), counting viewport commits where source == destination (the direct
precondition for no scaling), over a first drag from the default window plus an
aggressive grow/shrink drag: **897 of 897 presented exactly 1:1, 0 scaled, 0
protocol errors**.

Also verified: rendering is unchanged and sharp at rest (an incorrect
destination here would blur the window permanently), and the window renders
correctly after dragging.

**Known residual:** a small amount of stretch is still visible on the *initial*
drag. Everything after that is clean. The remaining case is a drag that gains a
full grid step (128 px) inside one frame, where the window outruns even the
headroom; raising `EGL_ALLOC_GRID` to 256 would double the margin at the cost of
a few MB of buffer. Left as-is pending review feedback.

**Testing gaps:** (3) was verified headless plus by direct observation on the
reporting rig; the wire-level counts come from `kwin_wayland --virtual`, which
has no real vblank. The artifact itself is not reproducible there, so those
counts confirm the mechanism, not the perceived result.

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.