### PR TITLE
fix(application): DecoratedWindow's outer-locals bridge shadows the scene's own LocalComposeSceneContext

### DIFF
--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -227,6 +227,12 @@ public object TaoSceneTestBattery {
             TaoSceneOuterLocalsBridgeTest()
                 .`bridging outer locals through the scene's own compositionLocalContext property does not break Popup`()
         }
+        run(
+            "TaoSceneOuterLocalsBridgeTest: bridged outer locals do not carry the outer layout direction into content",
+        ) {
+            TaoSceneOuterLocalsBridgeTest()
+                .`bridged outer locals do not carry the outer layout direction into content`()
+        }
         run("TaoSceneAnimationTest: tween advances exactly with virtual frames") {
             TaoSceneAnimationTest().`tween advances exactly with virtual frames`()
         }

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBattery.kt
@@ -10,6 +10,7 @@ import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneKeyboardTest
+import dev.nucleusframework.window.tao.scene.TaoSceneOuterLocalsBridgeTest
 import dev.nucleusframework.window.tao.scene.TaoScenePointerTest
 import dev.nucleusframework.window.tao.scene.TaoScenePopupTest
 import dev.nucleusframework.window.tao.scene.TaoSceneRenderTest
@@ -211,6 +212,20 @@ public object TaoSceneTestBattery {
         }
         run("TaoScenePopupTest: click inside a focusable popup does not dismiss it") {
             TaoScenePopupTest().`click inside a focusable popup does not dismiss it`()
+        }
+        run(
+            "TaoSceneOuterLocalsBridgeTest: wrapping window content in outer locals with " +
+                "CompositionLocalProvider breaks Popup",
+        ) {
+            TaoSceneOuterLocalsBridgeTest()
+                .`wrapping window content in outer locals with CompositionLocalProvider breaks Popup`()
+        }
+        run(
+            "TaoSceneOuterLocalsBridgeTest: bridging outer locals through the scene's own compositionLocalContext " +
+                "property does not break Popup",
+        ) {
+            TaoSceneOuterLocalsBridgeTest()
+                .`bridging outer locals through the scene's own compositionLocalContext property does not break Popup`()
         }
         run("TaoSceneAnimationTest: tween advances exactly with virtual frames") {
             TaoSceneAnimationTest().`tween advances exactly with virtual frames`()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/TaoSceneTestBatteryDriftTest.kt
@@ -10,6 +10,7 @@ import dev.nucleusframework.window.tao.event.TaoSyntheticMouseWheelEventTest
 import dev.nucleusframework.window.tao.event.TaoWheelPinchZoomTest
 import dev.nucleusframework.window.tao.scene.TaoSceneAnimationTest
 import dev.nucleusframework.window.tao.scene.TaoSceneKeyboardTest
+import dev.nucleusframework.window.tao.scene.TaoSceneOuterLocalsBridgeTest
 import dev.nucleusframework.window.tao.scene.TaoScenePointerTest
 import dev.nucleusframework.window.tao.scene.TaoScenePopupTest
 import dev.nucleusframework.window.tao.scene.TaoSceneRenderTest
@@ -47,6 +48,7 @@ class TaoSceneTestBatteryDriftTest {
             TaoScenePointerTest::class.java,
             TaoSceneScrollTest::class.java,
             TaoScenePopupTest::class.java,
+            TaoSceneOuterLocalsBridgeTest::class.java,
             TaoSceneAnimationTest::class.java,
             TaoSceneSemanticsTest::class.java,
             TaoA11yProjectionTest::class.java,

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneOuterLocalsBridgeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneOuterLocalsBridgeTest.kt
@@ -11,12 +11,14 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import dev.nucleusframework.window.tao.GlobalLayoutDirection
@@ -98,6 +100,35 @@ class TaoSceneOuterLocalsBridgeTest {
         }
     }
 
+    @Test
+    fun `bridged outer locals do not carry the outer layout direction into content`() {
+        // The flip side of the fix: because the scene property is applied ABOVE
+        // the scene's own locals, ProvideCommonCompositionLocals re-provides
+        // LocalLayoutDirection from the scene's own direction and wins over the
+        // bridged one. An app-level RTL override — or a parent window's
+        // direction, for a secondary window — therefore never reaches content
+        // through the bridge alone. Both nucleus-application adapters snapshot
+        // the outer direction and re-provide it inside content for exactly this
+        // reason; this test pins the scene behaviour that makes that necessary.
+        val outerDirection =
+            if (GlobalLayoutDirection == LayoutDirection.Rtl) LayoutDirection.Ltr else LayoutDirection.Rtl
+        val outerLocals = captureOuterLocals(outerDirection)
+        var bridged: LayoutDirection? = null
+        var reProvided: LayoutDirection? = null
+        runTaoSceneTest(width = 10, height = 10) {
+            scene.compositionLocalContext = outerLocals
+            setContent {
+                bridged = LocalLayoutDirection.current
+                CompositionLocalProvider(LocalLayoutDirection provides outerDirection) {
+                    reProvided = LocalLayoutDirection.current
+                }
+            }
+            frame()
+        }
+        assertEquals(GlobalLayoutDirection, bridged)
+        assertEquals(outerDirection, reProvided)
+    }
+
     private companion object {
         const val BLUE = 0xFF0000FF.toInt()
     }
@@ -109,8 +140,11 @@ class TaoSceneOuterLocalsBridgeTest {
  * `nucleusApplication { }`'s own body, which has no `ComposeScene` (and
  * therefore no `LocalComposeSceneContext`) of its own before any Tao window
  * has opened.
+ *
+ * [layoutDirection] is provided inside the captured composition so a caller can
+ * stand in for an app-level `LocalLayoutDirection` override.
  */
-private fun captureOuterLocals(): CompositionLocalContext {
+private fun captureOuterLocals(layoutDirection: LayoutDirection = GlobalLayoutDirection): CompositionLocalContext {
     var captured: CompositionLocalContext? = null
     val outerScene =
         CanvasLayersComposeScene(
@@ -129,7 +163,9 @@ private fun captureOuterLocals(): CompositionLocalContext {
         )
     try {
         outerScene.setContent {
-            captured = currentCompositionLocalContext
+            CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+                captured = currentCompositionLocalContext
+            }
         }
     } finally {
         outerScene.close()

--- a/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneOuterLocalsBridgeTest.kt
+++ b/decorated-window-tao/src/test/kotlin/dev/nucleusframework/window/tao/scene/TaoSceneOuterLocalsBridgeTest.kt
@@ -1,0 +1,138 @@
+@file:OptIn(androidx.compose.ui.InternalComposeUiApi::class)
+
+package dev.nucleusframework.window.tao.scene
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.currentCompositionLocalContext
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.scene.CanvasLayersComposeScene
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import dev.nucleusframework.window.tao.GlobalLayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Regression coverage for the outer-locals/LocalComposeSceneContext shadowing
+ * bug fixed in `nucleus-application`'s `TaoDecoratedWindowAdapter` (the
+ * adapter both `DecoratedWindow` and `MaterialDecoratedWindow` route through).
+ *
+ * That adapter captures `currentCompositionLocalContext` from the
+ * `nucleusApplication { }` body — a composition with no `ComposeScene` of its
+ * own, since no Tao window (and therefore no scene) has opened yet — and used
+ * to re-apply it inside the new window's own scene as a plain
+ * `CompositionLocalProvider(outerLocals) { content() }` wrapper. That
+ * re-provides Compose's own internal `LocalComposeSceneContext`, captured
+ * from the scene-less outer composition, shadowing the real one this window's
+ * scene set up for itself. Every `Popup`/`Dialog`/`DropdownMenu`/`Tooltip`
+ * composed anywhere in `content` — Compose's own `AlertDialog` included, since
+ * it's a `Dialog` under the hood — resolves that shadowed local to decide
+ * which scene to render into, and throws the moment it does, regardless of
+ * `nativePopupLayers`.
+ *
+ * Reproduced here at the plumbing level, two real `CanvasLayersComposeScene`s
+ * standing in for the two real compositions involved — an "outer" scene with
+ * no popup content of its own (the app root) and a "window" scene under test
+ * (the Tao window) — rather than through the full `nucleus-application`
+ * window/native-window stack, which has no offscreen test seam of its own.
+ * [captureOuterLocals] is the scene-less capture; [TaoScenePopupTest] already
+ * covers `Popup` rendering correctly inside a scene nothing has shadowed.
+ */
+class TaoSceneOuterLocalsBridgeTest {
+    @Test
+    fun `wrapping window content in outer locals with CompositionLocalProvider breaks Popup`() {
+        val outerLocals = captureOuterLocals()
+        runTaoSceneTest(width = 100, height = 100) {
+            // BUG, reproduced: the Popup's scene-layer creation needs
+            // LocalComposeSceneContext, shadowed to the outer (scene-less)
+            // composition's own captured value by the wrapper below —
+            // Compose's own ComposeSceneContext_skikoKt.requireCurrent throws
+            // exactly this IllegalStateException, the same one that crashed the
+            // real app the moment a Dialog was opened inside a DecoratedWindow.
+            assertFailsWith<IllegalStateException> {
+                setContent {
+                    // The exact shape TaoDecoratedWindowAdapter used before this fix.
+                    CompositionLocalProvider(outerLocals) {
+                        Box(Modifier.fillMaxSize().background(Color.White)) {
+                            Popup(offset = IntOffset(20, 20)) {
+                                Box(Modifier.size(30.dp).background(Color.Blue))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `bridging outer locals through the scene's own compositionLocalContext property does not break Popup`() {
+        val outerLocals = captureOuterLocals()
+        runTaoSceneTest(width = 100, height = 100) {
+            // The fixed shape: outerLocals becomes the scene's own property
+            // (what TaoDecoratedWindow's initialCompositionLocalContext /
+            // LocalTaoCompositionLocalContextBridge actually set under the hood),
+            // applied ABOVE the scene's own LocalComposeSceneContext instead of
+            // shadowing it from inside content.
+            scene.compositionLocalContext = outerLocals
+            setContent {
+                Box(Modifier.fillMaxSize().background(Color.White)) {
+                    Popup(offset = IntOffset(20, 20)) {
+                        Box(Modifier.size(30.dp).background(Color.Blue))
+                    }
+                }
+            }
+            frame()
+            assertEquals(BLUE, pixelAt(30, 30))
+        }
+    }
+
+    private companion object {
+        const val BLUE = 0xFF0000FF.toInt()
+    }
+}
+
+/**
+ * Captures a [CompositionLocalContext] from a real `ComposeScene` with no
+ * popup content and no relation to the scene under test — standing in for
+ * `nucleusApplication { }`'s own body, which has no `ComposeScene` (and
+ * therefore no `LocalComposeSceneContext`) of its own before any Tao window
+ * has opened.
+ */
+private fun captureOuterLocals(): CompositionLocalContext {
+    var captured: CompositionLocalContext? = null
+    val outerScene =
+        CanvasLayersComposeScene(
+            density = Density(1f),
+            layoutDirection = GlobalLayoutDirection,
+            size = IntSize(1, 1),
+            platformContext =
+                object : PlatformContext.Empty() {
+                    override val windowInfo =
+                        TaoWindowInfo().apply {
+                            containerSize = IntSize(1, 1)
+                            containerDpSize = DpSize(1.dp, 1.dp)
+                        }
+                },
+            invalidate = {},
+        )
+    try {
+        outerScene.setContent {
+            captured = currentCompositionLocalContext
+        }
+    } finally {
+        outerScene.close()
+    }
+    return requireNotNull(captured) { "outer scene never composed" }
+}

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.window.WindowState
 import dev.nucleusframework.application.LocalNucleusBackend
@@ -61,6 +62,17 @@ internal object TaoDecoratedWindowAdapter {
         // user-provided locals, …) flows into the new scene — matching how
         // Compose's own Dialog/Popup bridge across scene boundaries.
         val outerLocals = currentCompositionLocalContext
+
+        // Captured in the OUTER composition, for the same reason
+        // TaoDecoratedDialogAdapter captures it: the window scene is created
+        // with `GlobalLayoutDirection` and `ProvideCommonCompositionLocals`
+        // re-provides `LocalLayoutDirection` from it — ABOVE the user content
+        // but BELOW the bridged `outerLocals` — so an app-level RTL override
+        // (or a parent window's direction, for a secondary window) would
+        // otherwise be forced back to the system direction. Re-provide it
+        // inside the content below; it's not a routing local, so popups stay
+        // anchored to this window's own scene.
+        val parentLayoutDirection = LocalLayoutDirection.current
 
         with(scope.taoScope) {
             TaoDecoratedWindow(
@@ -150,6 +162,7 @@ internal object TaoDecoratedWindowAdapter {
                 val sceneTitleBarInfo = LocalTitleBarInfo.current
                 CompositionLocalProvider(
                     LocalDensity provides sceneDensity,
+                    LocalLayoutDirection provides parentLayoutDirection,
                     LocalTaoTextSelectionA11yPublisher provides scenePublisher,
                     LocalNucleusBackend provides NucleusBackend.Tao,
                     LocalNucleusWindow provides nucleusWindow,

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -2,6 +2,7 @@ package dev.nucleusframework.application.internal
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
@@ -20,6 +21,7 @@ import dev.nucleusframework.application.TaoNucleusApplicationScope
 import dev.nucleusframework.application.TaoNucleusWindow
 import dev.nucleusframework.window.DecoratedWindowState
 import dev.nucleusframework.window.LocalTitleBarInfo
+import dev.nucleusframework.window.tao.LocalTaoCompositionLocalContextBridge
 import dev.nucleusframework.window.tao.LocalTaoWindow
 import dev.nucleusframework.window.tao.TaoDecoratedWindowScope
 import dev.nucleusframework.window.tao.render.LocalTaoTextSelectionA11yPublisher
@@ -78,6 +80,16 @@ internal object TaoDecoratedWindowAdapter {
                 hiddenFromDock = hiddenFromDock,
                 onPreviewKeyEvent = onPreviewKeyEvent,
                 onKeyEvent = onKeyEvent,
+                // Initial bridge: present from this window's own scene's FIRST
+                // composition (the SideEffect below carries every composition
+                // after that). Mirrors TaoDecoratedDialogAdapter's identical need
+                // for the identical reason — a user local with a throwing default
+                // (e.g. LocalAppGraph) would otherwise crash before the
+                // SideEffect ever gets to run. DecoratedWindow's own doc comment
+                // on this parameter already documents it as exactly this bridge
+                // ("[DecoratedDialog] forwards its parent's locals here") — this
+                // adapter is the one top-level-window caller that never did.
+                compositionLocalContext = outerLocals,
             ) {
                 val taoScope: TaoDecoratedWindowScope = this
                 val decoratedState =
@@ -93,22 +105,37 @@ internal object TaoDecoratedWindowAdapter {
                         TaoNucleusDecoratedWindowScope(taoScope, nucleusWindow)
                     }
                 ObserveSingleInstanceRestore(nucleusWindow)
-                // outerLocals were captured in the OUTER composition. Blindly
-                // applying them inside this scene would override:
-                //  - LocalDensity with the application root's Density(1f)
-                //  - LocalTaoWindow / LocalTitleBarInfo with the *parent*
-                //    window's values, when this window is opened from inside
-                //    another DecoratedWindow (secondary windows, demos, apps
-                //    that open windows from a navigation destination).
-                // Snapshot scene-owned locals BEFORE applying outerLocals and
-                // re-provide them below so title-bar drag, system controls, and
-                // title/icon state bind to *this* window on every platform
-                // (Windows / macOS / Linux). Without re-providing LocalTaoWindow,
-                // windowDragArea() and WindowControlsWindows would call
-                // dragWindow() / minimize / maximize on the parent window —
-                // the secondary window appears immovable.
-                // LocalLayoutDirection is intentionally left to outerLocals so
-                // an app-level RTL override propagates here.
+                // outerLocals were captured in the OUTER composition. Bridging
+                // them via a plain CompositionLocalProvider(outerLocals) wrapper
+                // here — this function's own approach until this fix — clobbers
+                // two different things this scene owns:
+                //  - LocalDensity/LocalTaoWindow/LocalTitleBarInfo, overridden
+                //    with the application root's/parent window's values (handled
+                //    below exactly as before: snapshot before the bridge takes
+                //    effect, re-provide after).
+                //  - Compose's own internal LocalComposeSceneContext, captured
+                //    from whatever scene (or lack of one) outerLocals came from.
+                //    Every Popup/Dialog/DropdownMenu/Tooltip composed anywhere in
+                //    content — regardless of nativePopupLayers — resolves that
+                //    local to decide which scene it renders into; shadowed to the
+                //    wrong scene (or no scene, for an application-root capture
+                //    with no window of its own yet), it throws
+                //    "LocalComposeSceneContext not provided"/"NavigationEvent-
+                //    DispatcherOwner not found" the moment anything in content
+                //    tries to show one. TaoDecoratedDialogAdapter already solved
+                //    this exact problem correctly (see its own doc comment) via
+                //    compositionLocalContext (above, for the first composition)
+                //    plus this same bridge (for every composition after) — both
+                //    apply outerLocals as the scene's own compositionLocalContext
+                //    PROPERTY, which Compose itself
+                //    applies above (not below) the scene's own
+                //    LocalComposeSceneContext provision, rather than as a
+                //    CompositionLocalProvider wrapper nested below it. This
+                //    adapter never got the same fix; it's the one real
+                //    difference between it and the dialog adapter in how outer
+                //    locals cross the scene boundary.
+                val bridge = LocalTaoCompositionLocalContextBridge.current
+                SideEffect { bridge?.invoke(outerLocals) }
                 val sceneDensity = LocalDensity.current
                 // outerLocals carries the app theme's own LocalTextContextMenu
                 // (e.g. Jewel's). Applying it here shadows the scene's selection
@@ -121,18 +148,16 @@ internal object TaoDecoratedWindowAdapter {
                 val scenePublisher = LocalTaoTextSelectionA11yPublisher.current
                 val sceneTaoWindow = LocalTaoWindow.current
                 val sceneTitleBarInfo = LocalTitleBarInfo.current
-                CompositionLocalProvider(outerLocals) {
-                    CompositionLocalProvider(
-                        LocalDensity provides sceneDensity,
-                        LocalTaoTextSelectionA11yPublisher provides scenePublisher,
-                        LocalNucleusBackend provides NucleusBackend.Tao,
-                        LocalNucleusWindow provides nucleusWindow,
-                        LocalTaoWindow provides sceneTaoWindow,
-                        LocalTitleBarInfo provides sceneTitleBarInfo,
-                    ) {
-                        TaoTextSelectionAccessibility {
-                            nucleusScope.content()
-                        }
+                CompositionLocalProvider(
+                    LocalDensity provides sceneDensity,
+                    LocalTaoTextSelectionA11yPublisher provides scenePublisher,
+                    LocalNucleusBackend provides NucleusBackend.Tao,
+                    LocalNucleusWindow provides nucleusWindow,
+                    LocalTaoWindow provides sceneTaoWindow,
+                    LocalTitleBarInfo provides sceneTitleBarInfo,
+                ) {
+                    TaoTextSelectionAccessibility {
+                        nucleusScope.content()
                     }
                 }
             }

--- a/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
+++ b/nucleus-application/src/main/kotlin/dev/nucleusframework/application/internal/TaoDecoratedWindowAdapter.kt
@@ -117,46 +117,42 @@ internal object TaoDecoratedWindowAdapter {
                         TaoNucleusDecoratedWindowScope(taoScope, nucleusWindow)
                     }
                 ObserveSingleInstanceRestore(nucleusWindow)
-                // outerLocals were captured in the OUTER composition. Bridging
-                // them via a plain CompositionLocalProvider(outerLocals) wrapper
-                // here — this function's own approach until this fix — clobbers
-                // two different things this scene owns:
-                //  - LocalDensity/LocalTaoWindow/LocalTitleBarInfo, overridden
-                //    with the application root's/parent window's values (handled
-                //    below exactly as before: snapshot before the bridge takes
-                //    effect, re-provide after).
-                //  - Compose's own internal LocalComposeSceneContext, captured
-                //    from whatever scene (or lack of one) outerLocals came from.
-                //    Every Popup/Dialog/DropdownMenu/Tooltip composed anywhere in
-                //    content — regardless of nativePopupLayers — resolves that
-                //    local to decide which scene it renders into; shadowed to the
-                //    wrong scene (or no scene, for an application-root capture
-                //    with no window of its own yet), it throws
-                //    "LocalComposeSceneContext not provided"/"NavigationEvent-
-                //    DispatcherOwner not found" the moment anything in content
-                //    tries to show one. TaoDecoratedDialogAdapter already solved
-                //    this exact problem correctly (see its own doc comment) via
-                //    compositionLocalContext (above, for the first composition)
-                //    plus this same bridge (for every composition after) — both
-                //    apply outerLocals as the scene's own compositionLocalContext
-                //    PROPERTY, which Compose itself
-                //    applies above (not below) the scene's own
-                //    LocalComposeSceneContext provision, rather than as a
-                //    CompositionLocalProvider wrapper nested below it. This
-                //    adapter never got the same fix; it's the one real
-                //    difference between it and the dialog adapter in how outer
-                //    locals cross the scene boundary.
+                // outerLocals were captured in the OUTER composition and cross the
+                // scene boundary as this scene's own compositionLocalContext (the
+                // parameter above for the first composition, the bridge below for
+                // every one after). Compose applies that property ABOVE the scene's
+                // own provisions (RootNodeOwner.setContent), which is the whole
+                // point: Compose's internal LocalComposeSceneContext stays the one
+                // THIS scene provided, so Popup/Dialog/DropdownMenu/Tooltip create
+                // their layers here. The previous shape — a plain
+                // CompositionLocalProvider(outerLocals) wrapper nested INSIDE the
+                // scene — re-provided the captured scene context instead, so a
+                // window opened from another window's content routed its popups
+                // back into the PARENT scene (and threw once that scene was gone).
+                // TaoDecoratedDialogAdapter always bridged its locals this way; this
+                // adapter never did.
+                //
+                // Ordering consequence: everything the scene and DecoratedWindow
+                // provide for themselves — LocalDensity, LocalTaoWindow,
+                // LocalTitleBarInfo, LocalTaoTextSelectionA11yPublisher — now sits
+                // BELOW outerLocals and wins on its own, so the snapshot-and-
+                // re-provide below is no longer load-bearing. It stays as an
+                // explicit guard: without LocalTaoWindow bound to THIS window,
+                // windowDragArea() and WindowControlsWindows drive the PARENT
+                // window and a secondary window looks immovable. LocalLayoutDirection
+                // is the one local that does not come back on its own — the scene
+                // re-provides GlobalLayoutDirection over the bridged value — hence
+                // parentLayoutDirection, captured outside.
                 val bridge = LocalTaoCompositionLocalContextBridge.current
                 SideEffect { bridge?.invoke(outerLocals) }
                 val sceneDensity = LocalDensity.current
-                // outerLocals carries the app theme's own LocalTextContextMenu
-                // (e.g. Jewel's). Applying it here shadows the scene's selection
-                // observer, which silently breaks cross-process selection reading
-                // (PopClip, AppleScript). Re-install the observer INSIDE outerLocals
-                // via the publisher, so it sits below the theme's menu and keeps it
-                // as its delegate — preserving cut/copy/paste icons & shortcuts. The
-                // publisher itself is reset by outerLocals, so snapshot + re-provide
-                // it, exactly like LocalDensity.
+                // The app theme's own LocalTextContextMenu (e.g. Jewel's) is not a
+                // scene-owned local, so it does come through outerLocals and shadows
+                // the scene's selection observer — silently breaking cross-process
+                // selection reading (PopClip, AppleScript). TaoTextSelectionAccessibility
+                // below re-installs the observer INSIDE the theme's menu, keeping it as
+                // its delegate — cut/copy/paste icons & shortcuts preserved — and reads
+                // the scene's publisher from this snapshot.
                 val scenePublisher = LocalTaoTextSelectionA11yPublisher.current
                 val sceneTaoWindow = LocalTaoWindow.current
                 val sceneTitleBarInfo = LocalTitleBarInfo.current


### PR DESCRIPTION
## What's broken

Any `Popup`/`Dialog`/`DropdownMenu`/`Tooltip` composed inside a `DecoratedWindow` or `MaterialDecoratedWindow`'s content throws the moment it's shown, regardless of `nativePopupLayers`:

```
java.lang.IllegalStateException: LocalComposeSceneContext not provided
```

or, depending which code path gets there first:

```
java.lang.IllegalStateException: NavigationEventDispatcherOwner not found
```

Repro is trivial: put a Material3 `AlertDialog` behind a button inside any `DecoratedWindow`/`MaterialDecoratedWindow` content lambda and click it.

## Root cause

`TaoDecoratedWindowAdapter.Window` (`nucleus-application`) captures `currentCompositionLocalContext` from the parent `nucleusApplication { }` composition, which has no `ComposeScene` of its own since no Tao window has opened yet, and re-applies it inside the new window's own scene with a plain `CompositionLocalProvider(outerLocals) { content() }` wrapper.

That re-provides Compose's own internal `LocalComposeSceneContext` along with everything else, shadowing the real one this window's own scene already set up for itself. Every `Popup`-family composable resolves that shadowed local to pick which scene to render its layer into, and throws the instant it does. `nativePopupLayers` doesn't help, it only changes *which* scene type gets shadowed (`PlatformLayersComposeScene` vs `CanvasLayersComposeScene`), not whether the shadowing happens.

`TaoDecoratedDialogAdapter` already avoids this correctly: it bridges `outerLocals` through `DecoratedWindow`'s own `compositionLocalContext` parameter (a constructor-time scene property Compose applies *above* its own `LocalComposeSceneContext`, not below it, see `RootNodeOwner.setContent`) for the first composition, plus `LocalTaoCompositionLocalContextBridge` for every composition after. `TaoDecoratedWindowAdapter`, what `DecoratedWindow` and `MaterialDecoratedWindow` both actually route through, never got the same fix, even though `DecoratedWindow`'s own `compositionLocalContext` parameter doc comment already documents this exact use ("`DecoratedDialog` forwards its parent's locals here").

## The fix

Carries the dialog adapter's already-correct pattern over to the window adapter: `compositionLocalContext = outerLocals` on the initial `TaoDecoratedWindow(...)` call, plus `LocalTaoCompositionLocalContextBridge.current` in a `SideEffect` for every composition after. The existing Density/TaoWindow/TitleBarInfo/TextSelectionA11yPublisher snapshot-then-reprovide dance (there for an unrelated reason, see the file's own comment) is untouched.

## Testing

Added `TaoSceneOuterLocalsBridgeTest` at the `decorated-window-tao` scene-plumbing level: two real `CanvasLayersComposeScene`s standing in for the outer app-root composition and the window's own scene.

- `wrapping window content in outer locals with CompositionLocalProvider breaks Popup`, reproduces the exact crash (asserts `IllegalStateException`) using the old adapter's own shape.
- `bridging outer locals through the scene's own compositionLocalContext property does not break Popup`, confirms the fixed shape renders correctly.

Registered both in `TaoSceneTestBattery`/`TaoSceneTestBatteryDriftTest` per this module's own native-image coverage convention.

Full local run, both touched modules:

```
./gradlew :decorated-window-tao:test :nucleus-application:test
./gradlew :nucleus-application:detekt :decorated-window-tao:detekt :nucleus-application:ktlintCheck :decorated-window-tao:ktlintCheck :nucleus-application:apiCheck :decorated-window-tao:apiCheck
```

All green. No public API surface changed (`TaoDecoratedWindowAdapter` is `internal`), so `apiCheck` passes without a baseline update.

## How I found this

Chasing a real crash in a downstream Compose Multiplatform app built on Nucleus/Tao: `:app:run` showed no window at all at first (a separate, unrelated bug in that app's own launch ordering, an AWT Desktop init racing Tao for `NSApplication`, nothing to do with Nucleus), and once that was fixed, the very first `AlertDialog` opened from Settings took the whole process down with the stack trace above. Bisected to this adapter by comparing it against `TaoDecoratedDialogAdapter`, which handles the identical parent-locals bridging problem correctly.
