### PR TITLE
fix(tao/linux): declare the Compose subsurface's opaque region

### DIFF
--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/ffi/NativeTaoEglBridge.kt
@@ -121,6 +121,28 @@ internal object NativeTaoEglBridge {
         yLogical: Int,
     )
 
+    /**
+     * Wayland only: declares which part of the content surface is fully opaque,
+     * in surface (logical) units, with the four [cornerRadius]-sized corners
+     * excluded (they are painted transparent so the drop shadow shows through).
+     *
+     * Without this the compositor must treat our full-window surface as
+     * translucent and cannot cull the drop-shadow subsurface or GTK's toplevel
+     * underneath it — it alpha-blends all three every frame, which shows up as
+     * slower frame callbacks and therefore a slower resize. See
+     * `docs/linux-wayland-resize-latency.md`.
+     *
+     * Pass `logicalW <= 0` when the window really is translucent, which clears
+     * the region. Queued state — it lands with the next buffer commit.
+     */
+    @JvmStatic
+    external fun nativeSetOpaqueRegion(
+        handle: Long,
+        logicalW: Int,
+        logicalH: Int,
+        cornerRadius: Int,
+    )
+
     /** Pumps the back-buffer to screen via `eglSwapBuffers`. */
     @JvmStatic
     external fun nativePresent(handle: Long)

--- a/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
+++ b/decorated-window-tao/src/main/kotlin/dev/nucleusframework/window/tao/scene/TaoComposeSceneHostLinux.kt
@@ -222,6 +222,9 @@ internal class TaoComposeSceneHostLinux(
      */
     private var swapThread: SwapThread? = null
 
+    /** Last opaque region pushed: (logicalW, logicalH, cornerRadius). */
+    private var lastOpaqueRegion: Triple<Int, Int, Int>? = null
+
     private var widthPx: Int = 0
     private var heightPx: Int = 0
     private var scale: Float = 1f
@@ -979,6 +982,11 @@ internal class TaoComposeSceneHostLinux(
             updateWindowInfoSize()
             lastSceneSizeUpdateNs = now
         }
+        val opaqueScale = scale.roundToInt().coerceAtLeast(1)
+        pushOpaqueRegion(
+            (widthPx / opaqueScale).coerceAtLeast(1),
+            (heightPx / opaqueScale).coerceAtLeast(1),
+        )
         requestRedrawCoalesced()
     }
 
@@ -998,6 +1006,41 @@ internal class TaoComposeSceneHostLinux(
         val xLogical = (packed shr 32).toInt()
         val yLogical = packed.toInt()
         NativeTaoEglBridge.nativeSetContentOffset(attachmentHandle, xLogical, yLogical)
+    }
+
+    /**
+     * Tells the compositor which part of our surface is fully opaque, so it can
+     * skip compositing the drop shadow's interior and GTK's toplevel underneath
+     * us. Nothing declared this before, so the compositor blended all three
+     * across the whole window on every frame — which slows its frame callbacks,
+     * which throttles GDK's frame clock, which is what caps how fast the window
+     * edge moves during a resize.
+     *
+     * Cleared when the window is genuinely translucent: [clearColorArgbState] is
+     * what the scene is cleared to each frame, so an alpha below 255 means
+     * pixels really can show through and claiming otherwise would corrupt them.
+     * The rounded corners are excluded for the same reason — see
+     * [applyFrameDecoration], which carves them out.
+     */
+    private fun pushOpaqueRegion(
+        logicalW: Int,
+        logicalH: Int,
+    ) {
+        if (attachmentHandle == 0L) return
+        val opaque = (clearColorArgbState.value ushr 24) and 0xFF == 0xFF
+        if (!opaque) {
+            if (lastOpaqueRegion != null) {
+                NativeTaoEglBridge.nativeSetOpaqueRegion(attachmentHandle, 0, 0, 0)
+                lastOpaqueRegion = null
+            }
+            return
+        }
+        val squared = window.isMaximized || window.isFullscreen || window.isTiled
+        val radius = if (cornerRadiusPx > 0 && !squared) cornerRadiusPx else 0
+        val key = Triple(logicalW, logicalH, radius)
+        if (key == lastOpaqueRegion) return
+        lastOpaqueRegion = key
+        NativeTaoEglBridge.nativeSetOpaqueRegion(attachmentHandle, logicalW, logicalH, radius)
     }
 
     /**

--- a/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
+++ b/decorated-window-tao/src/main/native/linux/nucleus_tao_egl.c
@@ -291,6 +291,7 @@ typedef int             (*PFN_wl_display_flush)(wl_display *);
 #define WL_SURFACE_ATTACH                  1
 #define WL_SURFACE_DAMAGE                  2
 #define WL_SURFACE_FRAME                   3
+#define WL_SURFACE_SET_OPAQUE_REGION       4
 #define WL_SURFACE_SET_INPUT_REGION        5
 #define WL_SURFACE_COMMIT                  6
 #define WL_SURFACE_SET_BUFFER_SCALE        8
@@ -1480,6 +1481,76 @@ Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetContentOffs
             NULL, p_wl_proxy_get_version(att->wl_parent_surface), 0);
     }
     if (p_wl_display_flush && att->wl_display_conn) p_wl_display_flush(att->wl_display_conn);
+}
+
+/**
+ * Declares which part of the content surface is fully opaque.
+ *
+ * Nothing ever set this, even though the whole design depends on it: without an
+ * opaque region the compositor must assume our full-window surface is
+ * translucent, so it cannot cull *anything* underneath — not the drop-shadow
+ * subsurface's interior, not GTK's toplevel. It alpha-blends all three, every
+ * frame, over the whole window.
+ *
+ * That lands on the compositor's frame timing, which is what GDK's frame clock
+ * waits on, which is what sets how fast the window edge can move during a
+ * resize. Measured: the toplevel's frame callback comes back ~5 ms sooner with
+ * the shadow disabled entirely. Declaring the opaque region lets the compositor
+ * discard the same work without removing the shadow.
+ *
+ * [cornerRadius] carves the four corners out of the region, because
+ * `applyFrameDecoration` paints them transparent so the shadow shows through —
+ * claiming them opaque would leave square corners with the shadow clipped away.
+ *
+ * Pass `logicalW <= 0` to clear the region (window genuinely translucent).
+ * Coordinates are surface-local (logical) units. Queued state: it lands with the
+ * next `eglSwapBuffers` commit, so there is no extra commit and no race with the
+ * swap thread.
+ */
+JNIEXPORT void JNICALL
+Java_dev_nucleusframework_window_tao_ffi_NativeTaoEglBridge_nativeSetOpaqueRegion(
+    JNIEnv *env, jclass clazz, jlong handle,
+    jint logicalW, jint logicalH, jint cornerRadius)
+{
+    (void) env; (void) clazz;
+    EglAttachment *att = (EglAttachment *) (uintptr_t) handle;
+    if (!att || !att->wl_child_surface || !p_wl_proxy_marshal_flags) return;
+    if (!att->wl_compositor || !g_wl_region_interface) return;
+
+    if (logicalW <= 0 || logicalH <= 0) {
+        p_wl_proxy_marshal_flags(
+            att->wl_child_surface, WL_SURFACE_SET_OPAQUE_REGION, NULL,
+            p_wl_proxy_get_version(att->wl_child_surface), 0, NULL);
+        return;
+    }
+
+    wl_proxy *region = p_wl_proxy_marshal_flags(
+        (wl_proxy *) att->wl_compositor, WL_COMPOSITOR_CREATE_REGION,
+        g_wl_region_interface,
+        p_wl_proxy_get_version((wl_proxy *) att->wl_compositor), 0, NULL);
+    if (!region) return;
+    if (att->wl_queue && p_wl_proxy_set_queue) p_wl_proxy_set_queue(region, att->wl_queue);
+
+    int r = cornerRadius;
+    if (r < 0) r = 0;
+    if (2 * r >= logicalW || 2 * r >= logicalH) r = 0;
+    if (r == 0) {
+        p_wl_proxy_marshal_flags(region, WL_REGION_ADD, NULL,
+            p_wl_proxy_get_version(region), 0, 0, 0, logicalW, logicalH);
+    } else {
+        /* Everything except the four r x r corner squares. */
+        p_wl_proxy_marshal_flags(region, WL_REGION_ADD, NULL,
+            p_wl_proxy_get_version(region), 0, 0, r, logicalW, logicalH - 2 * r);
+        p_wl_proxy_marshal_flags(region, WL_REGION_ADD, NULL,
+            p_wl_proxy_get_version(region), 0, r, 0, logicalW - 2 * r, r);
+        p_wl_proxy_marshal_flags(region, WL_REGION_ADD, NULL,
+            p_wl_proxy_get_version(region), 0, r, logicalH - r, logicalW - 2 * r, r);
+    }
+    p_wl_proxy_marshal_flags(
+        att->wl_child_surface, WL_SURFACE_SET_OPAQUE_REGION, NULL,
+        p_wl_proxy_get_version(att->wl_child_surface), 0, region);
+    p_wl_proxy_marshal_flags(region, WL_REGION_DESTROY, NULL,
+        p_wl_proxy_get_version(region), WL_MARSHAL_FLAG_DESTROY);
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
## 🚀 Description

Declare the Compose content subsurface's opaque region via
`wl_surface.set_opaque_region`, so the compositor can cull what is hidden behind
it.

The region is the window rect minus the four corner squares — the corners are
painted transparent by `applyFrameDecoration` so the drop shadow can show
through there, and claiming them opaque would clip it.

It is cleared whenever the resolved clear colour has alpha < 255, so genuinely
translucent windows (including `DecoratedWindow(transparent = true)`) are
unaffected, and it is only re-sent when the size, corner radius or tiling state
changes.

## 📄 Motivation and Context

Fixes #446 . Related to #444 (the Tao/Wayland resize artifact) — both concern how
the Tao backend's surfaces are presented during a resize, but they are
independent and this one stands alone.

## 🧪 How Has This Been Tested?

Environment: Fedora 44, KWin 6.7.3 native Wayland, 3 × 4K at fractional scale
1.3, AMD Navi 48 / radv, Temurin 21.

Verified on the wire that the region is emitted with the corners excluded
(1024×720 window, KDE corner radius 5):

```
-> wl_compositor#36.create_region(new id wl_region#43)
-> wl_region#43.add(0, 5, 1024, 710)
-> wl_region#43.add(5, 0, 1014, 5)
-> wl_region#43.add(5, 715, 1014, 5)
-> wl_surface#35.set_opaque_region(wl_region#43)
```

Rendering is unaffected — rounded corners and drop shadow intact, no regressions
observed during resize, move, maximise or focus changes.

Measured during a resize drag on a 2842×1840 window:

| | before | after |
| --- | --- | --- |
| toplevel frame callback latency | 16.9 ms | 13.7 ms |
| median gap between window-edge moves | 25.6 ms | 20.0 ms |

**Caveat on those numbers:** they were taken before `de5e20ff` replaced the
`wl_shm` shadow subsurface with GTK's native CSD shadow, so they were measured
with one more full-window layer in the stack than exists today. The mechanism is
unchanged — the compositor still cannot cull beneath a surface it must assume is
translucent — but the magnitude should be re-measured on current `main` before
these figures are quoted anywhere.

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.